### PR TITLE
Command-line wrappers around extract_data.run and cpac_runner.run

### DIFF
--- a/tools/cpac_run.py
+++ b/tools/cpac_run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import sys
+from os import path
+
+def check_inputs(*pathstrs):
+    for pathstr in pathstrs:
+        if not path.exists(pathstr):
+            print "ERROR: input '%s' doesn't exist" % pathstr
+            raise SystemExit(2)
+        _,ext = path.splitext(pathstr):
+        if ext != ".py":
+            print "ERROR: input '%s' is not a python file (*.py)" % pathstr
+            raise SystemExit(2)
+    return
+
+if len(sys.argv) != 3:
+    print "Usage: %s /path/to/config.py /path/to/CPAC_subject_list.py" % path.basename(sys.argv[0])
+    print "Will run C-PAC"
+    raise SystemExit(1)
+
+config_file         = sys.argv[1]
+subject_list_file   = sys.argv[2]
+
+check_inputs(config_file, subject_list_file)
+
+import CPAC
+CPAC.pipeline.cpac_runner.run(config_file, subject_list_file)

--- a/tools/cpac_setup.py
+++ b/tools/cpac_setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import sys
+from os import path
+
+def check_inputs(*pathstrs):
+    for pathstr in pathstrs:
+        if not path.exists(pathstr):
+            print "ERROR: input '%s' doesn't exist" % pathstr
+            raise SystemExit(2)
+        _,ext = path.splitext(pathstr)
+        if ext != ".py":
+            print "ERROR: input '%s' is not a python file (*.py)" % pathstr
+            raise SystemExit(2)
+    return
+
+if len(sys.argv) != 2:
+    print "Usage: %s /path/to/data_config.py" % path.basename(sys.argv[0])
+    print "Will output three files needed by C-PAC into the current directory"
+    raise SystemExit(1)
+
+data_config_file = sys.argv[1]
+
+check_inputs(data_config_file)
+
+import CPAC
+CPAC.utils.extract_data.run(data_config_file)


### PR DESCRIPTION
Light wrappers around CPAC.utils.extract_data.run via cpac_setup.py and CPAC.pipeline.cpac_runner.run via cpac_run.py. Both scripts check that inputs on the command-line are files and have a .py extension. Then they run the respective python functions.

One question is whether to move these scripts from the tools directory to a bin directory so that they may be on the path for the user when C-PAC is installed.
