### PR TITLE
Power motion parameters calculation fix

### DIFF
--- a/CPAC/generate_motion_statistics/generate_motion_statistics.py
+++ b/CPAC/generate_motion_statistics/generate_motion_statistics.py
@@ -573,8 +573,8 @@ def calculate_FD_P(in_file):
     rows = [[float(x) for x in line.split()] for line in lines]
     cols = np.array([list(col) for col in zip(*rows)])
     
-    translations = np.transpose(np.abs(np.diff(cols[0:3, :])))
-    rotations = np.transpose(np.abs(np.diff(cols[3:6, :])))
+    translations = np.transpose(np.abs(np.diff(cols[3:6, :])))
+    rotations = np.transpose(np.abs(np.diff(cols[0:3, :])))
 
     FD_power = np.sum(translations, axis = 1) + (50*3.141/180)*np.sum(rotations, axis =1)
     


### PR DESCRIPTION
Power motion parameters are calculated from the movement vector as provided by 3dvolreg: "roll pitch yaw dS  dL  dP". There's currently a mistake in the code as the first three numbers are taken to be translations and the last three rotations, even though it should be the other way around.