### PR TITLE
fixed 3ddot reversed syntax which crashes analysis 

### DIFF
--- a/CPAC/pipeline/cpac_ga_model_generator.py
+++ b/CPAC/pipeline/cpac_ga_model_generator.py
@@ -94,8 +94,8 @@ def check_merged_file(list_of_output_files, merged_outfile):
     #   with the output file it should correspond to
     i = 0
     for output_file in list_of_output_files:
-        test_string = ["3ddot", "-demean", output_file, \
-            merged_outfile + "[" + str(i) + "]"]
+        test_string = ["3ddot", "-demean",  merged_outfile + "[" + str(i) + "]", \
+           output_file]
 
         try:
             retcode = subprocess.check_output(test_string)


### PR DESCRIPTION
Fixed 3ddot command in-which args were issued in reverse order, causing analysis pipeline to crash. 

Thanks to @florisvanvugt for pointing out the bug!