### PR TITLE
Fix set_frames_ex to exclude only existing frames

### DIFF
--- a/CPAC/generate_motion_statistics/generate_motion_statistics.py
+++ b/CPAC/generate_motion_statistics/generate_motion_statistics.py
@@ -528,7 +528,7 @@ def set_frames_ex(in_file, threshold,
                 
         #remove following frames
         count = 1
-        while count <= frames_after:
+        while count <= frames_after and (i+count) < len(data):
             extra_indices.append(i+count)
             count+=1
                     


### PR DESCRIPTION
The list of indices of frames to scrub (output of set_frames_ex) sometimes contains frames that are beyond the end of the scan.

For example, let's say that the scan contains 100 frames (numbered 0, 1, ..., 99) and the framewise displacement of the last frame is above a given threshold. If we scrub also the 2 following frames, the list of frames to scrub contains frames 99, 100, and 101. Frames 100 and 101 are beyond the end of the scan and shouldn't be included in the list.