### PR TITLE
Update of networkx drawing API

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -5723,14 +5723,12 @@ def prep_workflow(sub_dict, c, strategies, run, pipeline_timing_info=None,
                 os.makedirs(d_name)
 
             try:
-                from networkx.drawing.nx_pydot import write_dot
-
                 G = nx.DiGraph()
                 strat_name = strat.get_name()
                 G.add_edges_from([(strat_name[s], strat_name[s + 1]) for s in
                                   range(len(strat_name) - 1)])
                 dotfilename = os.path.join(d_name, 'strategy.dot')
-                write_dot(G, dotfilename)
+                nx.drawing.nx_pydot.write_dot(G, dotfilename)
                 format_dot(dotfilename, 'png')
             except:
                 logStandardWarning('Datasink',

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -5723,12 +5723,14 @@ def prep_workflow(sub_dict, c, strategies, run, pipeline_timing_info=None,
                 os.makedirs(d_name)
 
             try:
+                from networkx.drawing.nx_pydot import write_dot
+
                 G = nx.DiGraph()
                 strat_name = strat.get_name()
                 G.add_edges_from([(strat_name[s], strat_name[s + 1]) for s in
                                   range(len(strat_name) - 1)])
                 dotfilename = os.path.join(d_name, 'strategy.dot')
-                nx.write_dot(G, dotfilename)
+                write_dot(G, dotfilename)
                 format_dot(dotfilename, 'png')
             except:
                 logStandardWarning('Datasink',


### PR DESCRIPTION
`networkx` now uses a stratified API for drawing to allow using different rendering libs.
This minor PR update our use of this new API. It intends to fix #641 .