### PR TITLE
[FIX] Force empty Freesurfer var

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -2,6 +2,9 @@ Bootstrap: docker
 From: fcpindi/c-pac
 IncludeCmd: yes
 
+%environment
+FREESURFER_HOME=
+
 %post
 
 ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.19.0.0 \


### PR DESCRIPTION
In order to avoid env collisions w the host*, we empty the FREESURFER_HOME var so Nipype will not complain about license/build files.

* Singularity has different configs, and sometimes it will always forward the host environment to the container.