### PR TITLE
[Chore] Fix API update warning

### DIFF
--- a/CPAC/qc/utils.py
+++ b/CPAC/qc/utils.py
@@ -1261,7 +1261,7 @@ def gen_motion_plt(motion_parameters):
 
     data = np.loadtxt(motion_parameters).T
 
-    plt.gca().set_color_cycle(['red', 'green', 'blue'])
+    plt.gca().set_prop_cycle(['red', 'green', 'blue'])
     plt.plot(data[0])
     plt.plot(data[1])
     plt.plot(data[2])
@@ -1271,7 +1271,7 @@ def gen_motion_plt(motion_parameters):
     plt.savefig(rotation_plot)
     plt.close()
 
-    plt.gca().set_color_cycle(['red', 'green', 'blue'])
+    plt.gca().set_prop_cycle(['red', 'green', 'blue'])
     plt.plot(data[3])
     plt.plot(data[4])
     plt.plot(data[5])


### PR DESCRIPTION
```
/usr/local/miniconda/lib/python2.7/site-packages/matplotlib/cbook.py:136: MatplotlibDeprecationWarning: The set_color_cycle attribute was deprecated in version 1.5. Use set_prop_cycle instead.
  warnings.warn(message, mplDeprecation, stacklevel=1)
```