### PR TITLE
Fix test nuisance representations

### DIFF
--- a/CPAC/nuisance/tests/test_nuisance_representations.py
+++ b/CPAC/nuisance/tests/test_nuisance_representations.py
@@ -1,5 +1,5 @@
 import yaml
-from CPAC.nuisance import NuisanceRegressor
+from CPAC.nuisance.utils import NuisanceRegressor
 
 
 def test_representations():

--- a/CPAC/nuisance/tests/test_nuisance_representations.py
+++ b/CPAC/nuisance/tests/test_nuisance_representations.py
@@ -41,5 +41,5 @@ def test_representations():
 
     assert NuisanceRegressor.encode({
         'aCompCor': selector_test['aCompCor']
-    }) == 'aC-WM+CSF-PC5'
+    }) == 'aC-CSF+WM-2mm-PC5'
 

--- a/CPAC/nuisance/tests/test_nuisance_representations.py
+++ b/CPAC/nuisance/tests/test_nuisance_representations.py
@@ -35,7 +35,7 @@ def test_representations():
         
     """)
 
-    NuisanceRegressor.encode({
+    assert NuisanceRegressor.encode({
         'tCompCor': selector_test['tCompCor']
     }) == 'tC-S1.5SD-PC5'
 

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -442,9 +442,8 @@ def generate_summarize_tissue_mask_ventricles_masking(nuisance_wf,
 
 class NuisanceRegressor(object):
 
-    def __init__(self, selector, selectors=None):
+    def __init__(self, selector):
         self.selector = selector
-        self.selectors = selectors
 
         if 'Bandpass' in self.selector:
             s = self.selector['Bandpass']
@@ -504,7 +503,7 @@ class NuisanceRegressor(object):
         return rep
 
     @staticmethod
-    def encode(selector, selectors=None):
+    def encode(selector):
         regs = {
             'GreyMatter': 'GM',
             'WhiteMatter': 'WM',
@@ -658,7 +657,4 @@ class NuisanceRegressor(object):
         return "_".join(selectors_representations)
 
     def __repr__(self):
-        return NuisanceRegressor.encode(
-            self.selector,
-            self.selectors,
-        )
+        return NuisanceRegressor.encode(self.selector)

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -1,23 +1,16 @@
 import os
 import re
 from collections import OrderedDict
-import numpy as np
-import nibabel as nb
 
-import nipype.pipeline.engine as pe
-import nipype.interfaces.utility as util
-import nipype.interfaces.fsl as fsl
 import nipype.interfaces.ants as ants
+import nipype.interfaces.fsl as fsl
+import nipype.interfaces.utility as util
+import nipype.pipeline.engine as pe
 from nipype.interfaces import afni
 
-from CPAC.utils.interfaces.function import Function
-from CPAC.utils.interfaces.masktool import MaskTool
-from CPAC.utils.interfaces.brickstat import BrickStat
-
-from CPAC.nuisance.utils.crc import encode as crc_encode
 from CPAC.nuisance.utils.compcor import calc_compcor_components
-
-import scipy.signal as signal
+from CPAC.nuisance.utils.crc import encode as crc_encode
+from CPAC.utils.interfaces.function import Function
 
 
 def find_offending_time_points(fd_j_file_path=None, fd_p_file_path=None, dvars_file_path=None,

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -1,5 +1,6 @@
 import os
 import re
+from collections import OrderedDict
 import numpy as np
 import nibabel as nb
 
@@ -504,33 +505,19 @@ class NuisanceRegressor(object):
 
     @staticmethod
     def encode(selector):
-        regs = {
-            'GreyMatter': 'GM',
-            'WhiteMatter': 'WM',
-            'CerebrospinalFluid': 'CSF',
-            'tCompCor': 'tC',
-            'aCompCor': 'aC',
-            'GlobalSignal': 'G',
-            'Motion': 'M',
-            'Custom': 'T',
-            'PolyOrt': 'P',
-            'Bandpass': 'BP',
-            'Censor': 'C',
-        }
-
-        regs_order = [
-            'GreyMatter',
-            'WhiteMatter',
-            'CerebrospinalFluid',
-            'tCompCor',
-            'aCompCor',
-            'GlobalSignal',
-            'Motion',
-            'Custom',
-            'PolyOrt',
-            'Bandpass',
-            'Censor',
-        ]
+        regs = OrderedDict([
+            ('GreyMatter', 'GM'),
+            ('WhiteMatter', 'WM'),
+            ('CerebrospinalFluid', 'CSF'),
+            ('tCompCor', 'tC'),
+            ('aCompCor', 'aC'),
+            ('GlobalSignal', 'G'),
+            ('Motion', 'M'),
+            ('Custom', 'T'),
+            ('PolyOrt', 'P'),
+            ('Bandpass', 'BP'),
+            ('Censor', 'C')
+        ])
 
         tissues = ['GreyMatter', 'WhiteMatter', 'CerebrospinalFluid']
 
@@ -549,7 +536,7 @@ class NuisanceRegressor(object):
         # P-2
         # B-T0.01-B0.1
 
-        for r in regs_order:
+        for r in regs.iterkeys():
             if r not in selector:
                 continue
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -2383,8 +2383,7 @@ def prep_workflow(sub_dict, c, run, pipeline_timing_info=None,
 
                     # to guarantee immutability
                     regressors_selector = NuisanceRegressor(
-                        copy.deepcopy(regressors_selector),
-                        copy.deepcopy(c.Regressors)
+                        copy.deepcopy(regressors_selector)
                     )
 
                     # remove tissue regressors when there is no segmentation


### PR DESCRIPTION
While trying to troubleshoot an issue with nuisance regressors, I found that some unit tests were failing, so I fixed them, and performed some cleanup of the NuisanceRegressor class by removing an unused argument to the constructor, cleaning up imports, and using `OrderedDict` to retain dictionary key insertion order.