### PR TITLE
Issue 1100 Note about smoothing in vmhc.py

### DIFF
--- a/CPAC/image_utils/spatial_smoothing.py
+++ b/CPAC/image_utils/spatial_smoothing.py
@@ -3,16 +3,30 @@ import nipype.pipeline.engine as pe
 import nipype.interfaces.utility as util
 from CPAC.utils import Outputs
 
+
 def set_gauss(fwhm):
+    """
+    Compute the sigma value, given Full Width Half Max.
+    Returns an operand string
 
-    fwhm = float(fwhm)
+    Parameters
+    ----------
 
-    sigma = float(fwhm / 2.3548)
+    fwhm : float
 
-    op = "-kernel gauss %f -fmean -mas " % (sigma) + "%s"
-    op_string = op
+    Returns
+    -------
+
+    op_string : string
+
+    """
+
+    sigma = float(fwhm) / 2.3548
+
+    op_string = "-kernel gauss %f -fmean -mas " % sigma + "%s"
 
     return op_string
+
 
 def spatial_smooth_outputs(workflow, func_key, strat, num_strat, pipeline_config_object):
 

--- a/CPAC/vmhc/__init__.py
+++ b/CPAC/vmhc/__init__.py
@@ -1,7 +1,6 @@
 from vmhc import create_vmhc
 
-from utils import set_gauss, \
-                  get_img_nvols, \
+from utils import get_img_nvols, \
                   get_operand_expression
 
 

--- a/CPAC/vmhc/utils.py
+++ b/CPAC/vmhc/utils.py
@@ -6,36 +6,6 @@ import nipype.pipeline.engine as pe
 import nipype.interfaces.utility as util
 
 
-def set_gauss(fwhm):
-
-    """
-    Compute the sigma value, given Full Width Half Max. 
-    Further it builds an operand string and returns it
-
-    Parameters
-    ----------
-
-    fwhm : float
-
-    Returns
-    -------
-
-    op_string : string
-
-    """
-
-    op_string = ""
-
-    fwhm = float(fwhm)
-
-    sigma = float(fwhm / 2.3548)
-
-    op = "-kernel gauss %f -fmean -mas " % (sigma) + "%s"
-    op_string = op
-
-    return op_string
-
-
 def get_img_nvols(in_files):
 
     """

--- a/CPAC/vmhc/utils.py
+++ b/CPAC/vmhc/utils.py
@@ -1,11 +1,3 @@
-import os
-import sys
-import re
-import commands
-import nipype.pipeline.engine as pe
-import nipype.interfaces.utility as util
-
-
 def get_img_nvols(in_files):
 
     """

--- a/CPAC/vmhc/vmhc.py
+++ b/CPAC/vmhc/vmhc.py
@@ -146,7 +146,7 @@ def create_vmhc(workflow, num_strat, strat, pipeline_config_object,
     `fslmaths <http://www.fmrib.ox.ac.uk/fslcourse/lectures/practicals/intro/index.htm>`_::
 
         fslmaths rest_res_filt.nii.gz
-        -kernel gauss FWHM/ sqrt(8-ln(2))
+        -kernel gauss FWHM/ sqrt(8*ln(2))
         -fmean -mas rest_mask.nii.gz
         rest_res_filt_FWHM.nii.gz
         


### PR DESCRIPTION
Update comments relating sigma and FWHM, then remove unused `set_gauss` function. Should resolve #1100 .