### PR TITLE
🔗 BIDs validator links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 C-PAC: Configurable Pipeline for the Analysis of Connectomes
 ============================================================
-[![hosted on OpenNeuro](https://raw.githubusercontent.com/bids-standard/bids-website/gh-pages/old_website/openneuro_badge.svg)](https://openneuro.org) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.164638.svg)](https://doi.org/10.5281/zenodo.164638)
+[![OpenNeuro](https://raw.githubusercontent.com/bids-standard/bids-website/gh-pages/old_website/openneuro_badge.svg?sanitize=true)](https://openneuro.org) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.164638.svg)](https://doi.org/10.5281/zenodo.164638)
 
 
 A configurable, open-source, Nipype-based, automated processing pipeline for resting state fMRI data.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 C-PAC: Configurable Pipeline for the Analysis of Connectomes
 ============================================================
-[![DOI](http://bids.neuroimaging.io/openneuro_badge.svg)](https://openneuro.org) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.164638.svg)](https://doi.org/10.5281/zenodo.164638)
+[![hosted on OpenNeuro](https://raw.githubusercontent.com/bids-standard/bids-website/gh-pages/old_website/openneuro_badge.svg)](https://openneuro.org) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.164638.svg)](https://doi.org/10.5281/zenodo.164638)
 
 
-A configurable, open-source, Nipype-based, automated processing pipeline for resting state fMRI data. 
-Designed for use by both novice users and experts, C-PAC brings the power, flexibility and elegance 
+A configurable, open-source, Nipype-based, automated processing pipeline for resting state fMRI data.
+Designed for use by both novice users and experts, C-PAC brings the power, flexibility and elegance
 of Nipype to users in a plug-and-play fashion; no programming required.
 
 Website
@@ -39,4 +39,3 @@ Issue Tracker and Bugs
 This is a beta version of C-PAC, which means that it is still under active development. As such, although we have done our best to ensure a stable pipeline, there will likely still be a few bugs that we did not catch. If you find a bug or would like to suggest a new feature, please open an issue on the the C-PAC Github issue tracker: https://github.com/FCP-INDI/C-PAC/issues?state=open
 
 If you would like to suggest revisions to the user documentation, please open an issue on the C-PAC website's GitHub issue tracker: https://github.com/FCP-INDI/fcp-indi.github.com/issues
-

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -215,7 +215,7 @@ parser.add_argument('--participant_ndx', help='The index of the participant'
 parser.add_argument('-v', '--version', action='version',
                     version='C-PAC BIDS-App version {}'.format(__version__))
 parser.add_argument('--bids_validator_config', help='JSON file specifying configuration of '
-                    'bids-validator: See https://github.com/INCF/bids-validator for more info.')
+                    'bids-validator: See https://github.com/bids-standard/bids-validator for more info.')
 parser.add_argument('--skip_bids_validator',
                     help='Skips bids validation.',
                     action='store_true')


### PR DESCRIPTION
I noticed the [`run --help` description of `--bids_validator_config`](
https://shnizzedy.github.io/fcp-indi.github.com/docs/user/quick.html?highlight=https://github.com/INCF/bids-validator) includes a deprecated link to https://github.com/INCF/bids-validator. This PR

- updates https://github.com/INCF/bids-validator to https://github.com/bids-standard/bids-validator
- updates the dead "hosted on OpenNeuro" (![dead image](http://bids.neuroimaging.io/openneuro_badge.svg)) in the README to one hosted in https://github.com/bids-standard/bids-website (![live image](https://raw.githubusercontent.com/bids-standard/bids-website/gh-pages/old_website/openneuro_badge.svg?sanitize=true))
- updates the alt text for that image from "DOI" to "OpenNeuro"