### PR TITLE
update ANTs para of fmriprep option config

### DIFF
--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -307,7 +307,7 @@ regOption: [ANTS]
 # ANTs parameters, if select ANTs as regOption
 ANTs_para_T1_registration:
 
-   - collapse-output-transforms: 0
+   - collapse-output-transforms: 1
 
    - dimensionality: 3
 
@@ -327,7 +327,7 @@ ANTs_para_T1_registration:
             iteration : 1000x500x250x100
             convergenceThreshold : 1e-08
             convergenceWindowSize : 10
-          smoothing-sigmas : 3.0x2.0x1.0x0.0
+          smoothing-sigmas : 4.0x2.0x1.0x0.0vox
           shrink-factors : 8x4x2x1
           use-histogram-matching : True
 
@@ -343,7 +343,7 @@ ANTs_para_T1_registration:
             iteration : 1000x500x250x100
             convergenceThreshold : 1e-08
             convergenceWindowSize : 10
-          smoothing-sigmas : 3.0x2.0x1.0x0.0
+          smoothing-sigmas : 4.0x2.0x1.0x0.0vox
           shrink-factors : 8x4x2x1
           use-histogram-matching : True
 
@@ -353,18 +353,18 @@ ANTs_para_T1_registration:
           totalFieldVarianceInVoxelSpace : 0.0
           metric:
             type : CC
-            metricWeight: 1
+            metricWeight: 0.5
             radius : 4
           convergence:
-            iteration : 100x100x70x20
+            iteration : 50x10x0
             convergenceThreshold : 1e-09
             convergenceWindowSize : 15
-          smoothing-sigmas : 3.0x2.0x1.0x0.0
-          shrink-factors : 6x4x2x1
+          smoothing-sigmas : 2.0x1.0x0.0vox
+          shrink-factors : 4x2x1
           use-histogram-matching : True
           winsorize-image-intensities :
-            lowerQuantile : 0.01
-            upperQuantile : 0.99
+            lowerQuantile : 0.025
+            upperQuantile : 0.975
 
 
 # Please specify ANTs parameters,if run Functional to EPI Template Registration


### PR DESCRIPTION
ants registration para match to fmriprep-option. 

still missing two para. 
     -x, --masks [fixedImageMask,movingImageMask] 

          Image masks to limit voxels considered by the metric. Two options are allowed  

          for mask specification: 1) Either the user specifies a single mask to be used  

          for all stages or 2) the user specifies a mask for each stage. With the latter  

          one can select to which stages masks are applied by supplying valid file names.  

          If the file does not exist, a mask will not be used for that stage. Note that we  

          handle the fixed and moving masks separately to enforce this constraint.  

     --float  

          Use 'float' instead of 'double' for computations.  

          <VALUES>: 0 