### PR TITLE
🚑 Fix number of lines in censors.tsv

### DIFF
--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -113,7 +113,7 @@ def find_offending_time_points(fd_j_file_path=None, fd_p_file_path=None, dvars_f
     censor_vector[extended_censors] = 0
 
     out_file_path = os.path.join(os.getcwd(), "censors.tsv")
-    np.savetxt(out_file_path, censor_vector, fmt='%d')
+    np.savetxt(out_file_path, censor_vector, fmt='%d', header='censor')
 
     return out_file_path
 
@@ -410,16 +410,16 @@ def generate_summarize_tissue_mask_ventricles_masking(nuisance_wf,
                     nuisance_wf.connect(*(transforms['anat_to_mni_affine_xfm'] + (collect_linear_transforms, 'in3')))
 
                     # check transform list to exclude Nonetype (missing) init/rig/affine
-                    check_transform = pe.Node(util.Function(input_names=['transform_list'], 
+                    check_transform = pe.Node(util.Function(input_names=['transform_list'],
                                                             output_names=['checked_transform_list', 'list_length'],
                                                             function=check_transforms), name='{0}_check_transforms'.format(ventricles_key))
-                    
+
                     nuisance_wf.connect(collect_linear_transforms, 'out', check_transform, 'transform_list')
 
                     # generate inverse transform flags, which depends on the number of transforms
-                    inverse_transform_flags = pe.Node(util.Function(input_names=['transform_list'], 
+                    inverse_transform_flags = pe.Node(util.Function(input_names=['transform_list'],
                                                                     output_names=['inverse_transform_flags'],
-                                                                    function=generate_inverse_transform_flags), 
+                                                                    function=generate_inverse_transform_flags),
                                                                     name='{0}_inverse_transform_flags'.format(ventricles_key))
                     nuisance_wf.connect(check_transform, 'checked_transform_list', inverse_transform_flags, 'transform_list')
 

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -50,12 +50,12 @@ def find_offending_time_points(fd_j_file_path=None, fd_p_file_path=None, dvars_f
     offending_time_points = set()
     time_course_len = 0
 
-    # types = ['FDJ', 'FDP', 'DVARS']
-    # file_paths = [fd_j_file_path, fd_p_file_path, dvars_file_path]
-    # thresholds = [fd_j_threshold, fd_p_threshold, dvars_threshold]
-    types = ['FDP', 'DVARS']
-    file_paths = [fd_p_file_path, dvars_file_path]
-    thresholds = [fd_p_threshold, dvars_threshold]
+    types = ['FDJ', 'FDP', 'DVARS']
+    file_paths = [fd_j_file_path, fd_p_file_path, dvars_file_path]
+    thresholds = [fd_j_threshold, fd_p_threshold, dvars_threshold]
+    #types = ['FDP', 'DVARS']
+    #file_paths = [fd_p_file_path, dvars_file_path]
+    #thresholds = [fd_p_threshold, dvars_threshold]
 
     for type, file_path, threshold in zip(types, file_paths, thresholds):
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -2040,7 +2040,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
                 new_strat = strat.fork()
 
                 despike = pe.Node(interface=preprocess.Despike(),
-                                name='func_despiked')
+                                name='func_despiked_{0}'.format(num_strat))
                 despike.inputs.outputtype = 'NIFTI_GZ'
 
                 node, out_file = new_strat.get_leaf_properties()

--- a/CPAC/resources/configs/pipeline_config_benchmark-3.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-3.yml
@@ -23,7 +23,7 @@ resourceManager :  SGE
 
 # SGE Parallel Environment to use when running CPAC.
 # Only applies when you are running on a grid or compute cluster using SGE.
-parallelEnvironment :  mpi_smp
+parallelEnvironment :  cpac
 
 
 # SGE Queue to use when running CPAC.
@@ -32,23 +32,23 @@ queue :  all.q
 
 
 # The maximum amount of memory each participant's workflow can allocate. Use this to place an upper bound of memory usage. Warning: 'Memory Per Participant' multiplied by 'Number of Participants to Run Simultaneously' must not be more than the total amount of RAM. Conversely, using too little RAM can impede the speed of a pipeline run. It is recommended that you set this to a value that when multiplied by 'Number of Participants to Run Simultaneously' is as much RAM you can safely allocate.
-maximumMemoryPerParticipant :  1
+maximumMemoryPerParticipant :  3
 
 
 # The maximum amount of cores (on a single machine) or slots on a node (on a cluster/grid) to allocate per participant. Setting this above 1 will parallelize each participant's workflow where possible. If you wish to dedicate multiple cores to ANTS-based anatomical registration (below), this value must be equal or higher than the amount of cores provided to ANTS. The maximum number of cores your run can possibly employ will be this setting multiplied by the number of participants set to run in parallel (the 'Number ofParticipants to Run Simultaneously' setting).
-maxCoresPerParticipant :  1
+maxCoresPerParticipant :  3
 
 
 # The number of participant workflows to run at the same time. The maximum number of cores your run can possibly employ will be this setting multiplied by the number of cores dedicated to each participant (the 'Maximum Number of Cores Per Participant' setting).
-numParticipantsAtOnce :  1
+numParticipantsAtOnce :  15
 
 
 # The number of cores to allocate to ANTS-based anatomical registration per participant. Multiple cores can greatly speed up this preprocessing step. This number cannot be greater than the number of cores per participant.
-num_ants_threads :  4
+num_ants_threads :  3
 
 
 # Name for this pipeline configuration - useful for identification.
-pipelineName :  ndmg
+pipelineName :  benchmark-3
 
 
 # Directory where CPAC should store temporary and intermediate files.
@@ -56,7 +56,7 @@ workingDirectory :  /tmp
 
 
 # Directory where CPAC should write crash logs.
-crashLogDirectory :  /tmp
+crashLogDirectory :  /output
 
 
 # Directory where CPAC should place processed data.
@@ -68,7 +68,7 @@ run_logging :  True
 
 
 # Directory where CPAC should place run logs.
-logDirectory :  /tmp
+logDirectory :  /output
 
 
 # If setting the 'Output Directory' to an S3 bucket, insert the path to your AWS credentials file here.
@@ -80,16 +80,16 @@ s3Encryption :  [0]
 
 
 # Include extra versions and intermediate steps of functional preprocessing in the output directory.
-write_func_outputs :  [0]
+write_func_outputs :  [1]
 
 
 # Include extra outputs in the output directory that may be of interest when more information is needed.
-write_debugging_outputs :  [0]
+write_debugging_outputs :  [1]
 
 
 # Output directory format and structure.
 # Options: default, ndmg
-output_tree: "ndmg"
+output_tree: "default"
 
 
 # Generate quality control pages containing preprocessing and derivative outputs.
@@ -98,7 +98,7 @@ generateQualityControlImages :  [1]
 
 # Deletes the contents of the Working Directory after running.
 # This saves disk space, but any additional preprocessing or analysis will have to be completely re-run.
-removeWorkingDir :  True
+removeWorkingDir :  False
 
 
 # Uses the contents of the Working Directory to regenerate all outputs and their symbolic links.
@@ -110,11 +110,11 @@ reGenerateOutputs :  False
 # ---------------------------------
 
 # Non-local means filtering / Denoise image
-non_local_means_filtering: False
+non_local_means_filtering: True
 
 
 # N4 bias field correction
-n4_bias_field_correction: False
+n4_bias_field_correction: True
 
 
 # Disables skull-stripping on the anatomical inputs if they are already skull-stripped outside of C-PAC.
@@ -124,11 +124,7 @@ already_skullstripped :  [0]
 
 # Choice of using AFNI or FSL-BET or niworkflows-ants to perform SkullStripping
 # Options: ['AFNI', 'FSL', 'niworkflows-ants']
-skullstrip_option :  ['AFNI']
-
-
-# UNet model
-unet_model : s3://fcp-indi/resources/cpac/resources/Site-All-T-epoch_36.model
+skullstrip_option :  ['niworkflows-ants']
 
 
 # Template to be used during niworkflows-ants.
@@ -147,8 +143,8 @@ niworkflows_ants_regmask_path : /ants_template/oasis/T_template0_BrainCerebellum
 
 # Options to be used for AFNI 3dSkullStrip only.
 
-# Output a mask volume instead of a skull-stripped volume. The mask volume containes 0 to 6, which represents voxel's postion. If set to True, C-PAC will use this output to generate anatomical brain mask for further analysis.
-skullstrip_mask_vol: False
+# Choice of using monkey option for AFNI 3dskullstrip
+skullstrip_monkey : False
 
 
 # Set the threshold value controlling the brain vs non-brain voxels. Default is 0.6.
@@ -204,7 +200,7 @@ skullstrip_exp_frac :  0.1
 
 
 # Perform aggressive push to edge. This might cause leakage. Default is Off.
-skullstrip_push_to_edge :  False
+skullstrip_push_to_edge :  Off
 
 
 # Use outer skull to limit expansion of surface into the skull in case of very strong shading artifacts. Use this only if you have leakage into the skull.
@@ -223,22 +219,22 @@ skullstrip_max_inter_iter :  4
 skullstrip_fac :  1
 
 
-# Options to be used for FSL-BET skull-stripping only.
-
 # Blur dataset after spatial normalization. Recommended when you have lots of CSF in brain and when you have protruding gyri (finger like). If so, recommended value range is 2-4. Otherwise, leave at 0.
 skullstrip_blur_fwhm :  0
 
 
-# Set it as True if processing monkey data with AFNI 
+# Set it as True if processing monkey data with AFNI
 skullstrip_monkey : False
 
 
-# Set the threshold value controling the brain vs non-brain voxels, default is 0.5
+# Options to be used for FSL-BET skull-stripping only.
+
+# Set the threshold value controling the brain vs non-brain voxels - default is 0.5
 bet_frac :  0.5
 
 
-# Mask created along with skull stripping. It should be `On`, if selected functionalMasking :  ['Anatomical_Refined'] and `FSL` as skull-stripping method.
-bet_mask_boolean :  On
+# Mask created along with skull stripping
+bet_mask_boolean :  Off
 
 
 # Mesh created along with skull stripping
@@ -287,6 +283,8 @@ bet_vertical_gradient : 0.0
 
 # The resolution to which anatomical images should be transformed during registration.
 # This is the resolution at which processed anatomical files will be output.
+# If three dimensions are identical, enter only one number (integer or floating point number), eg. 2mm or 1.5mm;
+# if three dimensions are different, enter: num1xnum2xnum3, eg. 2mmx2mmx1.5mm
 resolution_for_anat :  2mm
 
 
@@ -301,20 +299,74 @@ template_skull_for_anat :  /usr/share/fsl/5.0/data/standard/MNI152_T1_${resoluti
 
 
 # Use either ANTS or FSL (FLIRT and FNIRT) as your anatomical registration method.
-regOption :  ['FSL']
+regOption :  ['ANTS', 'FSL']
 
 
 # ANTs parameters, if select ANTs as regOption
-ANTs_para_T1_registration: None
+ANTs_para_T1_registration:
+
+   - collapse-output-transforms: 0
+
+   - dimensionality: 3
+
+   - initial-moving-transform :
+      initializationFeature: 0
+
+   - transforms:
+      - Rigid:
+          gradientStep : 0.1
+          metric :
+            type : MI
+            metricWeight: 1
+            numberOfBins : 32
+            samplingStrategy : Regular
+            samplingPercentage : 0.25
+          convergence:
+            iteration : 1000x500x250x100
+            convergenceThreshold : 1e-08
+            convergenceWindowSize : 10
+          smoothing-sigmas : 3.0x2.0x1.0x0.0
+          shrink-factors : 8x4x2x1
+          use-histogram-matching : True
+
+      - Affine:
+          gradientStep : 0.1
+          metric :
+            type : MI
+            metricWeight: 1
+            numberOfBins : 32
+            samplingStrategy : Regular
+            samplingPercentage : 0.25
+          convergence:
+            iteration : 1000x500x250x100
+            convergenceThreshold : 1e-08
+            convergenceWindowSize : 10
+          smoothing-sigmas : 3.0x2.0x1.0x0.0
+          shrink-factors : 8x4x2x1
+          use-histogram-matching : True
+
+      - SyN:
+          gradientStep : 0.1
+          updateFieldVarianceInVoxelSpace : 3.0
+          totalFieldVarianceInVoxelSpace : 0.0
+          metric:
+            type : CC
+            metricWeight: 1
+            radius : 4
+          convergence:
+            iteration : 100x100x70x20
+            convergenceThreshold : 1e-09
+            convergenceWindowSize : 15
+          smoothing-sigmas : 3.0x2.0x1.0x0.0
+          shrink-factors : 6x4x2x1
+          use-histogram-matching : True
+          winsorize-image-intensities :
+            lowerQuantile : 0.01
+            upperQuantile : 0.99
 
 
 # Please specify ANTs parameters,if run Functional to EPI Template Registration
 ANTs_para_EPI_registration: None
-
-
-# If a lesion mask is available for a T1w image, use it to improve the ANTs' registration
-# ANTS registration only.
-use_lesion_mask : [0]
 
 
 # Use only FLIRT, without FNIRT, for anatomical-to-template registration.
@@ -332,11 +384,7 @@ ref_mask :  /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_br
 
 
 # Register skull-on anatomical image to a template.
-regWithSkull :  [1]
-
-
-# Disables skull-stripping on the anatomical inputs if they are already skull-stripped outside of C-PAC. Set this to On if your input images are already skull-stripped.
-already_skullstripped :  [0]
+regWithSkull :  [0]
 
 
 # Automatically segment anatomical images into white matter, gray matter, and CSF based on prior probability maps.
@@ -391,7 +439,7 @@ PRIORS_CSF :  $priors_path/avg152T1_csf_bin.nii.gz
 # Use threshold to further refine the resulting segmentation tissue masks.
 # FSL-FAST Thresholding - Use FSL FAST generated tissue class files (binary masks) to generate the resulting segmentation tissue masks.
 # Customized Thresholding - Set the threshold value for tissue probability maps to generate the resulting segmentation tissue masks.
-seg_use_threshold : ['FSL-FAST Thresholding']
+seg_use_threshold : ['Customized Thresholding']
 
 
 # Set the threshold value for refining the resulting segmentation tissue masks (CSF, White Matter, and Gray Matter)
@@ -496,15 +544,15 @@ scaling_factor : 10
 
 
 # run motion statistics before slice timing correction
-runMotionStatisticsFirst : [0]
+runMotionStatisticsFirst : [1]
 
 
 # Choose motion correction method. Options: AFNI 3dvolreg, FSL mcflirt
-motion_correction : ['3dvolreg']
+motion_correction : ['mcflirt']
 
 
 # Choose motion correction reference. Options: mean, median, selected volume
-motion_correction_reference: ['mean']
+motion_correction_reference: ['median']
 
 
 # Choose motion correction reference volume
@@ -512,11 +560,11 @@ motion_correction_reference_volume :  0
 
 
 # This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
-functional_volreg_twopass :  On
+functional_volreg_twopass :  Off
 
 
 # Run AFNI 3dDespike
-runDespike : [0]
+runDespike : [1]
 
 
 # Interpolate voxel time courses so they are sampled at the same time points.
@@ -539,21 +587,22 @@ slice_timing_pattern :  Use NIFTI Header
 # Default is 0 (beginning of timeseries).
 # First timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
 # Note: the selection here applies to all scans of all participants.
-startIdx :  0
+startIdx :  5
 
 
 # Last timepoint to include in analysis.
 # Default is None or End (end of timeseries).
 # Last timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
 # Note: the selection here applies to all scans of all participants.
-stopIdx :  None
+stopIdx :  100
+
 
 
 # Perform distortion correction.
 # PhaseDiff - Perform field map correction using a single phase difference image, a subtraction of the two phase images from each echo. Default scanner for this method is SIEMENS.
 # Blip - Uses AFNI 3dQWarp to calculate the distortion unwarp for EPI field maps of opposite/same phase encoding direction.
 # Options: ["PhaseDiff", "Blip", "None"]
-distortion_correction :  ["None"]
+distortion_correction :  ["PhaseDiff", "Blip"]
 
 
 # Options for 'PhaseDiff' distortion correction only.
@@ -570,10 +619,6 @@ fmap_distcorr_frac : [0.5]
 # Set the threshold value for the skull-stripping of the magnitude file. Depending on the data, a tighter extraction may be necessary in order to prevent noisy voxels from interfering with preparing the field map.
 # The default value is 0.5.
 fmap_distcorr_threshold :  0.6
-
-
-# Run Functional to EPI Template Registration
-runRegisterFuncToEPI :  [0]
 
 
 # Run Functional to Anatomical Registration
@@ -617,17 +662,13 @@ funcRegFSLinterpolation: sinc
 func_reg_input :  ['Mean Functional']
 
 
-# Run ANTs’ N4 Bias Field Correction on the input BOLD average(mean EPI)
-n4_correct_mean_EPI : False
-
-
 # Only for when 'Use as Functional-to-Anatomical Registration Input' is set to 'Selected Functional Volume'. Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
 func_reg_input_volume :  0
 
 
 # Choose which tool to be used in functional masking - AFNI (3dAutoMask), FSL (BET) or FSL_AFNI (BET+3dAutoMask).
 # Options: ['AFNI', 'FSL', 'FSL_AFNI']
-functionalMasking :  ['AFNI']
+functionalMasking :  ['FSL_AFNI']
 
 
 # Choose whether or not to dilate anatomical mask if choose 'Anatomical_Refined' as functionalMasking option. It will dilate only one voxel if anatomical_mask_dilation : True
@@ -637,20 +678,17 @@ anatomical_mask_dilation : False
 # Run Functional to Template Registration
 # This option must be enabled if you wish to calculate any derivatives.
 # Options: ['T1_template', 'EPI_template', 'Off']
-runRegisterFuncToTemplate :  ['T1_template']
+runRegisterFuncToTemplate :  ['T1_template', 'Off']
 
 
 # The resolution (in mm) to which the preprocessed, registered functional timeseries outputs are written into. Note that selecting a 1 mm or 2 mm resolution might substantially increase your RAM needs- these resolutions should be selected with caution. For most cases, 3 mm or 4 mm resolutions are suggested.
 # If three dimensions are identical, enter only one number (integer or floating point number), eg. 3mm or 2.5mm; if three dimensions are different, enter: num1xnum2xnum3, eg. 3mmx2.5mmx2.5mm
-resolution_for_func_preproc :  2mm
+resolution_for_func_preproc :  3mm
 
 
 # The resolution (in mm) to which the registered derivative outputs are written into.
+# If three dimensions are identical, enter only one number (integer or floating point number), eg. 3mm or 2.5mm; if three dimensions are different, enter: num1xnum2xnum3, eg. 3mmx2.5mmx2.5mm
 resolution_for_func_derivative :  2mm
-
-
-# A standard template for resampling if using float resolution
-template_for_resample :  $FSLDIR/data/standard/MNI152_T1_1mm_brain.nii.gz
 
 
 # Standard FSL Skull Stripped Template. Used as a reference image for functional registration
@@ -661,17 +699,13 @@ template_brain_only_for_func :  /usr/share/fsl/5.0/data/standard/MNI152_T1_${res
 template_skull_for_func :  /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_func_preproc}.nii.gz
 
 
-# EPI template
-template_epi :  s3://fcp-indi/resources/cpac/resources/epi_hbn.nii.gz
-
-
 # Matrix containing all 1's. Used as an identity matrix during registration.
 # It is not necessary to change this path unless you intend to use non-standard MNI registration.
 identityMatrix :  /usr/share/fsl/5.0/etc/flirtsch/ident.mat
 
 
 # Run ICA-AROMA de-noising.
-runICA :  [0]
+runICA :  [1, 0]
 
 
 # Types of denoising strategy: i)nonaggr-patial component regression, ii)aggr-aggressive denoising
@@ -688,7 +722,13 @@ lateral_ventricles_mask :  /usr/share/fsl/5.0/data/atlases/HarvardOxford/Harvard
 
 # Select which nuisance signal corrections to apply
 Regressors :
- - aCompCor:
+
+ - Motion:
+     include_delayed: true
+     include_squared: true
+     include_delayed_squared: true
+
+   aCompCor:
      summary:
        method: DetrendPC
        components: 5
@@ -700,18 +740,52 @@ Regressors :
    CerebrospinalFluid:
      summary: Mean
      extraction_resolution: 2
-     
+
    PolyOrt:
-    degree: 2
+    degree: 1
 
    Bandpass:
      bottom_frequency: 0.01
      top_frequency: 0.1
 
+ - Motion:
+     include_delayed: true
+     include_squared: true
+     include_delayed_squared: false
+
+   aCompCor:
+     summary:
+       method: DetrendPC
+       components: 5
+     tissues:
+       - CerebrospinalFluid
+     extraction_resolution: 2
+
+   CerebrospinalFluid:
+     summary: Mean
+     extraction_resolution: 2
+     erode_mask: true
+
+   GlobalSignal:
+     summary: Mean
+
+ - Motion:
+     include_delayed: true
+     include_squared: false
+     include_delayed_squared: false
+
+   Censor:
+     method: Kill
+     thresholds:
+      - type: FD_P
+        value: 0.3
+     number_of_previous_trs_to_censor: 1
+     number_of_subsequent_trs_to_censor: 1
+
 
 # Whether to run frequency filtering before or after nuisance regression.
 # ['Before'] or ['After']
-filtering_order: ['After']
+filtering_order: ['Before']
 
 
 # Correct for the global signal using Median Angle Correction.
@@ -740,26 +814,8 @@ realignment : ['ROI_to_func']
 # Available analyses: ['Avg', 'Voxel', 'SpatialReg'].
 # Denote which analyses to run for each ROI path by listing the names above. For example, if you wish to run Avg and SpatialReg, you would enter: '/path/to/ROI.nii.gz': Avg, SpatialReg
 tsa_roi_paths:
-  - /ndmg_atlases/label/Human/aal_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/brodmann_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/CPAC200_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/desikan_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DKT_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00071_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00096_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00108_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00140_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00195_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00278_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00350_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00446_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00583_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS00833_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/DS01216_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/HarvardOxfordcort-maxprob-thr25_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/HarvardOxfordsub-maxprob-thr25_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/JHU_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
-    /ndmg_atlases/label/Human/princetonvisual-top_space-MNI152NLin6_res-2x2x2.nii.gz: Avg
+  - s3://fcp-indi/resources/cpac/resources/rois_2mm.nii.gz: Avg, Voxel, SpatialReg
+
 
 
 # By default, extracted time series are written as both a text file and a 1D file. Additional output formats are as a .csv spreadsheet or a Numpy array.
@@ -768,13 +824,15 @@ roiTSOutputs :  [True, True]
 
 # For each extracted ROI Average time series, CPAC will generate a whole-brain correlation map.
 # It should be noted that for a given seed/ROI, SCA maps for ROI Average time series will be the same.
-runSCA :  [0]
+runSCA :  [1]
 
 
 # Enter paths to region-of-interest (ROI) NIFTI files (.nii or .nii.gz) to be used for time-series extraction, and then select which types of analyses to run.
 # Available analyses: ['Avg', 'DualReg', 'MultReg'].
 # Denote which analyses to run for each ROI path by listing the names above. For example, if you wish to run Avg and MultReg, you would enter: '/path/to/ROI.nii.gz': Avg, MultReg
-sca_roi_paths: None
+sca_roi_paths:
+  - s3://fcp-indi/resources/cpac/resources/rois_2mm.nii.gz: Avg, MultReg
+    s3://fcp-indi/resources/cpac/resources/PNAS_Smith09_rsn10.nii.gz: DualReg
 
 
 # Normalize each time series before running Dual Regression SCA.
@@ -782,7 +840,7 @@ mrsNorm :  True
 
 
 # Calculate Voxel-mirrored Homotopic Connectivity (VMHC) for all voxels.
-runVMHC :  [0]
+runVMHC :  [1]
 
 
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
@@ -790,26 +848,14 @@ runVMHC :  [0]
 template_symmetric_brain_only :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_symmetric.nii.gz
 
 
-# A reference symmetric brain template for resampling
-template_symmetric_brain_for_resample : $FSLDIR/data/standard/MNI152_T1_1mm_brain_symmetric.nii.gz
-
-
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
 # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
 template_symmetric_skull :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_symmetric.nii.gz
 
 
-# A reference symmetric skull template for resampling
-template_symmetric_skull_for_resample :  $FSLDIR/data/standard/MNI152_T1_1mm_symmetric.nii.gz
-
-
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
 # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
 dilated_symmetric_brain_mask :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_symmetric_dil.nii.gz
-
-
-# A reference symmetric brain mask template for resampling
-dilated_symmetric_brain_mask_for_resample :  $FSLDIR/data/standard/MNI152_T1_1mm_brain_mask_symmetric_dil.nii.gz
 
 
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
@@ -818,7 +864,7 @@ configFileTwomm :  $FSLDIR/etc/flirtsch/T1_2_MNI152_2mm.cnf
 
 
 # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and and fractional ALFF (f/ALFF) for all voxels.
-runALFF :  [0]
+runALFF :  [1]
 
 
 # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
@@ -830,7 +876,7 @@ lowPassFreqALFF : [0.1]
 
 
 # Calculate Regional Homogeneity (ReHo) for all voxels.
-runReHo :  [0]
+runReHo :  [1]
 
 
 # Number of neighboring voxels used when calculating ReHo
@@ -841,11 +887,11 @@ clusterSize :  27
 
 
 # Calculate Degree, Eigenvector Centrality, or Functional Connectivity Density.
-runNetworkCentrality :  [0]
+runNetworkCentrality :  [1]
 
 
 # Full path to a NIFTI file describing the mask. Centrality will be calculated for all voxels within the mask.
-templateSpecificationFile :  /cpac_templates/Mask_ABIDE_85Percent_GM.nii.gz
+templateSpecificationFile :  s3://fcp-indi/resources/cpac/resources/mask-thr50-3mm.nii.gz
 
 
 # Enable/Disable degree centrality by selecting the connectivity weights
@@ -864,7 +910,7 @@ degCorrelationThreshold :  0.001
 
 
 # Enable/Disable eigenvector centrality by selecting the connectivity weights
-eigWeightOptions :  [False, True]
+eigWeightOptions :  [True, True]
 
 
 # Select the type of threshold used when creating the eigenvector centrality adjacency matrix.
@@ -883,32 +929,32 @@ lfcdWeightOptions :  [True, True]
 
 
 # Select the type of threshold used when creating the lFCD adjacency matrix.
-lfcdCorrelationThresholdOption :  ['Correlation threshold']
+lfcdCorrelationThresholdOption :  ['Significance threshold']
 
 
 # Based on the Threshold Type selected above, enter a Threshold Value.
 # P-value for Significance Threshold
 # Sparsity value for Sparsity Threshold
 # Pearson's r value for Correlation Threshold
-lfcdCorrelationThreshold :  0.6
+lfcdCorrelationThreshold :  0.001
 
 
 # Maximum amount of RAM (in GB) to be used when calculating Degree Centrality.
 # Calculating Eigenvector Centrality will require additional memory based on the size of the mask or number of ROI nodes.
-memoryAllocatedForDegreeCentrality :  1.0
+memoryAllocatedForDegreeCentrality :  3.0
 
 
 # Smooth the derivative outputs.
 # On - Run smoothing and output only the smoothed outputs.
 # On/Off - Run smoothing and output both the smoothed and non-smoothed outputs.
 # Off - Don't run smoothing.
-run_smoothing :  [1]
+run_smoothing :  [1, 0]
 
 
 # Tool to use for smoothing.
 # ['FSL'] for FSL MultiImageMaths for FWHM provided
 # ['AFNI'] for AFNI 3dBlurToFWHM for FWHM provided
-smoothing_method : ['FSL']
+smoothing_method : ['AFNI']
 
 
 # Full Width at Half Maximum of the Gaussian kernel used during spatial smoothing.
@@ -925,7 +971,7 @@ smoothing_order :  ['Before']
 # On - Run z-scoring and output only the z-scored outputs.
 # On/Off - Run z-scoring and output both the z-scored and raw score versions of the outputs.
 # Off - Don't run z-scoring.
-runZScoring :  [1]
+runZScoring :  [1, 0]
 
 
 # PyPEER integration

--- a/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
@@ -611,6 +611,22 @@ scaling_factor : 10
 runMotionStatisticsFirst : [0]
 
 
+# Choose motion correction method. Options: AFNI 3dvolreg, FSL mcflirt
+motion_correction : ['3dvolreg']
+
+
+# Choose motion correction reference. Options: mean, median, selected volume
+motion_correction_reference: ['mean']
+
+
+# Choose motion correction reference volume
+motion_correction_reference_volume :  0
+
+
+# This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
+functional_volreg_twopass :  On
+
+
 # Run AFNI 3dDespike
 runDespike : [0]
 

--- a/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
@@ -817,6 +817,19 @@ Regressors :
    GlobalSignal:
      summary: Mean
 
+ - Motion:
+     include_delayed: true
+     include_squared: false
+     include_delayed_squared: false
+
+   Censor:
+     method: Kill
+     thresholds:
+      - type: FD_J
+        value: 0.3
+     number_of_previous_trs_to_censor: 1
+     number_of_subsequent_trs_to_censor: 1
+
 
 # Whether to run frequency filtering before or after nuisance regression.
 # ['Before'] or ['After']

--- a/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
@@ -488,6 +488,22 @@ scaling_factor : 10
 runMotionStatisticsFirst : [0]
 
 
+# Choose motion correction method. Options: AFNI 3dvolreg, FSL mcflirt
+motion_correction : ['3dvolreg']
+
+
+# Choose motion correction reference. Options: mean, median, selected volume
+motion_correction_reference: ['mean']
+
+
+# Choose motion correction reference volume
+motion_correction_reference_volume :  0
+
+
+# This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
+functional_volreg_twopass :  On
+
+
 # Run AFNI 3dDespike
 runDespike : [0]
 

--- a/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
@@ -696,6 +696,19 @@ Regressors :
 
    GlobalSignal:
      summary: Mean
+
+ - Motion:
+     include_delayed: true
+     include_squared: false
+     include_delayed_squared: false
+
+   Censor:
+     method: Kill
+     thresholds:
+      - type: FD_P
+        value: 0.3
+     number_of_previous_trs_to_censor: 1
+     number_of_subsequent_trs_to_censor: 1
      
 
 # Whether to run frequency filtering before or after nuisance regression.

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -127,6 +127,10 @@ already_skullstripped :  [0]
 skullstrip_option :  ['unet']
 
 
+	# UNet model	
+unet_model : s3://fcp-indi/resources/cpac/resources/Site-All-T-epoch_36.model
+
+
 # Template to be used during niworkflows-ants.
 # For skullstrip option 'niworkflows-ants' only.
 # It is not necessary to change this path unless you intend to use a non-standard template.
@@ -142,6 +146,11 @@ niworkflows_ants_regmask_path : /ants_template/oasis/T_template0_BrainCerebellum
 
 
 # Options to be used for AFNI 3dSkullStrip only.
+
+
+# Output a mask volume instead of a skull-stripped volume. The mask volume containes 0 to 6, which represents voxel's postion. If set to True, C-PAC will use this output to generate anatomical brain mask for further analysis.	
+skullstrip_mask_vol: False
+
 
 # Choice of using monkey option for AFNI 3dskullstrip 
 skullstrip_monkey : True
@@ -229,7 +238,8 @@ skullstrip_blur_fwhm :  0
 bet_frac :  0.5
 
 
-# Mask created along with skull stripping
+# Mask created along with skull stripping. 
+# It should be `On`, if selected functionalMasking :  ['Anatomical_Refined'] and `FSL` as skull-stripping method.
 bet_mask_boolean :  On
 
 
@@ -623,21 +633,6 @@ fmap_distcorr_frac : [0.5]
 fmap_distcorr_threshold :  0.6
 
 
-# Set the Delta-TE value, used for preparing field map, time delay between the first and second echo images. Default value is 2.46 ms.
-fmap_distcorr_deltaTE: [2.46]
-
-
-# Set the Dwell Time for the fugue input. This is the time between scans, default value is 0.0005s.
-fmap_distcorr_dwell_time: [0.0005]
-
-
-# Set the asymmetric ratio value for FSL Fugue input.
-fmap_distcorr_dwell_asym_ratio: [0.93902439]
-
-
-# Set the phase-encoding direction. The options are: x, y, z, -x, -y, -z.
-fmap_distcorr_pedir: -y
-
 # Run Functional to Anatomical Registration
 runRegisterFuncToAnat :  [1]
 
@@ -677,6 +672,10 @@ funcRegFSLinterpolation: sinc
 
 # Choose whether to use the mean of the functional/EPI as the input to functional-to-anatomical registration or one of the volumes from the functional 4D timeseries that you choose.
 func_reg_input :  ['Mean Functional']
+
+
+# Run ANTs’ N4 Bias Field Correction on the input BOLD average(mean EPI)
+n4_correct_mean_EPI: true
 
 
 # Only for when 'Use as Functional-to-Anatomical Registration Input' is set to 'Selected Functional Volume'. Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
@@ -744,10 +743,6 @@ bold_bet_threshold :  Off
 bold_bet_vertical_gradient : 0.0
 
 
-# Choose whether or not to dilate anatomical mask if choose 'Anatomical_Refined' as functionalMasking option. It will dilate only one voxel if anatomical_mask_dilation : True 
-anatomical_mask_dilation: True
-
-
 # Choose whether or not to dilate anatomical mask if choose 'Anatomical_Refined' as functionalMasking option. It will dilate only one voxel if anatomical_mask_dilation : True
 anatomical_mask_dilation : False
 
@@ -800,7 +795,7 @@ runNuisance :  [1]
 
 
 # Standard Lateral Ventricles Binary Mask
-# lateral_ventricles_mask :  $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
+# lateral_ventricles_mask :  /Path/to/lateral-ventricles.nii.gz
 lateral_ventricles_mask :  None
 
 

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -284,12 +284,12 @@ resolution_for_anat :  2mm
 
 # Template to be used during registration.
 # It is not necessary to change this path unless you intend to use a non-standard template.
-template_brain_only_for_anat :  /Path/to/NMTtemplate/NMT_SS_1mm.nii.gz
+template_brain_only_for_anat: /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm_brain.nii.gz
 
 
 # Template to be used during registration.
 # It is not necessary to change this path unless you intend to use a non-standard template.
-template_skull_for_anat : /Path/to/NMTtemplate/NMT_1mm.nii.gz
+template_skull_for_anat: /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm.nii.gz
 
 
 # Use either ANTS or FSL (FLIRT and FNIRT) as your anatomical registration method.
@@ -379,7 +379,7 @@ fsl_linear_reg_only :  [0]
 
 # Configuration file to be used by FSL to set FNIRT parameters.
 # It is not necessary to change this path unless you intend to use custom FNIRT parameters or a non-standard e.
-ref_mask :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
+ref_mask :  /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm_brain_mask.nii.gz
 
 
 # Register skull-on anatomical image to a template.
@@ -534,6 +534,38 @@ gm_erosion_mm: 0
 runFunctional: [1]
 
 
+# Scale functional raw data, usually used in rodent pipeline
+runScaling: false
+
+
+# Set scaling factor, if runScaling : True. Scale the size of the dataset voxels by the factor.
+scaling_factor: 10
+
+
+# run motion statistics before slice timing correction
+runMotionStatisticsFirst : [0]
+
+
+# Choose motion correction method. Options: AFNI 3dvolreg, FSL mcflirt
+motion_correction : ['3dvolreg']
+
+
+# Choose motion correction reference. Options: mean, median, selected volume 
+motion_correction_reference: ['mean']
+
+
+# Choose motion correction reference volume
+motion_correction_reference_volume :  0
+
+
+# This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
+functional_volreg_twopass :  On
+
+
+# Run AFNI 3dDespike
+runDespike : [0]
+
+
 # Interpolate voxel time courses so they are sampled at the same time points.
 slice_timing_correction :  [1]
 
@@ -591,12 +623,27 @@ fmap_distcorr_frac : [0.5]
 fmap_distcorr_threshold :  0.6
 
 
+# Set the Delta-TE value, used for preparing field map, time delay between the first and second echo images. Default value is 2.46 ms.
+fmap_distcorr_deltaTE: [2.46]
+
+
+# Set the Dwell Time for the fugue input. This is the time between scans, default value is 0.0005s.
+fmap_distcorr_dwell_time: [0.0005]
+
+
+# Set the asymmetric ratio value for FSL Fugue input.
+fmap_distcorr_dwell_asym_ratio: [0.93902439]
+
+
+# Set the phase-encoding direction. The options are: x, y, z, -x, -y, -z.
+fmap_distcorr_pedir: -y
+
 # Run Functional to Anatomical Registration
 runRegisterFuncToAnat :  [1]
 
 
 # Run Functional to Anatomical Registration with BB Register
-runBBReg :  [1]
+runBBReg :  [0]
 
 
 # Standard FSL 5.0 Scheduler used for Boundary Based Registration.
@@ -636,9 +683,69 @@ func_reg_input :  ['Mean Functional']
 func_reg_input_volume :  0
 
 
-# Choose which tool to be used in functional masking - AFNI (3dAutoMask), FSL (BET) or FSL_AFNI (BET+3dAutoMask).
-# Options: ['AFNI', 'FSL', 'FSL_AFNI']
-functionalMasking :  ['AFNI']
+# Choose which tool to be used in functional masking - AFNI (3dAutoMask), FSL (BET),  FSL_AFNI (BET+3dAutoMask), or refine functional mask by registering anatomical mask to functional space. 
+# Options: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined']
+functionalMasking: [Anatomical_Refined]
+
+
+# Options to be used for FSL skull-stripping of functional masking.
+
+# Apply to 4D FMRI data, if bold_bet_functional_mean_boolean : Off. 
+# Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+# It must be 'on' if select 'bold_bet_reduce_bias','bold_bet_robust','bold_bet_padding','bold_bet_remove_eyes',or 'bold_bet_surfaces' on
+bold_bet_functional_mean_boolean : Off
+
+
+# Set the threshold value controling the brain vs non-brain voxels.
+bold_bet_frac :  0.3
+
+
+# Mesh created along with skull stripping
+bold_bet_mesh_boolean :  Off
+
+
+# Create a surface outline image
+bold_bet_outline :  Off
+
+
+# Add padding to the end of the image, improving BET.Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+bold_bet_padding :  Off
+
+
+# Integer value of head radius
+bold_bet_radius :  0
+
+
+# Reduce bias and cleanup neck. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+bold_bet_reduce_bias :  Off
+
+
+# Eyes and optic nerve cleanup. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+bold_bet_remove_eyes :  Off
+
+
+# Robust brain center estimation. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+bold_bet_robust :  Off
+
+
+# Create a skull image
+bold_bet_skull :  Off
+
+
+# Gets additional skull and scalp surfaces by running bet2 and betsurf. This is mutually exclusive with reduce_bias, robust, padding, remove_eyes
+bold_bet_surfaces :  Off
+
+
+# Apply thresholding to segmented brain image and mask
+bold_bet_threshold :  Off
+
+
+# Vertical gradient in fractional intensity threshold (-1,1)
+bold_bet_vertical_gradient : 0.0
+
+
+# Choose whether or not to dilate anatomical mask if choose 'Anatomical_Refined' as functionalMasking option. It will dilate only one voxel if anatomical_mask_dilation : True 
+anatomical_mask_dilation: True
 
 
 # Choose whether or not to dilate anatomical mask if choose 'Anatomical_Refined' as functionalMasking option. It will dilate only one voxel if anatomical_mask_dilation : True
@@ -652,19 +759,27 @@ runRegisterFuncToTemplate :  ['T1_template']
 
 
 # The resolution (in mm) to which the preprocessed, registered functional timeseries outputs are written into. Note that selecting a 1 mm or 2 mm resolution might substantially increase your RAM needs- these resolutions should be selected with caution. For most cases, 3 mm or 4 mm resolutions are suggested.
-resolution_for_func_preproc :  3mm
+resolution_for_func_preproc: 2mm
 
 
 # The resolution (in mm) to which the registered derivative outputs are written into.
-resolution_for_func_derivative :  3mm
+resolution_for_func_derivative: 2mm
+
+
+# A standard template for resampling if using float resolution
+template_for_resample: /Path/to/Yerkes19/MacaqueYerkes19_T1w_2mm.nii.gz
 
 
 # Standard FSL Skull Stripped Template. Used as a reference image for functional registration
-template_brain_only_for_func :  /Path/to/NMTtemplate/NMT_SS_2mm.nii.gz
+template_brain_only_for_func: /Path/to/Yerkes19/MacaqueYerkes19_T1w_2mm_brain.nii.gz
 
 
 # Standard FSL Anatomical Brain Image with Skull
-template_skull_for_func :  /Path/to/NMTtemplate/NMT_2mm.nii.gz 
+template_skull_for_func: /Path/to/Yerkes19/MacaqueYerkes19_T1w_2mm.nii.gz
+
+
+# EPI template
+template_epi: s3://fcp-indi/resources/cpac/resources/epi_hbn.nii.gz
 
 
 # Matrix containing all 1's. Used as an identity matrix during registration.
@@ -686,7 +801,8 @@ runNuisance :  [1]
 
 # Standard Lateral Ventricles Binary Mask
 # lateral_ventricles_mask :  $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
-lateral_ventricles_mask :  /Path/to/NMTtemplate/fullmask.nii.gz
+lateral_ventricles_mask :  None
+
 
 # Select which nuisance signal corrections to apply
 Regressors :
@@ -705,7 +821,7 @@ Regressors :
        - CerebrospinalFluid
      extraction_resolution: 2
 
-  CerebrospinalFluid:
+   CerebrospinalFluid:
     summary: Mean
     extraction_resolution: 2
     erode_mask: true
@@ -735,7 +851,7 @@ Regressors :
        - CerebrospinalFluid
      extraction_resolution: 2
 
-  CerebrospinalFluid:
+   CerebrospinalFluid:
     summary: Mean
     extraction_resolution: 2
     erode_mask: true
@@ -822,17 +938,29 @@ runVMHC :  [0]
 
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
 # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
-template_symmetric_brain_only :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_symmetric.nii.gz
+template_symmetric_brain_only: /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm_brain.nii.gz
+
+
+# A reference symmetric brain template for resampling
+template_symmetric_brain_for_resample: /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm.nii.gz
 
 
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
 # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
-template_symmetric_skull :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_symmetric.nii.gz
+template_symmetric_skull: /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm.nii.gz
+
+
+# A reference symmetric skull template for resampling
+template_symmetric_skull_for_resample: /Path/to/Yerkes19/MacaqueYerkes19_T1w_1.0mm.nii.gz
 
 
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
 # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
-dilated_symmetric_brain_mask :  $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_symmetric_dil.nii.gz
+dilated_symmetric_brain_mask: /Path/to/Yerkes19/MacaqueYerkes19_T1w_2mm_brain_mask.nii.gz
+
+
+# A reference symmetric brain mask template for resampling
+dilated_symmetric_brain_mask_for_resample: /Path/to/Yerkes19/MacaqueYerkes19_T1w_2mm_brain_mask.nii.gz
 
 
 # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -127,7 +127,7 @@ already_skullstripped :  [0]
 skullstrip_option :  ['unet']
 
 
-	# UNet model	
+# UNet model	
 unet_model : s3://fcp-indi/resources/cpac/resources/Site-All-T-epoch_36.model
 
 
@@ -604,10 +604,6 @@ startIdx :  0
 # Last timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
 # Note: the selection here applies to all scans of all participants.
 stopIdx :  None
-
-
-# This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
-functional_volreg_twopass :  On
 
 
 # Perform distortion correction.

--- a/CPAC/resources/configs/pipeline_config_preproc.yml
+++ b/CPAC/resources/configs/pipeline_config_preproc.yml
@@ -566,6 +566,14 @@ motion_correction_reference: ['mean']
 motion_correction_reference_volume :  0
 
 
+# This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
+functional_volreg_twopass :  On
+
+
+# Run AFNI 3dDespike
+runDespike : [0]
+
+
 # Interpolate voxel time courses so they are sampled at the same time points.
 slice_timing_correction :  [1]
 
@@ -594,10 +602,6 @@ startIdx :  0
 # Last timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
 # Note: the selection here applies to all scans of all participants.
 stopIdx :  None
-
-
-# This options is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
-functional_volreg_twopass :  On
 
 
 # Perform distortion correction.


### PR DESCRIPTION
AFNI expects TSVs to have a header row, so the first value was being considered the header. This PR adds a header row to `censors.tsv` and should resolve the issue.

> -----------
>  TSV files: [Sep 2018]
> -----------
> * 1dcat can now also read .tsv files, which are columns of values separated
>   by tab characters (tsv = tab separated values). The first row of a .tsv 
>   file is a set of column labels. After the header row, each column is either
>   all numbers, or is a column of strings. For example
>      Col 1 Col 2 Col 3
>      3.2 7.2 Elvis
>      8.2 -1.2 Sinatra
>      6.66  33.3 20892
>   In this example, the column labels contain spaces, which are NOT separators;
>   the only column separator used in a .tsv file is the tab character.
>   The first and second columns are converted to number columns, since every
>   value (after the label/header row) is a numeric string. The third column
>   is stored as strings, since some of the entries are not valid numbers.
> 
> * 1dcat can deal with a mix of .1D and .tsv files. The .tsv file header
>   rows are NOT output by default, since .1D files don't have such headers.
> 
> * The usual output from 1dcat is NOT a .tsv file - blanks are used for
>   separators. You can use the '-tsvout' option to get TSV formatted output.
> 
> * If you mix .1D and .tsv files, the number of data rows in each file
>   must be the same. Since the header row in a .tsv file is NOT used here,
>   **the total number of lines in a .tsv file must be 1 more than the number**
>   **of lines in a .1D file for the two files to match** in this program.

― [AFNI program: 1dcat Output of -help](https://afni.nimh.nih.gov/pub/dist/doc/program_help/1dcat.html) (emphasis added)

Ref [Nuisance regression error on singularity](https://groups.google.com/forum/#!topic/cpax_forum/USFpu9cf11Y)