### PR TITLE
🚑 Fix number of lines in censors.tsv

### DIFF
--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -113,7 +113,7 @@ def find_offending_time_points(fd_j_file_path=None, fd_p_file_path=None, dvars_f
     censor_vector[extended_censors] = 0
 
     out_file_path = os.path.join(os.getcwd(), "censors.tsv")
-    np.savetxt(out_file_path, censor_vector, fmt='%d')
+    np.savetxt(out_file_path, censor_vector, fmt='%d', header='censor')
 
     return out_file_path
 
@@ -410,16 +410,16 @@ def generate_summarize_tissue_mask_ventricles_masking(nuisance_wf,
                     nuisance_wf.connect(*(transforms['anat_to_mni_affine_xfm'] + (collect_linear_transforms, 'in3')))
 
                     # check transform list to exclude Nonetype (missing) init/rig/affine
-                    check_transform = pe.Node(util.Function(input_names=['transform_list'], 
+                    check_transform = pe.Node(util.Function(input_names=['transform_list'],
                                                             output_names=['checked_transform_list', 'list_length'],
                                                             function=check_transforms), name='{0}_check_transforms'.format(ventricles_key))
-                    
+
                     nuisance_wf.connect(collect_linear_transforms, 'out', check_transform, 'transform_list')
 
                     # generate inverse transform flags, which depends on the number of transforms
-                    inverse_transform_flags = pe.Node(util.Function(input_names=['transform_list'], 
+                    inverse_transform_flags = pe.Node(util.Function(input_names=['transform_list'],
                                                                     output_names=['inverse_transform_flags'],
-                                                                    function=generate_inverse_transform_flags), 
+                                                                    function=generate_inverse_transform_flags),
                                                                     name='{0}_inverse_transform_flags'.format(ventricles_key))
                     nuisance_wf.connect(check_transform, 'checked_transform_list', inverse_transform_flags, 'transform_list')
 


### PR DESCRIPTION
AFNI expects TSVs to have a header row, so the first value was being considered the header. This PR adds a header row to `censors.tsv` and should resolve the issue.

> -----------
>  TSV files: [Sep 2018]
> -----------
> * 1dcat can now also read .tsv files, which are columns of values separated
>   by tab characters (tsv = tab separated values). The first row of a .tsv 
>   file is a set of column labels. After the header row, each column is either
>   all numbers, or is a column of strings. For example
>      Col 1 Col 2 Col 3
>      3.2 7.2 Elvis
>      8.2 -1.2 Sinatra
>      6.66  33.3 20892
>   In this example, the column labels contain spaces, which are NOT separators;
>   the only column separator used in a .tsv file is the tab character.
>   The first and second columns are converted to number columns, since every
>   value (after the label/header row) is a numeric string. The third column
>   is stored as strings, since some of the entries are not valid numbers.
> 
> * 1dcat can deal with a mix of .1D and .tsv files. The .tsv file header
>   rows are NOT output by default, since .1D files don't have such headers.
> 
> * The usual output from 1dcat is NOT a .tsv file - blanks are used for
>   separators. You can use the '-tsvout' option to get TSV formatted output.
> 
> * If you mix .1D and .tsv files, the number of data rows in each file
>   must be the same. Since the header row in a .tsv file is NOT used here,
>   **the total number of lines in a .tsv file must be 1 more than the number**
>   **of lines in a .1D file for the two files to match** in this program.

― [AFNI program: 1dcat Output of -help](https://afni.nimh.nih.gov/pub/dist/doc/program_help/1dcat.html) (emphasis added)

Ref [Nuisance regression error on singularity](https://groups.google.com/forum/#!topic/cpax_forum/USFpu9cf11Y)