### PR TITLE
Proposal of simple format for strategy info within resource pool.

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1006,7 +1006,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
                 raise Exception
 
             flirt_reg_anat_mni = create_fsl_flirt_linear_reg(
-                'anat_mni_flirt_register_{0}'.format(num_strat)
+                f'anat_mni_flirt_register_{num_strat}'
             )
 
             # Input registration parameters
@@ -1054,7 +1054,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
             if strat.get('registration_method') == 'FSL':
 
                 fnirt_reg_anat_mni = create_fsl_fnirt_nonlinear_reg(
-                    'anat_mni_fnirt_register_{0}'.format(num_strat)
+                    f'anat_mni_fnirt_register_{num_strat}'
                 )
 
                 node, out_file = strat['anatomical_brain']
@@ -1113,7 +1113,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
 
             ants_reg_anat_mni = \
                 create_wf_calculate_ants_warp(
-                    'anat_mni_ants_register_{0}'.format(num_strat),
+                    f'anat_mni_ants_register_{num_strat}',
                     num_threads=num_ants_cores,
                     reg_ants_skull = c.regWithSkull
                 )

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1006,7 +1006,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
                 raise Exception
 
             flirt_reg_anat_mni = create_fsl_flirt_linear_reg(
-                'anat_mni_flirt_register_%d' % num_strat
+                'anat_mni_flirt_register_{0}'.format(num_strat)
             )
 
             # Input registration parameters
@@ -1030,6 +1030,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
                                       'outputspec.output_brain')
 
             strat.update_resource_pool({
+                'registration_method': 'FSL',
                 'anatomical_to_mni_linear_xfm': (flirt_reg_anat_mni, 'outputspec.linear_xfm'),
                 'mni_to_anatomical_linear_xfm': (flirt_reg_anat_mni, 'outputspec.invlinear_xfm'),
                 'anatomical_to_standard': (flirt_reg_anat_mni, 'outputspec.output_brain')
@@ -1050,10 +1051,10 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
 
             nodes = strat.get_nodes_names()
 
-            if 'anat_mni_flirt_register' in nodes:
+            if strat.get('registration_method') == 'FSL':
 
                 fnirt_reg_anat_mni = create_fsl_fnirt_nonlinear_reg(
-                    'anat_mni_fnirt_register_%d' % num_strat
+                    'anat_mni_fnirt_register_{0}'.format(num_strat)
                 )
 
                 node, out_file = strat['anatomical_brain']
@@ -1108,12 +1109,11 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
 
         # or run ANTS anatomical-to-MNI registration instead
         if 'ANTS' in c.regOption and \
-            'anat_mni_flirt_register' not in nodes and \
-                'anat_mni_fnirt_register' not in nodes:
+                strat.get('registration_method') != 'FSL':
 
             ants_reg_anat_mni = \
                 create_wf_calculate_ants_warp(
-                    'anat_mni_ants_register_%d' % num_strat,
+                    'anat_mni_ants_register_{0}'.format(num_strat),
                     num_threads=num_ants_cores,
                     reg_ants_skull = c.regWithSkull
                 )
@@ -1220,6 +1220,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
                                       'outputspec.normalized_output_brain')
 
             strat.update_resource_pool({
+                'registration_method': 'ANTS',
                 'ants_initial_xfm': (ants_reg_anat_mni, 'outputspec.ants_initial_xfm'),
                 'ants_rigid_xfm': (ants_reg_anat_mni, 'outputspec.ants_rigid_xfm'),
                 'ants_affine_xfm': (ants_reg_anat_mni, 'outputspec.ants_affine_xfm'),
@@ -1242,7 +1243,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
             nodes = strat.get_nodes_names()
 
             if 'FSL' in c.regOption and \
-               'anat_mni_ants_register' not in nodes:
+                   strat.get('registration_method') != 'ANTS':
 
                 # this is to prevent the user from running FNIRT if they are
                 # providing already-skullstripped inputs. this is because
@@ -1261,7 +1262,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
                     raise Exception
 
                 flirt_reg_anat_symm_mni = create_fsl_flirt_linear_reg(
-                    'anat_symmetric_mni_flirt_register_%d' % num_strat
+                    'anat_symmetric_mni_flirt_register_{0}'.format(num_strat)
                 )
 
 
@@ -1310,7 +1311,7 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
 
                 nodes = strat.get_nodes_names()
 
-                if 'anat_mni_flirt_register' in nodes:
+                if strat.get('registration_method') == 'FSL':
                     fnirt_reg_anat_symm_mni = create_fsl_fnirt_nonlinear_reg(
                         'anat_symmetric_mni_fnirt_register_%d' % num_strat
                     )

--- a/CPAC/utils/strategy.py
+++ b/CPAC/utils/strategy.py
@@ -51,6 +51,9 @@ class Strategy(object):
                 )
             self.resource_pool[key] = value
 
+    def get(self, resource_key):
+        return self.resource_pool.get(resource_key)
+
     def __getitem__(self, resource_key):
         assert isinstance(resource_key, six.string_types)
         try:


### PR DESCRIPTION
Key changes:
- Introduction of a "get" object method for Strategy- unlike __getitem__, it will run a dict.get(). This should only be used for checking strategy info, which may not be initialized yet in the pipeline. The usual __getitem__ approach for everything else.
- Replacing the `etc. in nodes:` checks with `strat.get('registration_method') == etc.`