### PR TITLE
update motion strat resource pool

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1525,6 +1525,9 @@ def connect_func_preproc(workflow, strat_list, c):
                         new_strat.set_leaf_properties(func_preproc, 'outputspec.preprocessed')
 
                         new_strat.update_resource_pool({
+                            'bold_masking_method': skullstrip_tool,
+                            'motion_correction_method': motion_correct_tool,
+                            'motion_correction_ref': motion_correct_ref,
                             'mean_functional': (func_preproc, 'outputspec.func_mean'),
                             'functional_preprocessed_mask': (func_preproc, 'outputspec.preprocessed_mask'),
                             'movement_parameters': (func_preproc, 'outputspec.movement_parameters'),


### PR DESCRIPTION
update resource pool for the case 'motion_params' not in strat.
- 'bold_masking_method', 'motion_correction_method', 'motion_correction_ref'.  
current develop is generating Node`gen_motion_stats_None_None_None_0` in [ line ](https://github.com/FCP-INDI/C-PAC/blob/develop/CPAC/pipeline/cpac_pipeline.py#L2214) and making motion relevant crashes when set `runMotionStatisticsFirst : [0]`