### PR TITLE
✏️ Fix minor but frequent sinker TypeError

### DIFF
--- a/CPAC/utils/interfaces/datasink.py
+++ b/CPAC/utils/interfaces/datasink.py
@@ -525,7 +525,7 @@ class DataSink(IOBase):
             if not isdefined(files):
                 continue
             iflogger.debug("key: %s files: %s", key, str(files))
-            files = ensure_list(files)
+            files = ensure_list(files if files else [])
             tempoutdir = outdir
             if s3_flag:
                 s3tempoutdir = s3dir


### PR DESCRIPTION
Resolves recurring crashfile

```Python
  File "/code/CPAC/utils/interfaces/datasink.py", line 545, in _list_outputs
    for src in ensure_list(files):

TypeError: 'NoneType' object is not iterable
```

by setting `files` to an empty list if `files` is `None`.