### PR TITLE
Allow ingress of tissue masks

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -739,28 +739,31 @@ def build_workflow(subject_id, sub_dict, c, pipeline_name=None, num_ants_cores=1
         'anatomical': (anat_flow, 'outputspec.anat')
     })
 
-    if 'brain_mask' in sub_dict.keys():
-        if sub_dict['brain_mask'] and sub_dict['brain_mask'].lower() != 'none':
-            brain_flow = create_anat_datasource('brain_gather_%d' % num_strat)
-            brain_flow.inputs.inputnode.subject = subject_id
-            brain_flow.inputs.inputnode.anat = sub_dict['brain_mask']
-            brain_flow.inputs.inputnode.creds_path = input_creds_path
-            brain_flow.inputs.inputnode.dl_dir = c.workingDirectory
+    anat_ingress = [
+        'brain_mask',
+        'lesion_mask',
+        'anatomical_csf_mask',
+        'anatomical_gm_mask',
+        'anatomical_wm_mask'
+    ]
 
-            strat_initial.update_resource_pool({
-                'anatomical_brain_mask': (brain_flow, 'outputspec.anat')
-            })
+    for key in anat_ingress:
+        if key in sub_dict.keys():
+            if sub_dict['key'] and sub_dict['key'].lower() != 'none':
 
-    if 'lesion_mask' in sub_dict.keys():
-        lesion_datasource = create_anat_datasource('lesion_gather_%d' % num_strat)
-        lesion_datasource.inputs.inputnode.subject = subject_id
-        lesion_datasource.inputs.inputnode.anat = sub_dict['lesion_mask']
-        lesion_datasource.inputs.inputnode.creds_path = input_creds_path
-        lesion_datasource.inputs.inputnode.dl_dir = c.workingDirectory
+                anat_ingress_flow = create_anat_datasource(
+                    f'anat_ingress_gather_{num_strat}')
+                anat_ingress_flow.inputs.inputnode.subject = subject_id
+                anat_ingress_flow.inputs.inputnode.anat = sub_dict[key]
+                anat_ingress_flow.inputs.inputnode.creds_path = input_creds_path
+                anat_ingress_flow.inputs.inputnode.dl_dir = c.workingDirectory
 
-        strat_initial.update_resource_pool({
-            'lesion_mask': (lesion_datasource, 'outputspec.anat')
-        })
+                if key == 'brain_mask':
+                    key = 'anatomical_brain_mask'
+
+                strat_initial.update_resource_pool({
+                    key: (anat_ingress_flow, 'outputspec.anat')
+                })
 
     templates_for_resampling = [
         (c.resolution_for_anat, c.template_brain_only_for_anat, 'template_brain_for_anat', 'resolution_for_anat'),


### PR DESCRIPTION
**What It Does, and Where**
Injects user-provided custom tissue masks (from the data config) into the resource pool at the beginning of the pipeline, bypassing tissue segmentation.

**Why**
Allows people to use tissue masks derived by tools not available in C-PAC, or created manually or modified.

**Flowchart**
N/A

**Test Cases**
- [x] Run regular FAST, then start a new run with the FAST-generated tissue masks, and ensure the outputs are identical.