### PR TITLE
✏️ If maxCoresPerParticipant unset, set num_cores_per_sub without dividing by maxCoresPerParticipant

### DIFF
--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -1201,7 +1201,7 @@ def check_config_resources(c):
         else:
             num_cores_per_sub = c.maxCoresPerParticipant
     else:
-        num_cores_per_sub = num_cores / c.maxCoresPerParticipant
+        num_cores_per_sub = num_cores / c.numParticipantsAtOnce
 
     # Now check ANTS
     if 'ANTS' in c.regOption:


### PR DESCRIPTION
```Python
if c.numCoresPerSubject:
    {do stuff}
else:
    num_cores_per_sub = num_cores/c.numCoresPerSubject
```

has persisted through variable name changes since its introduction in 5103492. That `else` will always fail because it will only be reached if the denominator is falsy.