### PR TITLE
🚜 `create_nuisance_workflow` → `create_nuisance_regression_workflow`

### DIFF
--- a/CPAC/nuisance/__init__.py
+++ b/CPAC/nuisance/__init__.py
@@ -20,7 +20,9 @@ from .utils.compcor import (
 )
 
 __all__ = [
-    'create_nuisance_workflow',
+    'create_regressor_workflow',
+    'create_nuisance_regression_workflow',
+    'filtering_bold_and_regressors',
     'find_offending_time_points',
     'temporal_variance_mask',
     'generate_summarize_tissue_mask',

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -575,8 +575,8 @@ def create_regressor_workflow(nuisance_selectors,
     High Level Workflow Graph:
 
     .. exec::
-        from CPAC.nuisance import create_nuisance_workflow
-        wf = create_nuisance_workflow({
+        from CPAC.nuisance import create_nuisance_regression_workflow
+        wf = create_nuisance_regression_workflow({
             'PolyOrt': {'degree': 2},
             'tCompCor': {'summary': {'method': 'PC', 'components': 5}, 'threshold': '1.5SD', 'by_slice': True},
             'aCompCor': {'summary': {'method': 'PC', 'components': 5}, 'tissues': ['WhiteMatter', 'CerebrospinalFluid'], 'extraction_resolution': 2},

--- a/CPAC/nuisance/tests/test_nuisance.py
+++ b/CPAC/nuisance/tests/test_nuisance.py
@@ -4,7 +4,7 @@ import glob
 import nipype.pipeline.engine as pe
 import nipype.interfaces.utility as util
 
-from CPAC.nuisance import create_nuisance_workflow
+from CPAC.nuisance import create_nuisance_regression_workflow
 from CPAC.nuisance.utils import NuisanceRegressor
 
 selector_config = """
@@ -93,7 +93,7 @@ def test_nuisance_workflow_type1():
     for selector in selector_test:
 
         nuisance_regression_workflow = \
-            create_nuisance_workflow(
+            create_nuisance_regression_workflow(
                 nuisance_selectors=NuisanceRegressor(selector),
                 use_ants=True,
                 name='nuisance'

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -113,7 +113,9 @@ def find_offending_time_points(fd_j_file_path=None, fd_p_file_path=None, dvars_f
     censor_vector[extended_censors] = 0
 
     out_file_path = os.path.join(os.getcwd(), "censors.tsv")
-    np.savetxt(out_file_path, censor_vector, fmt='%d', header='censor')
+    np.savetxt(
+        out_file_path, censor_vector, fmt='%d', header='censor', comments=''
+    )
 
     return out_file_path
 


### PR DESCRIPTION
## Description
`create_nuisance_workflow` was split into `create_regressor_workflow`, `create_nuisance_regression_workflow` and `filtering_bold_and_regressors` in b3f027e. This PR updates the remaining places `create_nuisance_workflow` was imported to import `create_nuisance_regression_workflow` instead.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>