### PR TITLE
Feature/volreg parallel

### DIFF
--- a/CPAC/func_preproc/utils.py
+++ b/CPAC/func_preproc/utils.py
@@ -18,17 +18,17 @@ def nullify(value, function=None):
     return value
 
 
-def chunk_ts(func_file):
-    func_img = nb.load(func)
+def chunk_ts(func_file, n_cpus):
+    func_img = nb.load(func_file)
     trs = func_img.shape[3]
     chunk = trs/n_cpus
     TR_ranges = []
 
     for chunk_idx in range(0, n_cpus):
         if chunk_idx == n_cpus - 1:
-            TR_ranges.append((chunk_idx*chunk, trs - 1))
+            TR_ranges.append((int(chunk_idx*chunk), int(trs - 1)))
         else:
-            TR_ranges.append((chunk_idx*chunk, (chunk_idx+1)*chunk -1))
+            TR_ranges.append((int(chunk_idx*chunk), int((chunk_idx+1)*chunk -1)))
     return TR_ranges
 
 
@@ -50,3 +50,26 @@ def split_ts_chunks(func_file, tr_ranges):
         split_funcs.append(out_file)
 
     return split_funcs
+
+
+def oned_text_concat(in_files):
+    out_file = os.path.join(os.getcwd(), os.path.basename(in_files[0].replace("_0", "")))
+
+    out_txt = []
+    for txt in in_files:
+        with open(txt, 'r') as f:
+            txt_lines = f.readlines()
+        if not out_txt:
+            out_txt = [x for x in txt_lines]
+        else:
+            for line in txt_lines:
+                if "#" in line:
+                    continue
+                out_txt.append(line)
+
+    with open(out_file, 'wt') as f:
+        for line in out_txt:
+            f.write(line)
+
+    return out_file
+

--- a/CPAC/func_preproc/utils.py
+++ b/CPAC/func_preproc/utils.py
@@ -1,4 +1,7 @@
 
+import nibabel as nb
+import subprocess
+
 def add_afni_prefix(tpattern):
     if tpattern:
         if ".txt" in tpattern:
@@ -13,3 +16,37 @@ def nullify(value, function=None):
     if function:
         return function(value)
     return value
+
+
+def chunk_ts(func_file):
+    func_img = nb.load(func)
+    trs = func_img.shape[3]
+    chunk = trs/n_cpus
+    TR_ranges = []
+
+    for chunk_idx in range(0, n_cpus):
+        if chunk_idx == n_cpus - 1:
+            TR_ranges.append((chunk_idx*chunk, trs - 1))
+        else:
+            TR_ranges.append((chunk_idx*chunk, (chunk_idx+1)*chunk -1))
+    return TR_ranges
+
+
+def split_ts_chunks(func_file, tr_ranges):
+    if '.nii' in func_file:
+        ext = '.nii'
+    if '.nii.gz' in func_file:
+        ext = '.nii.gz'
+
+    split_funcs = []
+    for chunk_idx, tr_range in enumerate(tr_ranges):
+        out_file = os.path.join(os.getcwd(), os.path.basename(func_file).replace(ext, "_{0}{1}".format(chunk_idx, ext)))
+        in_file = "{0}[{1}..{2}]".format(func_file, tr_range[0], tr_range[1])
+
+        cmd = ["3dcalc", "-a", in_file, "-expr", "a", "-prefix", out_file]
+
+        retcode = subprocess.check_output(cmd)
+
+        split_funcs.append(out_file)
+
+    return split_funcs


### PR DESCRIPTION
Makes [AFNI 3dvolreg motion correction](https://github.com/FCP-INDI/C-PAC/blob/ce26ba9a38cbd401cd405150eeed23b805007724/CPAC/func_preproc/func_preproc.py#L827-L830) ([both nodes](https://github.com/FCP-INDI/C-PAC/blob/ce26ba9a38cbd401cd405150eeed23b805007724/CPAC/func_preproc/func_preproc.py#L902)) parallelizable when the user sets [multiple CPUs per participant](https://github.com/FCP-INDI/C-PAC/blob/ce26ba9a38cbd401cd405150eeed23b805007724/dev/docker_data/default_pipeline.yml#L38-L39).

The time series will be split into chunks (n chunks per CPU), then re-merged.
Setting 5 CPUs made motion correction ~4.85 faster. (Some overhead for the extra I/O and merging etc.).

This should help with data featuring 1000+ TRs. If the user has CPUs to spare, can set something like 20 CPUs for a participant and blast through motion correction.