### PR TITLE
➕ Add 3dCM to required AFNI packages

### DIFF
--- a/dev/docker_data/required_afni_pkgs.txt
+++ b/dev/docker_data/required_afni_pkgs.txt
@@ -3,6 +3,7 @@ linux_openmp_64/3dBandpass
 linux_openmp_64/3dBlurToFWHM
 linux_openmp_64/3dBrickStat
 linux_openmp_64/3dcalc
+linux_openmp_64/3dCM
 linux_openmp_64/3dDegreeCentrality
 linux_openmp_64/3dDespike
 linux_openmp_64/3dDetrend


### PR DESCRIPTION
To resolve / prevent
```
OSError: No command "3dCM" found on host < SHA >. Please check that the corresponding package is installed.
```

The package is used in 3 places:

https://github.com/FCP-INDI/C-PAC/blob/6ea89f8665c703a37bf7b87c91439baa3a849594/CPAC/longitudinal_pipeline/longitudinal_workflow.py#L712

https://github.com/FCP-INDI/C-PAC/blob/6ea89f8665c703a37bf7b87c91439baa3a849594/CPAC/func_preproc/func_preproc.py#L825

https://github.com/FCP-INDI/C-PAC/blob/6ea89f8665c703a37bf7b87c91439baa3a849594/CPAC/anat_preproc/anat_preproc.py#L157