### PR TITLE
🚑 Fix SameFileError

### DIFF
--- a/CPAC/utils/interfaces/datasink.py
+++ b/CPAC/utils/interfaces/datasink.py
@@ -562,7 +562,7 @@ class DataSink(IOBase):
                     out_files.append(s3dst)
                 # Otherwise, copy locally src -> dst
                 if not s3_flag or isdefined(self.inputs.local_copy):
-                    # Create output directory if it doesnt exist
+                    # Create output directory if it doesn't exist
                     if not os.path.exists(path):
                         try:
                             os.makedirs(path)
@@ -571,24 +571,19 @@ class DataSink(IOBase):
                                 pass
                             else:
                                 raise (inst)
-                    # If src == dest, it's already home
-                    if src != dst:
+                    # If src == dst, it's already home
+                    if (not os.path.exists(dst)) or (
+                        os.stat(src) != os.stat(dst)
+                    ):
                         # If src is a file, copy it to dst
                         if os.path.isfile(src):
                             iflogger.debug(f'copyfile: {src} {dst}')
-                            try:
-                                copyfile(
-                                    src,
-                                    dst,
-                                    copy=True,
-                                    hashmethod='content',
-                                    use_hardlink=use_hardlink)
-                            # … unless dst already contains same contents
-                            except SameFileError:
-                                iflogger.debug(
-                                    f'{dst} already contains contents of {src}'
-                                )
-                            out_files.append(dst)
+                            copyfile(
+                                src,
+                                dst,
+                                copy=True,
+                                hashmethod='content',
+                                use_hardlink=use_hardlink)
                         # If src is a directory, copy
                         # entire contents to dst dir
                         elif os.path.isdir(src):

--- a/Singularity
+++ b/Singularity
@@ -1,4 +1,5 @@
 Bootstrap: docker
+From: fcpindi/c-pac
 IncludeCmd: yes
 
 %environment


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Builds on #1313 by @shnizzedy
Fixes #1260 by @HechengJin0 

## Description
`CPAC.utils.interfaces.datasink.DataSink._list_outputs` uses `nipype.utils.filemanip.copyfile` which in turn uses [`shutil.copyfile`](https://docs.python.org/3/library/shutil.html#shutil.copyfile):

> If src and dst specify the same file, [SameFileError](https://docs.python.org/3/library/shutil.html#shutil.SameFileError) is raised.

#1313 resolves for matching paths. This PR resolves for matching contents.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Additional information
Also includes c9fd9ad to resolve a merge error from #1311

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>