### PR TITLE
🚑 Fix CSV has x-1 time points, but dataset has x values

### DIFF
--- a/CPAC/timeseries/timeseries_analysis.py
+++ b/CPAC/timeseries/timeseries_analysis.py
@@ -95,6 +95,18 @@ def clean_roi_csv(roi_csv):
     If there are no file path comments to remove, this function simply
     passes the original file as output, instead of unnecessarily opening and
     re-writing it.
+
+    Parameters
+    ----------
+    roi_csv: str
+        path to CSV
+
+    Returns
+    -------
+    roi_array: numpy.ndarray
+
+    edited_roi_csv: str
+        path to CSV
     """
     import os
     import pandas as pd
@@ -132,7 +144,7 @@ def clean_roi_csv(roi_csv):
     else:
         edited_roi_csv = [roi_csv]
 
-    data = pd.read_csv(edited_roi_csv[0], sep=',', header=0)
+    data = pd.read_csv(edited_roi_csv[0], sep=',', header=1)
     data = data.dropna(axis=1)
     roi_array = np.transpose(data.values)
 

--- a/CPAC/timeseries/timeseries_analysis.py
+++ b/CPAC/timeseries/timeseries_analysis.py
@@ -96,9 +96,6 @@ def clean_roi_csv(roi_csv):
     passes the original file as output, instead of unnecessarily opening and
     re-writing it.
     """
-
-    import pandas as pd
-
     import os
     import pandas as pd
     import numpy as np
@@ -106,7 +103,14 @@ def clean_roi_csv(roi_csv):
     with open(roi_csv, 'r') as f:
         csv_lines = f.readlines()
 
+    # flag whether to re-write
     modified = False
+
+    # uncomment the header if commented:
+    if csv_lines[1].lstrip()[0] == '#':
+        csv_lines[1] = csv_lines[1].lstrip()[1:].lstrip()
+        modified = True
+
     edited_lines = []
     for line in csv_lines:
         line = line.replace('\t\t\t', '')
@@ -128,7 +132,7 @@ def clean_roi_csv(roi_csv):
     else:
         edited_roi_csv = [roi_csv]
 
-    data = pd.read_csv(edited_roi_csv[0], sep = ',', header = 1)
+    data = pd.read_csv(edited_roi_csv[0], sep=',', header=0)
     data = data.dropna(axis=1)
     roi_array = np.transpose(data.values)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1327 by @shnizzedy
Related to #770 by @sgiavasis, #1265 by @HechengJin0 & #1268 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
Checks the header row for a leading `#` and drops that character if it exists. Keeps
```CSV
#File,Sub-brick
```
as-is in the first line, so the comments + header changes from
```CSV
#File,Sub-brick
#Mean_1  ,Mean_2  ,Mean_3  ,Mean_4  ,Mean_5  ,Mean_6  ,Mean_7  ,Mean_8  ,Mean_9  ,Mean_10  ,Mean_11  ,Mean_12  ,Mean_13  ,Mean_14  ,Mean_15  ,Mean_16  ,Mean_17  ,Mean_18  ,Mean_19  ,Mean_21  ,Mean_22  ,Mean_23  ,Mean_24  ,Mean_25  ,Mean_26  ,Mean_27  ,Mean_28  ,Mean_29  ,Mean_30  ,Mean_31  ,Mean_32  ,Mean_33  ,Mean_34  ,Mean_35  ,Mean_36  ,Mean_37  ,Mean_38  ,Mean_39  ,Mean_40  ,Mean_41  ,Mean_42  ,Mean_43  ,Mean_44  ,Mean_45  ,Mean_46  ,Mean_47  ,Mean_48  ,Mean_49  ,Mean_50  ,Mean_51  ,Mean_52  ,Mean_53  ,Mean_54  ,Mean_55  ,Mean_56  ,Mean_57  ,Mean_58  ,Mean_59  ,Mean_60  ,Mean_61  ,Mean_62  ,Mean_63  ,Mean_65  ,Mean_66  ,Mean_67  ,Mean_68  ,Mean_69  ,Mean_70  ,Mean_71  ,Mean_72  ,Mean_73  ,Mean_74  ,Mean_75  ,Mean_76  ,Mean_77  ,Mean_78  ,Mean_79  ,Mean_80  ,Mean_81  ,Mean_82  ,Mean_83  ,Mean_84  ,Mean_85  ,Mean_86  ,Mean_87  ,Mean_88  ,Mean_89  ,Mean_90  ,Mean_91
```
to
```CSV
#File,Sub-brick
Mean_1  ,Mean_2  ,Mean_3  ,Mean_4  ,Mean_5  ,Mean_6  ,Mean_7  ,Mean_8  ,Mean_9  ,Mean_10  ,Mean_11  ,Mean_12  ,Mean_13  ,Mean_14  ,Mean_15  ,Mean_16  ,Mean_17  ,Mean_18  ,Mean_19  ,Mean_21  ,Mean_22  ,Mean_23  ,Mean_24  ,Mean_25  ,Mean_26  ,Mean_27  ,Mean_28  ,Mean_29  ,Mean_30  ,Mean_31  ,Mean_32  ,Mean_33  ,Mean_34  ,Mean_35  ,Mean_36  ,Mean_37  ,Mean_38  ,Mean_39  ,Mean_40  ,Mean_41  ,Mean_42  ,Mean_43  ,Mean_44  ,Mean_45  ,Mean_46  ,Mean_47  ,Mean_48  ,Mean_49  ,Mean_50  ,Mean_51  ,Mean_52  ,Mean_53  ,Mean_54  ,Mean_55  ,Mean_56  ,Mean_57  ,Mean_58  ,Mean_59  ,Mean_60  ,Mean_61  ,Mean_62  ,Mean_63  ,Mean_65  ,Mean_66  ,Mean_67  ,Mean_68  ,Mean_69  ,Mean_70  ,Mean_71  ,Mean_72  ,Mean_73  ,Mean_74  ,Mean_75  ,Mean_76  ,Mean_77  ,Mean_78  ,Mean_79  ,Mean_80  ,Mean_81  ,Mean_82  ,Mean_83  ,Mean_84  ,Mean_85  ,Mean_86  ,Mean_87  ,Mean_88  ,Mean_89  ,Mean_90  ,Mean_91
```
## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Also expand the docstring a bit and minor linting.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
I'm rerunning the test that failed, leading to #1327 with this change in place

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors. ← :construction: in progress

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>