### PR TITLE
More robust ROI label parsing for multiple regression.

### DIFF
--- a/CPAC/sca/utils.py
+++ b/CPAC/sca/utils.py
@@ -85,7 +85,7 @@ def check_ts(in_file):
             csv_array = csv_array[1:]
         timepoints, rois = csv_array.shape
         # multiple regression (fsl_glm) needs this format for -design input
-        out_file = os.path.join(os.getcwd(),
+        out_file = os.path.join(os.getcwd(), 
                                 os.path.basename(in_file).replace('.csv', '.txt'))
         np.savetxt(out_file, csv_array, delimiter='\t')
     if rois > timepoints:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1357 by @sgiavasis 

## Description
This resolves the temporal_regression crashes caused when certain extracted time series CSVs are parsed by this line:
https://github.com/FCP-INDI/C-PAC/blob/5d712c678278985844be27c372047a15733e3c94/CPAC/sca/utils.py#L134

## Technical details
Pandas has been introduced to more cleanly manage the extracted time series CSVs.

## Tests
Just make sure a full pipeline run with multiple regression enabled doesn't result in  `temporal_regression_sca_0.split_raw_volumes` crash files.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
