### PR TITLE
🐛 Fix indentation of code block

### DIFF
--- a/CPAC/distortion_correction/distortion_correction.py
+++ b/CPAC/distortion_correction/distortion_correction.py
@@ -548,19 +548,20 @@ def connect_distortion_correction(workflow, strat_list, c, diff, blip,
             workflow.connect(match_epi_fmaps_node, 'same_pe_epi',
                              blip_correct, 'inputspec.same_pe_epi')
 
-        if False in c.functional_preproc['distortion_correction']['run']:
-            strat = strat.fork()
-            new_strat_list.append(strat)
+            if False in c.functional_preproc['distortion_correction']['run']:
+                strat = strat.fork()
+                new_strat_list.append(strat)
 
-        strat.append_name(blip_correct.name)
+            strat.append_name(blip_correct.name)
 
-        strat.update_resource_pool({
-            'blip_warp': (blip_correct, 'outputspec.blip_warp'),
-            'blip_warp_inverse': (blip_correct,
-                                  'outputspec.blip_warp_inverse'),
-            'mean_functional': (blip_correct, 'outputspec.new_func_mean'),
-            'functional_brain_mask': (blip_correct, 'outputspec.new_func_mask')
-        }, override=True)
+            strat.update_resource_pool({
+                'blip_warp': (blip_correct, 'outputspec.blip_warp'),
+                'blip_warp_inverse': (blip_correct,
+                                      'outputspec.blip_warp_inverse'),
+                'mean_functional': (blip_correct, 'outputspec.new_func_mean'),
+                'functional_brain_mask': (blip_correct,
+                                          'outputspec.new_func_mask')
+            }, override=True)
 
     strat_list += new_strat_list
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes https://github.com/FCP-INDI/C-PAC/pull/1400#discussion_r523270119 by @shnizzedy
Related to #1366 by @sgiavasis

## Description
<!-- Concisely describe what the pull request does. -->
Indents https://github.com/FCP-INDI/C-PAC/blob/6fb4ac207f80df5e9a107fa56087d3919b221591/CPAC/distortion_correction/distortion_correction.py#L551-L563 one level to include in loop https://github.com/FCP-INDI/C-PAC/blob/6fb4ac207f80df5e9a107fa56087d3919b221591/CPAC/distortion_correction/distortion_correction.py#L494

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `enh/nested_config` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
