### PR TITLE
🩹 Handful of simple fixes to 1.8 upgrade issues

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1300,7 +1300,8 @@ def bold_mask_fsl_afni(wf, cfg, strat_pool, pipe_num, opt=None):
 
     node, out = strat_pool.get_data(["desc-motion_bold", "desc-preproc_bold",
                                      "bold"])
-    wf.connect(node, out, func_skull_mean, [('func', 'in_file')])
+
+    wf.connect(node, out, func_skull_mean, 'in_file')
 
     wf.connect([(func_skull_mean, skullstrip_first_pass,
                  [('out_file', 'in_file')]),

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1096,7 +1096,7 @@ def calc_motion_stats(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out_file,
                gen_motion_stats, 'inputspec.motion_correct')
 
-    node, out_file = strat_pool.get_data("space-bold_desc-brain_mask")
+    node, out_file = strat_pool.get_data('space-bold_desc-brain_mask')
     wf.connect(node, out_file,
                gen_motion_stats, 'inputspec.mask')
 

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -30,6 +30,8 @@ from CPAC.nuisance.utils.compcor import (
     cosine_filter,
     TR_string_to_float)
 
+from CPAC.seg_preproc.utils import erosion
+
 from CPAC.utils.datasource import check_for_s3
 from .bandpass import bandpass_voxels
 
@@ -1851,11 +1853,11 @@ def erode_mask_WM(wf, cfg, strat_pool, pipe_num, opt=None):
         '2-nuisance_regression']['regressor_masks']['erode_wm'][
         'wm_erosion_prop']
 
-    node, out = strat_pool.get_data('label-WM_desc-brain_mask')
+    node, out = strat_pool.get_data('label-WM_mask')
     wf.connect(node, out, erode, 'inputspec.mask')
 
     outputs = {
-        'label-CSF_desc-eroded_mask': (erode, 'outputspec.eroded_mask')
+        'label-WM_desc-eroded_mask': (erode, 'outputspec.eroded_mask')
     }
 
     return (wf, outputs)

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1036,15 +1036,20 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     # Connect the entire pipeline!
     for block in pipeline_blocks:
         try:
-            wf = NodeBlock(block).connect_block(wf, cfg, rpool)
+            nb = NodeBlock(block)
+            wf = nb.connect_block(wf, cfg, rpool)
         except LookupError as e:
+            previous_nb_str = (
+                f"after node block '{previous_nb.get_name()}':"
+            ) if previous_nb else 'at beginning:'
             # Alert user to block that raises error
             e.args = (
                 'When trying to connect node block '
                 f"'{NodeBlock(block).get_name()}' "
-                f"to workflow '{wf}':" + e.args[0],
+                f"to workflow '{wf}' " + previous_nb_str + e.args[0],
             )
             raise
+        previous_nb = nb
 
     # Write out the data
     # TODO enforce value with schema validation

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1035,7 +1035,16 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
 
     # Connect the entire pipeline!
     for block in pipeline_blocks:
-        wf = NodeBlock(block).connect_block(wf, cfg, rpool)
+        try:
+            wf = NodeBlock(block).connect_block(wf, cfg, rpool)
+        except LookupError as e:
+            # Alert user to block that raises error
+            e.args = (
+                'When trying to connect node block '
+                f"'{NodeBlock(block).get_name()}' "
+                f"to workflow '{wf}':" + e.args[0],
+            )
+            raise
 
     # Write out the data
     # TODO enforce value with schema validation

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -1169,6 +1169,8 @@ def wrap_block(node_blocks, interface, wf, cfg, strat_pool, pipe_num, opt):
 
 
 def ingress_raw_data(wf, rpool, cfg, data_paths, unique_id, part_id, ses_id):
+    if 'creds_path' not in data_paths:
+        data_paths['creds_path'] = None
 
     anat_flow = create_anat_datasource(f'anat_gather_{part_id}_{ses_id}')
     anat_flow.inputs.inputnode.set(
@@ -1341,6 +1343,8 @@ def initiate_rpool(wf, cfg, data_paths):
 
     part_id = data_paths['subject_id']
     ses_id = data_paths['unique_id']
+    if 'creds_path' not in data_paths:
+        data_paths['creds_path'] = None
 
     unique_id = f'{part_id}_{ses_id}'
 

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -216,12 +216,12 @@ class ResourcePool(object):
                     if report_fetched:
                         return (None, None)
                     return None
-                raise Exception("\n\n[!] C-PAC says: The listed resource is "
-                                f"not in the resource pool:\n{resource}\n\n"
-                                "Developer Note: This may be due to a mis"
-                                "match between the node block's docstring "
-                                "'input' field and a strat_pool.get_data() "
-                                "call within the block function.\n")
+                raise LookupError("\n\n[!] C-PAC says: The listed resource is "
+                                  f"not in the resource pool:\n{resource}\n\n"
+                                  "Developer Note: This may be due to a mis"
+                                  "match between the node block's docstring "
+                                  "'input' field and a strat_pool.get_data() "
+                                  "call within the block function.\n")
             if report_fetched:
                 if pipe_idx:
                     return (self.rpool[resource][pipe_idx], resource)

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -533,7 +533,7 @@ schema = Schema({
         },
         '2-nuisance_regression': {
             'run': forkable,
-            'Regressors': [{
+            'Regressors': Maybe([{
                 Required('Name'): str,
                 'Censor': {
                     'method': str,
@@ -589,7 +589,7 @@ schema = Schema({
                     'top_frequency': float,
                     'method': str,
                 }  # how to check if [0] is > than [1]?
-            }],
+            }]),
             'lateral_ventricles_mask': Maybe(str),
             'bandpass_filtering_order': Maybe(
                 In({'After', 'Before'})),

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -533,8 +533,8 @@ schema = Schema({
         },
         '2-nuisance_regression': {
             'run': forkable,
-            'Regressors': Maybe([{
-                'Name': str,
+            'Regressors': [{
+                Required('Name'): str,
                 'Censor': {
                     'method': str,
                     'thresholds': [{
@@ -589,7 +589,7 @@ schema = Schema({
                     'top_frequency': float,
                     'method': str,
                 }  # how to check if [0] is > than [1]?
-            }]),
+            }],
             'lateral_ventricles_mask': Maybe(str),
             'bandpass_filtering_order': Maybe(
                 In({'After', 'Before'})),

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -645,8 +645,7 @@ schema = Schema({
         'spatial_smoothing': {
             'output': [In({'smoothed', 'nonsmoothed'})],
             'smoothing_method': [In({'FSL', 'AFNI'})],
-            'fwhm': [int],
-            'smoothing_order': In({'Before', 'After'})
+            'fwhm': [int]
         },
         'z-scoring': {
             'output': [In({'z-scored', 'raw'})],

--- a/CPAC/resources/configs/1.7-1.8-deprecations.yml
+++ b/CPAC/resources/configs/1.7-1.8-deprecations.yml
@@ -20,3 +20,4 @@
 - runFristonModel
 - runMotionSpike
 - spikeThreshold
+- smoothing_order

--- a/CPAC/resources/configs/1.7-1.8-nesting-mappings.yml
+++ b/CPAC/resources/configs/1.7-1.8-nesting-mappings.yml
@@ -1041,10 +1041,6 @@ fwhm:
    - post_processing
    - spatial_smoothing
    - fwhm
-smoothing_order:
-   - post_processing
-   - spatial_smoothing
-   - smoothing_order
 runZScoring:
    - post_processing
    - z-scoring

--- a/CPAC/resources/configs/pipeline_config_anat-only.yml
+++ b/CPAC/resources/configs/pipeline_config_anat-only.yml
@@ -196,12 +196,6 @@ nuisance_corrections:
     # used in CSF mask refinement for CSF signal-related regressions
     lateral_ventricles_mask: $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
 
-# OUTPUTS AND DERIVATIVES
-# -----------------------
-post_processing: 
-
-  spatial_smoothing: 
-
 timeseries_extraction: 
 
   run: [Off]

--- a/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
@@ -155,6 +155,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         aCompCor:
@@ -175,6 +176,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: true
+        Name: Regressor-2
         aCompCor:
           extraction_resolution: 2
           summary:
@@ -193,6 +195,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-3
 
 # OUTPUTS AND DERIVATIVES
 # -----------------------

--- a/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
@@ -175,6 +175,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         aCompCor:
@@ -195,6 +196,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: true
+        Name: Regressor-2
         aCompCor:
           extraction_resolution: 2
           summary:
@@ -213,6 +215,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-3
 
 # OUTPUTS AND DERIVATIVES
 # -----------------------

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -314,6 +314,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -303,18 +303,13 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
           summary:
             components: 5
             method: PC
-
-# OUTPUTS AND DERIVATIVES
-# -----------------------
-post_processing: 
-
-  spatial_smoothing: 
 
 timeseries_extraction: 
 

--- a/CPAC/resources/configs/pipeline_config_ndmg.yml
+++ b/CPAC/resources/configs/pipeline_config_ndmg.yml
@@ -132,6 +132,7 @@ nuisance_corrections:
         CerebrospinalFluid:
           extraction_resolution: 2
           summary: Mean
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         aCompCor:
@@ -142,12 +143,6 @@ nuisance_corrections:
           tissues:
           - WhiteMatter
           - CerebrospinalFluid
-
-# OUTPUTS AND DERIVATIVES
-# -----------------------
-post_processing: 
-
-  spatial_smoothing: 
 
 timeseries_extraction: 
 

--- a/CPAC/resources/configs/pipeline_config_nhp-macaque.yml
+++ b/CPAC/resources/configs/pipeline_config_nhp-macaque.yml
@@ -303,18 +303,13 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
           summary:
             components: 5
             method: PC
-
-# OUTPUTS AND DERIVATIVES
-# -----------------------
-post_processing: 
-
-  spatial_smoothing: 
 
 timeseries_extraction: 
 

--- a/CPAC/resources/configs/pipeline_config_preproc.yml
+++ b/CPAC/resources/configs/pipeline_config_preproc.yml
@@ -154,6 +154,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         aCompCor:
@@ -175,6 +176,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         aCompCor:
@@ -189,12 +191,6 @@ nuisance_corrections:
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions
     lateral_ventricles_mask: $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
-
-# OUTPUTS AND DERIVATIVES
-# -----------------------
-post_processing: 
-
-  spatial_smoothing: 
 
 timeseries_extraction: 
 

--- a/CPAC/resources/configs/pipeline_config_regtest-1.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-1.yml
@@ -151,6 +151,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         aCompCor:
@@ -171,6 +172,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: true
+        Name: Regressor-2
         aCompCor:
           extraction_resolution: 2
           summary:
@@ -189,6 +191,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-3
 
 # OUTPUTS AND DERIVATIVES
 # -----------------------

--- a/CPAC/resources/configs/pipeline_config_regtest-2.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-2.yml
@@ -173,6 +173,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         aCompCor:
@@ -193,6 +194,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: true
+        Name: Regressor-2
         aCompCor:
           extraction_resolution: 2
           summary:
@@ -211,6 +213,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-3
 
 # OUTPUTS AND DERIVATIVES
 # -----------------------

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -201,6 +201,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         aCompCor:
@@ -221,6 +222,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: true
+        Name: Regressor-2
         aCompCor:
           extraction_resolution: 2
           summary:
@@ -239,6 +241,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-3
 
     # Whether to run frequency filtering before or after nuisance regression.
     # Options: 'After' or 'Before'

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -220,6 +220,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         aCompCor:
@@ -240,6 +241,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: true
+        Name: Regressor-2
         aCompCor:
           extraction_resolution: 2
           summary:
@@ -258,6 +260,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-3
 
 # OUTPUTS AND DERIVATIVES
 # -----------------------

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -322,6 +322,7 @@ nuisance_corrections:
           include_delayed: false
           include_delayed_squared: false
           include_squared: false
+        Name: Regressor-1
 
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions

--- a/CPAC/resources/configs/test_configs/pipe-test_ABCD.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_ABCD.yml
@@ -274,6 +274,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
 
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions

--- a/CPAC/resources/configs/test_configs/pipe-test_ANTs-3dSk-AllNuis.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_ANTs-3dSk-AllNuis.yml
@@ -173,6 +173,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -211,6 +212,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -249,6 +251,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_ANTs-3dSk-DistCorr3dSk.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_ANTs-3dSk-DistCorr3dSk.yml
@@ -188,6 +188,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -226,6 +227,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -264,6 +266,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_ANTs-3dSk-DistCorrBET.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_ANTs-3dSk-DistCorrBET.yml
@@ -179,6 +179,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -217,6 +218,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -255,6 +257,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_ANTs-BET-AllNuis.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_ANTs-BET-AllNuis.yml
@@ -187,6 +187,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -225,6 +226,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -263,6 +265,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_FNIRT-3dSk-AllNuis.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_FNIRT-3dSk-AllNuis.yml
@@ -178,6 +178,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -216,6 +217,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -254,6 +256,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-BASC.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-BASC.yml
@@ -192,6 +192,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -230,6 +231,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -268,6 +270,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-ISC-voxel.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-ISC-voxel.yml
@@ -192,6 +192,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -230,6 +231,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -268,6 +270,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-ISC.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-ISC.yml
@@ -192,6 +192,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -230,6 +231,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -268,6 +270,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-MDMR.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis-MDMR.yml
@@ -192,6 +192,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -230,6 +231,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -268,6 +270,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_FNIRT-BET-AllNuis.yml
@@ -192,6 +192,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -230,6 +231,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 2
         WhiteMatter:
@@ -268,6 +270,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 2
         WhiteMatter:

--- a/CPAC/resources/configs/test_configs/pipe-test_all.yml
+++ b/CPAC/resources/configs/test_configs/pipe-test_all.yml
@@ -178,6 +178,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-1
         PolyOrt:
           degree: 1
         WhiteMatter:
@@ -216,6 +217,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-2
         PolyOrt:
           degree: 1
         WhiteMatter:
@@ -254,6 +256,7 @@ nuisance_corrections:
           include_delayed: true
           include_delayed_squared: true
           include_squared: true
+        Name: Regressor-3
         PolyOrt:
           degree: 1
         WhiteMatter:

--- a/CPAC/utils/configuration.py
+++ b/CPAC/utils/configuration.py
@@ -79,17 +79,18 @@ class Configuration(object):
             config_map = {}
 
         base_config = config_map.get('FROM', 'default_pipeline')
-        # base on default pipeline if FROM not specified or specified 'default'
-        if base_config in ['default', 'default_pipeline']:
-            config_map = update_nested_dict(default_config, config_map)
-        # base on another config (specified with 'FROM' key)
-        else:
+
+        # import another config (specified with 'FROM' key)
+        if base_config not in ['default', 'default_pipeline']:
             try:
                 base_config = load_preconfig(base_config)
             except OptionError:
                 base_config = base_config
             from_config = yaml.safe_load(open(base_config, 'r'))
             config_map = update_nested_dict(from_config, config_map)
+
+        # base everything on default pipeline
+        config_map = update_nested_dict(default_config, config_map)
 
         for i, regressor in enumerate(lookup_nested_value(
             config_map,

--- a/CPAC/utils/configuration.py
+++ b/CPAC/utils/configuration.py
@@ -92,17 +92,21 @@ class Configuration(object):
         # base everything on default pipeline
         config_map = update_nested_dict(default_config, config_map)
 
-        for i, regressor in enumerate(lookup_nested_value(
+        config_map = self.nonestr_to_None(config_map)
+
+        regressors = lookup_nested_value(
             config_map,
             ['nuisance_corrections', '2-nuisance_regression', 'Regressors']
-        )):
-            # set Regressor 'Name's if not provided
-            if 'Name' not in regressor:
-                regressor['Name'] = f'Regressor-{str(i + 1)}'
-            # replace spaces with hyphens in Regressor 'Name's
-            regressor['Name'] = regressor['Name'].replace(' ', '-')
+        )
+        if isinstance(regressors, list):
+            for i, regressor in enumerate(regressors):
+                # set Regressor 'Name's if not provided
+                if 'Name' not in regressor:
+                    regressor['Name'] = f'Regressor-{str(i + 1)}'
+                # replace spaces with hyphens in Regressor 'Name's
+                regressor['Name'] = regressor['Name'].replace(' ', '-')
 
-        config_map = schema(self.nonestr_to_None(config_map))
+        config_map = schema(config_map)
 
         # remove 'FROM' before setting attributes now that it's imported
         if 'FROM' in config_map:

--- a/CPAC/utils/configuration.py
+++ b/CPAC/utils/configuration.py
@@ -71,7 +71,8 @@ class Configuration(object):
     """
     def __init__(self, config_map=None):
         from CPAC.pipeline.schema import schema
-        from CPAC.utils.utils import load_preconfig, update_nested_dict
+        from CPAC.utils.utils import load_preconfig, lookup_nested_value, \
+            update_nested_dict
         from optparse import OptionError
 
         if config_map is None:
@@ -89,6 +90,15 @@ class Configuration(object):
                 base_config = base_config
             from_config = yaml.safe_load(open(base_config, 'r'))
             config_map = update_nested_dict(from_config, config_map)
+
+        for i, regressor in enumerate(lookup_nested_value(
+            config_map,
+            ['nuisance_corrections', '2-nuisance_regression', 'Regressors']
+        )):
+            # set Regressor 'Name's if not provided
+            if 'Name' not in regressor:
+                regressor['Name'] = f'Regressor {str(i + 1)}'
+
         config_map = schema(self.nonestr_to_None(config_map))
 
         # remove 'FROM' before setting attributes now that it's imported
@@ -104,6 +114,7 @@ class Configuration(object):
         for key in config_map:
             # set attribute
             setattr(self, key, set_from_ENV(config_map[key]))
+
         self.__update_attr()
 
     def __str__(self):

--- a/CPAC/utils/configuration.py
+++ b/CPAC/utils/configuration.py
@@ -97,7 +97,9 @@ class Configuration(object):
         )):
             # set Regressor 'Name's if not provided
             if 'Name' not in regressor:
-                regressor['Name'] = f'Regressor {str(i + 1)}'
+                regressor['Name'] = f'Regressor-{str(i + 1)}'
+            # replace spaces with hyphens in Regressor 'Name's
+            regressor['Name'] = regressor['Name'].replace(' ', '-')
 
         config_map = schema(self.nonestr_to_None(config_map))
 

--- a/CPAC/utils/datasource.py
+++ b/CPAC/utils/datasource.py
@@ -384,7 +384,7 @@ def ingress_func_metadata(wf, cfg, rpool, sub_dict, subject_id,
     if "fmap" in sub_dict:
         for key in sub_dict["fmap"]:
             gather_fmap = create_fmap_datasource(sub_dict["fmap"],
-                                                 f"fmap_gather_{part_id}")
+                                                 f"fmap_gather_{subject_id}")
             gather_fmap.inputs.inputnode.set(
                 subject=subject_id,
                 creds_path=input_creds_path,

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -1583,7 +1583,10 @@ def dct_diff(dct1, dct2):
     for key in dct1:
         if isinstance(dct1[key], dict):
             if not isinstance(dct2, dict):
-                raise Exception(dct2)
+                try:
+                    dct2 = dct2.dict()
+                except AttributeError:
+                    raise TypeError(f'{dct2} is not a dict.')
             diff[key] = dct_diff(dct1[key], dct2.get(key, {}))
         else:
             dct1_val = dct1.get(key)

--- a/CPAC/utils/yaml_template.py
+++ b/CPAC/utils/yaml_template.py
@@ -329,9 +329,11 @@ def upgrade_pipeline_to_1_8(path):
     # upgrade and overwrite
     orig_dict = yaml.safe_load(original)
     # set Regressor 'Name's if not provided
-    for i, regressor in enumerate(orig_dict.get('Regressors', [])):
-        if 'Name' not in regressor:
-            regressor['Name'] = f'Regressor-{str(i + 1)}'
+    regressors = orig_dict.get('Regressors')
+    if isinstance(regressors, list):
+        for i, regressor in enumerate(regressors):
+            if 'Name' not in regressor:
+                regressor['Name'] = f'Regressor-{str(i + 1)}'
     if 'pipelineName' in orig_dict and len(original.strip()):
         middle_dict, leftovers_dict, complete_dict = update_config_dict(
             orig_dict)

--- a/CPAC/utils/yaml_template.py
+++ b/CPAC/utils/yaml_template.py
@@ -328,6 +328,10 @@ def upgrade_pipeline_to_1_8(path):
     open(backup, 'w').write(original)
     # upgrade and overwrite
     orig_dict = yaml.safe_load(original)
+    # set Regressor 'Name's if not provided
+    for i, regressor in enumerate(orig_dict.get('Regressors', [])):
+        if 'Name' not in regressor:
+            regressor['Name'] = f'Regressor-{str(i + 1)}'
     if 'pipelineName' in orig_dict and len(original.strip()):
         middle_dict, leftovers_dict, complete_dict = update_config_dict(
             orig_dict)

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -471,7 +471,7 @@ elif args.analysis_level in ["test_config", "participant"]:
         upgrade_pipeline_to_1_8(updated_config)
         c = load_yaml_config(updated_config, args.aws_input_creds)
 
-    c = Configuration(c).dict()
+    c = Configuration(c)
 
     overrides = {}
     if args.pipeline_override:


### PR DESCRIPTION
I can break this up into mutliple PRs if we want the history to reflect each fix separately.

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
1. Resolves crash if `creds_path` is not set
2. ```Python
   Traceback (most recent call last):
     File "/code/run.py", line 644, in <module>
       test_config = 1 if args.analysis_level == "test_config" else 0
     File "/code/CPAC/pipeline/cpac_runner.py", line 521, in run
       p_name, plugin, plugin_args, test_config)
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 406, in run_workflow
       subject_id, sub_dict, c, p_name, num_ants_cores
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 1026, in build_workflow
       wf = NodeBlock(block).connect_block(wf, cfg, rpool)
     File "/code/CPAC/pipeline/engine.py", line 1004, in connect_block
       pipe_x, opt)
     File "/code/CPAC/func_preproc/func_preproc.py", line 1303, in bold_mask_fsl_afni
       wf.connect(node, out, func_skull_mean, [('func', 'in_file')])
     File "/usr/local/miniconda/lib/python3.7/site-packages/nipype/pipeline/engine/workflows.py", line 199, in connect
       if not destnode._check_inputs(dest):
     File "/usr/local/miniconda/lib/python3.7/site-packages/nipype/pipeline/engine/base.py", line 104, in _check_inputs
       return hasattr(self.inputs, parameter)
   TypeError: hasattr(): attribute name must be string
   ```
3. ```Python
   Traceback (most recent call last):
     File "/code/run.py", line 662, in <module>
       test_config = 1 if args.analysis_level == "test_config" else 0
     File "/code/CPAC/pipeline/cpac_runner.py", line 521, in run
       p_name, plugin, plugin_args, test_config)
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 407, in run_workflow
       subject_id, sub_dict, c, p_name, num_ants_cores
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 1038, in build_workflow
       wf = NodeBlock(block).connect_block(wf, cfg, rpool)
     File "/code/CPAC/pipeline/engine.py", line 1015, in connect_block
       pipe_x, opt)
     File "/code/CPAC/nuisance/nuisance.py", line 1758, in erode_mask_T1w
       erode = erode_mask(f'erode_T1w_mask_{pipe_num}')
     File "/code/CPAC/nuisance/nuisance.py", line 64, in erode_mask
       function=erosion,
   NameError: name 'erosion' is not defined
   ```
4. ```Python
   Traceback (most recent call last):
     File "/code/run.py", line 662, in <module>
       test_config = 1 if args.analysis_level == "test_config" else 0
     File "/code/CPAC/pipeline/cpac_runner.py", line 521, in run
       p_name, plugin, plugin_args, test_config)
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 407, in run_workflow
       subject_id, sub_dict, c, p_name, num_ants_cores
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 1038, in build_workflow
       wf = NodeBlock(block).connect_block(wf, cfg, rpool)
     File "/code/CPAC/pipeline/engine.py", line 1015, in connect_block
       pipe_x, opt)
     File "/code/CPAC/nuisance/nuisance.py", line 1856, in erode_mask_WM
       node, out = strat_pool.get_data('label-WM_desc-brain_mask')
     File "/code/CPAC/pipeline/engine.py", line 248, in get_data
       return self.get(resource)['data']
     File "/code/CPAC/pipeline/engine.py", line 219, in get
       raise Exception("
   
   [!] C-PAC says: The listed resource is "
   Exception: 
   [!] C-PAC says: The listed resource is not in the resource pool:
   label-WM_desc-brain_mask
   Developer Note: This may be due to a mismatch between the node block's docstring 'input' field and a strat_pool.get_data() call within the block function.
   ```
5. ```Python
   Traceback (most recent call last):
     File "/code/run.py", line 662, in <module>
       test_config = 1 if args.analysis_level == "test_config" else 0
     File "/code/CPAC/pipeline/cpac_runner.py", line 521, in run
       p_name, plugin, plugin_args, test_config)
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 407, in run_workflow
       subject_id, sub_dict, c, p_name, num_ants_cores
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 1038, in build_workflow
       wf = NodeBlock(block).connect_block(wf, cfg, rpool)
     File "/code/CPAC/pipeline/engine.py", line 1015, in connect_block
       pipe_x, opt)
     File "/code/CPAC/nuisance/nuisance.py", line 2108, in nuisance_regression_complete
       name='nuisance_regressors_'
   KeyError: 'Name'
   ```
6. https://github.com/FCP-INDI/C-PAC/commit/84c21553cec2f54ec0a89549b57472d68e0406e3#diff-0fb1a4b689e02f659d52894fd4c22de53737af73444f5544b755a461f663a1abL1059-L1062
7. `[!] C-PAC says: The listed resource is not in the resource pool:` doesn't tell what node block is looking for the listed resource.
8. When basing a pipeline on another pipeline (other than default), any default keys not included in the FROM pipeline were not included in the combined pipeline.
9. ```Python
   Traceback (most recent call last):
     File "/code/dev/docker_data/run.py", line 654, in <module>
       test_config = 1 if args.analysis_level == "test_config" else 0
     File "/home/circleci/project/CPAC/pipeline/cpac_runner.py", line 537, in run
       p_name, plugin, plugin_args, test_config)
     File "/home/circleci/project/CPAC/pipeline/cpac_pipeline.py", line 407, in run_workflow
       subject_id, sub_dict, c, p_name, num_ants_cores
     File "/home/circleci/project/CPAC/pipeline/cpac_pipeline.py", line 775, in build_workflow
       wf, rpool = initiate_rpool(wf, cfg, sub_dict)
     File "/home/circleci/project/CPAC/pipeline/engine.py", line 1356, in initiate_rpool
       part_id, ses_id)
     File "/home/circleci/project/CPAC/pipeline/engine.py", line 1207, in ingress_raw_data
       data_paths['creds_path'])
     File "/home/circleci/project/CPAC/utils/datasource.py", line 387, in ingress_func_metadata
       f"fmap_gather_{part_id}")
   NameError: name 'part_id' is not defined
   ```

## Description
<!-- Concisely describe what the pull request does. -->
1. Set `creds_path` to `None` if not set
2. https://github.com/FCP-INDI/C-PAC/commit/5cf70efc86d550cc0e629fe7147701fbead37e55: change https://github.com/FCP-INDI/C-PAC/blob/d1d0a955444989964aab98d8b819e1e0c876000f/CPAC/func_preproc/func_preproc.py#L1303 to https://github.com/FCP-INDI/C-PAC/blob/5cf70efc86d550cc0e629fe7147701fbead37e55/CPAC/func_preproc/func_preproc.py#L1304
3. https://github.com/FCP-INDI/C-PAC/blob/26fc89d6bfbd548b2acfc45b0680f6d85b9ce609/CPAC/nuisance/nuisance.py#L33
4. Change https://github.com/FCP-INDI/C-PAC/blob/5cf70efc86d550cc0e629fe7147701fbead37e55/CPAC/nuisance/nuisance.py#L1854-L1859 to https://github.com/FCP-INDI/C-PAC/blob/26fc89d6bfbd548b2acfc45b0680f6d85b9ce609/CPAC/nuisance/nuisance.py#L1856-L1861
5. Make 'Name' required in `schema.py`: https://github.com/FCP-INDI/C-PAC/blob/439e37fa8c7585dd815ef2e83ea87609679340a2/CPAC/pipeline/schema.py#L536-L537; https://github.com/FCP-INDI/C-PAC/commit/aa28fc6bfcd4ecc956d87482bea5c2e23be29499: set Regressor `"Name"`s to "Regressor {#}" if not provided (both when upgrading a pipeline config from 1.7 to 1.8 and at runtime)
6. Deprecated `smoothing_order` pipeline config key
7. Adds 
   > When trying to connect node block '{name}' to workflow '{name}' {after node block '{name}' | at beginning}:
   
   to top of error message when connecting the entire pipeline: https://github.com/FCP-INDI/C-PAC/blob/81ddd3331af8944677682cf24f09395f11f6864d/CPAC/pipeline/cpac_pipeline.py#L1041-L1051
8. Update in 2 steps: 1. Update FROM config with custom configuration 2. Update default config with that combined config: https://github.com/FCP-INDI/C-PAC/blob/1d0283155d11146775ad0c3713b43c446dc827f6/CPAC/utils/configuration.py#L83-L93
9. https://github.com/FCP-INDI/C-PAC/commit/fb77180a6167f67baebefdc26e14a46a146f7df0: change https://github.com/FCP-INDI/C-PAC/blob/e803abc7e0793c1187be60f22121e38860442662/CPAC/utils/datasource.py#L387 to https://github.com/FCP-INDI/C-PAC/blob/fb77180a6167f67baebefdc26e14a46a146f7df0/CPAC/utils/datasource.py#L387

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
