### PR TITLE
📝 Clarify valid `motion_estimate_filter` settings

### DIFF
--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -436,7 +436,7 @@ schema = Schema({
                 'motion_correction_reference_volume': int,
             },
             'motion_estimate_filter': Required(
-                Any({
+                Any({  # no motion estimate filter
                     'run': Maybe(Any([False], False)),
                     'filter_type': Maybe(In({'notch', 'lowpass'})),
                     'filter_order': Maybe(int),
@@ -445,16 +445,16 @@ schema = Schema({
                     'center_frequency': Maybe(Number),
                     'filter_bandwidth': Maybe(Number),
                     'lowpass_cutoff': Maybe(Number),
-                }, {
+                }, {  # notch filter with breathing_rate_* set
                     'run': forkable,
                     'filter_type': 'notch',
                     'filter_order': int,
                     'breathing_rate_min': Number,
                     'breathing_rate_max': Number,
-                    'center_frequency': None,
-                    'filter_bandwidth': None,
+                    'center_frequency': Maybe(Number),
+                    'filter_bandwidth': Maybe(Number),
                     'lowpass_cutoff': Maybe(Number),
-                }, {
+                }, {  # notch filter with manual parameters set
                     'run': forkable,
                     'filter_type': 'notch',
                     'filter_order': int,
@@ -463,7 +463,7 @@ schema = Schema({
                     'center_frequency': Number,
                     'filter_bandwidth': Number,
                     'lowpass_cutoff': Maybe(Number),
-                }, {
+                }, {  # lowpass filter with breathing_rate_min
                     'run': forkable,
                     'filter_type': 'lowpass',
                     'filter_order': int,
@@ -471,8 +471,8 @@ schema = Schema({
                     'breathing_rate_max': Maybe(Number),
                     'center_frequency': Maybe(Number),
                     'filter_bandwidth': Maybe(Number),
-                    'lowpass_cutoff': None,
-                }, {
+                    'lowpass_cutoff': Maybe(Number),
+                }, {  # lowpass filter with lowpass_cutoff
                     'run': forkable,
                     'filter_type': 'lowpass',
                     'filter_order': int,
@@ -480,10 +480,9 @@ schema = Schema({
                     'breathing_rate_max': Maybe(Number),
                     'center_frequency': Maybe(Number),
                     'filter_bandwidth': Maybe(Number),
-                    'lowpass_cutoff': Maybe(Number),
+                    'lowpass_cutoff': Number,
                 },),
-                msg='Some mutually exclusive filter options are ambiguous in '
-                    'this pipeline configuration'
+                msg='motion_estimate_filter configuration is invalid.'
             ),
         },
         'distortion_correction': {

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -888,19 +888,34 @@ functional_preproc:
       # Number of filter coefficients.
       filter_order: 4
 
-      # Dataset-wide respiratory rate data from breathing belt required.
-      # mutually exclusive with cutoff, center frequency, and bandwidth options further below
+      # Dataset-wide respiratory rate data from breathing belt.
+      # Notch filter requires either:
+      #     "breathing_rate_min" and "breathing_rate_max"
+      # or
+      #     "center_frequency" and "filter_bandwitdh".
+      # Lowpass filter requires either:
+      #     "breathing_rate_min"
+      # or
+      #     "lowpass_cutoff".
+      # If "breathing_rate_min" (for lowpass and notch filter)
+      # and "breathing_rate_max" (for notch filter) are set,
+      # the values set in "lowpass_cutoff" (for lowpass filter),
+      # "center_frequency" and "filter_bandwidth" (for notch filter)
+      # options are ignored.
 
       # Lowest Breaths-Per-Minute in dataset.
-      # Required for both notch and lowpass filters.
+      # For both notch and lowpass filters.
       breathing_rate_min:
 
       # Highest Breaths-Per-Minute in dataset.
-      # Required for the notch filter.
+      # For notch filter.
       breathing_rate_max:
 
       # notch filter direct customization parameters
-      # mutually exclusive with breathing_rate options above
+
+      # mutually exclusive with breathing_rate options above.
+      # If breathing_rate_min and breathing_rate_max are provided,
+      # the following parameters will be ignored.
 
       # the center frequency of the notch filter
       center_frequency:
@@ -908,8 +923,11 @@ functional_preproc:
       # the width of the notch filter
       filter_bandwidth:
 
-      # lowpass filter direct customization parameters
-      # mutually exclusive with breathing_rate options above
+      # lowpass filter direct customization parameter
+
+      # mutually exclusive with breathing_rate options above.
+      # If breathing_rate_min is provided, the following
+      # parameter will be ignored.
 
       # the frequency cutoff of the filter
       lowpass_cutoff:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1425 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->

* Updates, attempts to clarify, the comments in the default pipeline config based on https://github.com/FCP-INDI/C-PAC/discussions/1425#discussioncomment-339343.
* Updates the schema to allow parameters to be set but unused based on https://github.com/FCP-INDI/C-PAC/discussions/1425#discussioncomment-339483, so any of the rows in the following table are valid settings:

| run | filter_type | breathing_rate_min | breathing_rate_max | center_frequency | filter_bandwidth | lowpass_cutoff |
| --- | --- | --- | --- | --- | --- | --- | 
| **off** | doesn't matter | doesn't matter | doesn't matter | doesn't matter | doesn't matter | doesn't matter | 
| on | **notch** | **required** | **required** | doesn't matter | doesn't matter | doesn't matter |
| on | **notch** | **None** | **None** | **required** | **required** | doesn't matter |
| on | **lowpass** | **required** | doesn't matter | doesn't matter | doesn't matter | doesn't matter |
| on | **lowpass** | **None** | doesn't matter | doesn't matter | doesn't matter | **required** |  

Prior to this change, the schema validation would raise an error on load if both motion estimate filter design options were provided (the alternative listed in #1430: 
> We can also throw an error, but this may be too disruptive.

) 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
