### PR TITLE
🐛 Cast config dict to Configuration class *after* overrides

### DIFF
--- a/CPAC/utils/configuration.py
+++ b/CPAC/utils/configuration.py
@@ -30,6 +30,13 @@ with open(DEFAULT_PIPELINE_FILE, 'r') as dp_fp:
     default_config = yaml.safe_load(dp_fp)
 
 
+class ConfigurationDictUpdateConflation(SyntaxError):
+    def __init__(self):
+        self.msg = (
+            '`Configuration().update` requires a key and a value. '
+            'Perhaps you meant `Configuration().dict().update`?')
+
+
 class Configuration(object):
     """Class to set dictionary keys as map attributes.
 
@@ -91,7 +98,8 @@ class Configuration(object):
                 Configuration(from_config).dict(), config_map)
 
         # base everything on default pipeline
-        config_map = _enforce_forkability(update_nested_dict(default_config, config_map))
+        config_map = _enforce_forkability(
+            update_nested_dict(default_config, config_map))
 
         config_map = self.nonestr_to_None(config_map)
 
@@ -256,7 +264,9 @@ class Configuration(object):
 
     __update_attr = update_attr
 
-    def update(self, key, val):
+    def update(self, key, val=ConfigurationDictUpdateConflation):
+        if isinstance(key, dict):
+            raise ConfigurationDictUpdateConflation
         setattr(self, key, val)
 
     def get_nested(self, d, keys):

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -471,8 +471,6 @@ elif args.analysis_level in ["test_config", "participant"]:
         upgrade_pipeline_to_1_8(updated_config)
         c = load_yaml_config(updated_config, args.aws_input_creds)
 
-    c = Configuration(c)
-
     overrides = {}
     if args.pipeline_override:
         overrides = {k: v for d in args.pipeline_override for k, v in d.items()}
@@ -523,8 +521,10 @@ elif args.analysis_level in ["test_config", "participant"]:
             args.n_cpus
         ) // c['pipeline_setup']['system_config']['num_participants_at_once']
     c['pipeline_setup']['system_config']['num_ants_threads'] = min(
-        c['pipeline_setup']['system_config']['max_cores_per_participant'] , int(c['pipeline_setup']['system_config']['num_ants_threads'])
+        c['pipeline_setup']['system_config']['max_cores_per_participant'], int(c['pipeline_setup']['system_config']['num_ants_threads'])
     )
+
+    c = Configuration(c)
 
     c['disable_log'] = args.disable_file_logging
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes
```Python
Traceback (most recent call last):
  File "/code/run.py", line 479, in <module>
    c.update(overrides)
TypeError: update() missing 1 required positional argument: 'val'
```
by @hahaai 

## Description
<!-- Concisely describe what the pull request does. -->
Moves the line where we convert the config dictionary to a Configuration object to after the `update`s from pipeline overrides. Adds an exception for trying to call `dict`'s `.update` on a `Configuration`.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Configurations have their own `update` method that takes a key and a value, while a dict's `update` takes another dict. The error above occurred because the pipeline overrides were being passed as a dict update to `c` after `c` was already converted to a `Configuration`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
