### PR TITLE
🐛 Add `include_*` keys to `Regressors` in validation schema

### DIFF
--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1,5 +1,6 @@
 from itertools import chain, permutations
-from voluptuous import All, Any, In, Length, Match, Range, Required, Schema
+from voluptuous import All, ALLOW_EXTRA, Any, In, Length, Match, Range, \
+                       Required, Schema
 from voluptuous.validators import Maybe
 
 # 1 or more digits, optional decimal, 'e', optional '-', 1 or more digits
@@ -61,7 +62,7 @@ valid_options = {
                 str, {'components': int, 'method': str}
             ),
         },
-    },
+    }
 }
 mutex = {  # mutually exclusive booleans
     'FSL-BET': {
@@ -547,7 +548,7 @@ schema = Schema({
         },
         '2-nuisance_regression': {
             'run': forkable,
-            'Regressors': Maybe([{
+            'Regressors': Maybe([Schema({
                 Required('Name'): str,
                 'Censor': {
                     'method': str,
@@ -581,7 +582,7 @@ schema = Schema({
                     'top_frequency': float,
                     'method': str,
                 }  # how to check if [0] is > than [1]?
-            }]),
+            }, extra=ALLOW_EXTRA)]),
             'lateral_ventricles_mask': Maybe(str),
             'bandpass_filtering_order': Maybe(
                 In({'After', 'Before'})),

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -54,6 +54,9 @@ valid_options = {
             'extraction_resolution': Any(
                 int, float, All(str, Match(resolution_regex))
             ),
+            'include_delayed': bool,
+            'include_delayed_squared': bool,
+            'include_squared': bool,
             'summary': Any(
                 str, {'components': int, 'method': str}
             ),

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -37,6 +37,18 @@ valid_options = {
         'template': ['EPI_Template', 'T1_Template']
     },
     'Regressors': {
+        'CompCor': {
+            'degree': int,
+            'erode_mask_mm': bool,
+            'summary': {
+                'method': str,
+                'components': int,
+                'filter': str,
+            },
+            'threshold': str,
+            'tissues': [str],
+            'extraction_resolution': int
+        },
         'segmentation': {
             'erode_mask': bool,
             'extraction_resolution': Any(
@@ -548,30 +560,8 @@ schema = Schema({
                     'include_squared': bool,
                     'include_delayed_squared': bool
                 },
-                'aCompCor': {
-                    'degree': int,
-                    'erode_mask_mm': bool,
-                    'summary': {
-                        'method': str,
-                        'components': int,
-                        'filter': str,
-                    },
-                    'threshold': str,
-                    'tissues': [str],
-                    'extraction_resolution': int
-                },
-                'tCompCor': {
-                    'degree': int,
-                    'erode_mask_mm': bool,
-                    'summary': {
-                        'method': str,
-                        'components': int,
-                        'filter': str,
-                    },
-                    'threshold': str,
-                    'tissues': [str],
-                    'extraction_resolution': int
-                },
+                'aCompCor': valid_options['Regressors']['CompCor'],
+                'tCompCor': valid_options['Regressors']['CompCor'],
                 'CerebrospinalFluid': valid_options[
                     'Regressors'
                 ]['segmentation'],


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes 
```Python
Traceback (most recent call last):
  File "/code/run.py", line 474, in <module>
    c = Configuration(c)
  File "/code/CPAC/utils/configuration.py", line 110, in __init__
    config_map = schema(config_map)
  File "/usr/local/miniconda/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/local/miniconda/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/usr/local/miniconda/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: extra keys not allowed @ data['nuisance_corrections']['2-nuisance_regression']['Regressors'][0]['CerebrospinalFluid']['include_delayed']
```
by @hahaai 

## Description
<!-- Concisely describe what the pull request does. -->
Adds these three keys https://github.com/FCP-INDI/C-PAC/blob/84d69e64bafe65e19f60b1086c327e559c874a8f/CPAC/pipeline/schema.py#L57-L59 to validation schema under `[nuisance_corrections']['2-nuisance_regression']['Regressors'][#]['CerebrospinalFluid']`, `[nuisance_corrections']['2-nuisance_regression']['Regressors'][#]['WhiteMatter']`, and `[nuisance_corrections']['2-nuisance_regression']['Regressors'][#]['GreyMatter']`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
