### PR TITLE
🐛 Move pipeline import earlier in configuration process

### DIFF
--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -477,9 +477,9 @@ elif args.analysis_level in ["test_config", "participant"]:
         c.update(overrides)
 
     if args.anat_only:
-        # TODO
-        # c.update({'functional_preproc': 'run': Off})?
-        c.update({"runFunctional": [0]})
+        c.update({'FROM': 'anat-only'})
+
+    c = Configuration(c)
 
     # get the aws_input_credentials, if any are specified
     if args.aws_input_creds:
@@ -523,8 +523,6 @@ elif args.analysis_level in ["test_config", "participant"]:
     c['pipeline_setup']['system_config']['num_ants_threads'] = min(
         c['pipeline_setup']['system_config']['max_cores_per_participant'], int(c['pipeline_setup']['system_config']['num_ants_threads'])
     )
-
-    c = Configuration(c)
 
     c['disable_log'] = args.disable_file_logging
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes
```Python
Running the 'fmriprep-options' pre-configured pipeline.
Traceback (most recent call last):
  File "/code/run.py", line 524, in <module>
    c['pipeline_setup']['system_config']['max_cores_per_participant'], int(c['pipeline_setup']['system_config']['num_ants_threads'])
KeyError: 'num_ants_threads'
```
by @shnizzedy 

Related to #1435 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
1. Moves the conversion of a pipeline config dict to a Configruration object from after https://github.com/FCP-INDI/C-PAC/blob/1cbbdaf09ea6a1e90392ad00c4e18853e3118414/dev/docker_data/run.py#L484-L525 to before.
2. Sets imported pipleine base to ['anat-only'](https://fcp-indi.github.io/docs/nightly/user/preconfig#anat-only-default-with-anatomical-preprocessing-only) if `args.anat_only`

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I overshot where to do this type conversion in #1435

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
