### PR TITLE
🚸 Include both full and minimal pipeline_config YAML files at run

### DIFF
--- a/CPAC/utils/yaml_template.py
+++ b/CPAC/utils/yaml_template.py
@@ -8,7 +8,9 @@ from CPAC.utils.utils import dct_diff, load_preconfig, lookup_nested_value, \
     update_config_dict, update_pipeline_values_1_8
 
 
-def create_yaml_from_template(d, template=DEFAULT_PIPELINE_FILE):
+def create_yaml_from_template(
+    d, template=DEFAULT_PIPELINE_FILE, include_all=False
+):
     """Save dictionary to a YAML file, keeping the structure
     (such as first level comments and ordering) from the template
 
@@ -21,6 +23,9 @@ def create_yaml_from_template(d, template=DEFAULT_PIPELINE_FILE):
 
     template : str
         path to template
+
+    include_all : bool
+        include every key, even those that are unchanged
 
     Examples
     --------
@@ -164,7 +169,11 @@ def create_yaml_from_template(d, template=DEFAULT_PIPELINE_FILE):
         template_name = 'default'
 
     # update values
-    d = _create_import_dict(dct_diff(d_default, d))
+    if include_all:
+        d_default.update(d.dict())
+        d = _create_import_dict(dct_diff({}, d_default))
+    else:
+        d = _create_import_dict(dct_diff(d_default, d))
 
     # generate YAML from template with updated values
     with open(template, 'r') as f:

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -577,8 +577,10 @@ elif args.analysis_level in ["test_config", "participant"]:
             DEFAULT_TMP_DIR, "cpac_pipeline_config_{0}.yml".format(st)
         )
 
-    with open(pipeline_config_file, 'w') as f:
-        f.write(create_yaml_from_template(c, DEFAULT_PIPELINE))
+    open(pipeline_config_file, 'w').write(
+        create_yaml_from_template(c, DEFAULT_PIPELINE, True))
+    open(f'{pipeline_config_file[:-4]}_min.yml', 'w').write(
+        create_yaml_from_template(c, DEFAULT_PIPELINE, False))
 
     participant_labels = []
     if args.participant_label:


### PR DESCRIPTION
## Description

I realized I never updated the step in `run.py` that writes the what-was-actually-run pipeline YAML file for #1411. Before this PR, the generated file just gives a minimal configuration showing what's different from the default. With this PR, both a full and minimal configuration are generated.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
