### PR TITLE
🩹 Keep `minimum_threads_per_subject` > 0

### DIFF
--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -506,20 +506,29 @@ elif args.analysis_level in ["test_config", "participant"]:
 
     # Preference: n_cpus if given, override if present, else from config if
     # present, else n_cpus=3
-    if args.n_cpus == 0:
+    if int(args.n_cpus) == 0:
         c['pipeline_setup']['system_config']['max_cores_per_participant'] = int(c['pipeline_setup']['system_config'].get('max_cores_per_participant', 3))
         args.n_cpus = 3
     else:
         c['pipeline_setup']['system_config']['max_cores_per_participant'] = args.n_cpus
+
     c['pipeline_setup']['system_config']['num_participants_at_once'] = int(c['pipeline_setup']['system_config'].get('num_participants_at_once', 1))
-    # Reduce cores per participant if cores times particiapants is more than
+    # Reduce cores per participant if cores times participants is more than
     # available CPUS. n_cpus is a hard upper limit.
-    if (c['pipeline_setup']['system_config']['max_cores_per_participant']  * c['pipeline_setup']['system_config']['num_participants_at_once']) > int(
+    if (c['pipeline_setup']['system_config']['max_cores_per_participant'] * c['pipeline_setup']['system_config']['num_participants_at_once']) > int(
         args.n_cpus
     ):
-        c['pipeline_setup']['system_config']['max_cores_per_participant']  = int(
+        c['pipeline_setup']['system_config']['max_cores_per_participant'] = int(
             args.n_cpus
         ) // c['pipeline_setup']['system_config']['num_participants_at_once']
+        if c['pipeline_setup']['system_config'][
+            'max_cores_per_participant'
+        ] == 0:
+            c['pipeline_setup']['system_config'][
+                'max_cores_per_participant'] = args.n_cpus
+            c['pipeline_setup']['system_config'][
+                'num_participants_at_once'] = 1
+
     c['pipeline_setup']['system_config']['num_ants_threads'] = min(
         c['pipeline_setup']['system_config']['max_cores_per_participant'], int(c['pipeline_setup']['system_config']['num_ants_threads'])
     )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes regtest-2‒4 in https://github.com/FCP-INDI/cpac_run_logs/issues/15#issue-811536953 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
Before this change, if `n_cpus` < `num_participants_at_once`, `minimum_threads_per_subject` ends up at 0. With this PR, in that situation, `minimum_threads_per_subject` becomes `n_cpus` and `num_participants_at_once` becomes 1.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
