### PR TITLE
📝 Clarify `motion_estimate_filter` validation message

### DIFF
--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -2,6 +2,7 @@ from itertools import chain, permutations
 from voluptuous import All, ALLOW_EXTRA, Any, In, Length, Match, Optional, \
                        Range, Required, Schema
 from voluptuous.validators import Maybe
+from CPAC import __version__
 
 # 1 or more digits, optional decimal, 'e', optional '-', 1 or more digits
 scientific_notation_str_regex = r'^([0-9]+(\.[0-9]*)*(e)-{0,1}[0-9]+)*$'
@@ -502,43 +503,46 @@ schema = Schema({
                     'filter_bandwidth': Maybe(Number),
                     'lowpass_cutoff': Maybe(Number),
                 }, {  # notch filter with breathing_rate_* set
-                    'run': forkable,
-                    'filter_type': 'notch',
-                    'filter_order': int,
-                    'breathing_rate_min': Number,
+                    Required('run'): forkable,
+                    Required('filter_type'): 'notch',
+                    Required('filter_order'): int,
+                    Required('breathing_rate_min'): Number,
                     'breathing_rate_max': Number,
                     'center_frequency': Maybe(Number),
                     'filter_bandwidth': Maybe(Number),
                     'lowpass_cutoff': Maybe(Number),
                 }, {  # notch filter with manual parameters set
-                    'run': forkable,
-                    'filter_type': 'notch',
-                    'filter_order': int,
+                    Required('run'): forkable,
+                    Required('filter_type'): 'notch',
+                    Required('filter_order'): int,
                     'breathing_rate_min': None,
                     'breathing_rate_max': None,
-                    'center_frequency': Number,
-                    'filter_bandwidth': Number,
+                    Required('center_frequency'): Number,
+                    Required('filter_bandwidth'): Number,
                     'lowpass_cutoff': Maybe(Number),
                 }, {  # lowpass filter with breathing_rate_min
-                    'run': forkable,
-                    'filter_type': 'lowpass',
-                    'filter_order': int,
-                    'breathing_rate_min': Number,
+                    Required('run'): forkable,
+                    Required('filter_type'): 'lowpass',
+                    Required('filter_order'): int,
+                    Required('breathing_rate_min'): Number,
                     'breathing_rate_max': Maybe(Number),
                     'center_frequency': Maybe(Number),
                     'filter_bandwidth': Maybe(Number),
                     'lowpass_cutoff': Maybe(Number),
                 }, {  # lowpass filter with lowpass_cutoff
-                    'run': forkable,
-                    'filter_type': 'lowpass',
-                    'filter_order': int,
-                    'breathing_rate_min': None,
+                    Required('run'): forkable,
+                    Required('filter_type'): 'lowpass',
+                    Required('filter_order'): int,
+                    Required('breathing_rate_min', default=None): None,
                     'breathing_rate_max': Maybe(Number),
                     'center_frequency': Maybe(Number),
                     'filter_bandwidth': Maybe(Number),
-                    'lowpass_cutoff': Number,
+                    Required('lowpass_cutoff'): Number,
                 },),
-                msg='motion_estimate_filter configuration is invalid.'
+                msg='`motion_estimate_filter` configuration is invalid. '
+                    f'See https://fcp-indi.github.io/docs/v{__version__}/'
+                    'user/func#motion_estimate_filter_valid_options '
+                    'for details.'
             ),
         },
         'distortion_correction': {


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->

- Improves validation of `motion_estimate_filter`
- Updates message when config is invalid for this key from 
   > ```Python
   > MultipleInvalid:  motion_estimate_filter configuration is invalid. for dictionary value @ data['motion_estimate_filter']
   > ```

   to 
   > ```Python
   > MultipleInvalid: `motion_estimate_filter` configuration is invalid. See https://fcp-indi.github.io/docs/v1.8.0/user/func#motion_estimate_filter_valid_options for details. for dictionary value @ data['motion_estimate_filter']
   > ```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
_https​://fcp-indi.github.io/docs/v1.8.0/user/func#motion_estimate_filter_valid_options_ will be something like
![https://fcp-indi.github.io/docs/v1.8.0/user/func#motion_estimate_filter_valid_options](https://user-images.githubusercontent.com/5974438/108542817-38f11180-72b2-11eb-8f6b-955b3bfc60e0.png) once https://github.com/FCP-INDI/fcp-indi.github.com/pull/248 is merged.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
