### PR TITLE
🔧 Update `anat-only` preconfig to not run `coregistration` and `func_registration_to_template`

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -652,7 +652,7 @@ CPAC run error:
                     run_finish=strftime("%Y-%m-%d %H:%M:%S")
                 ))
 
-                resource_report(c.pipeline_setup['log_directory']['path'],
+                resource_report(cb_log_filename,
                                 num_cores_per_sub, logger)
 
                 # Remove working directory when done

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -748,7 +748,7 @@ class ResourcePool(object):
             if not all:
                 if 'symtemplate' in resource:
                     continue
-
+            subdir = 'other'
             if resource.split('_')[-1] in anat:
                 subdir = 'anat'
                 #TODO: get acq- etc.
@@ -769,7 +769,6 @@ class ResourcePool(object):
                 if 'from-bold' in resource:
                     subdir = 'func'
             else:
-                subdir = 'other'
                 for tag in motions:
                     if tag in resource:
                         subdir = 'func'

--- a/CPAC/resources/configs/pipeline_config_anat-only.yml
+++ b/CPAC/resources/configs/pipeline_config_anat-only.yml
@@ -148,6 +148,8 @@ registration_workflows:
 
     coregistration: 
 
+      run: Off
+
       boundary_based_registration: 
 
         # this is a fork point
@@ -169,6 +171,8 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
 
     func_registration_to_template: 
+
+      run: Off
 
       target_template: 
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes https://github.com/FCP-INDI/cpac_run_logs/issues/10 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
* Turns https://github.com/FCP-INDI/C-PAC/blob/26fb1b6edd7c5356f3baa040fd7a1e0003f5e7eb/CPAC/resources/configs/pipeline_config_anat-only.yml#L147-L151 https://github.com/FCP-INDI/C-PAC/blob/26fb1b6edd7c5356f3baa040fd7a1e0003f5e7eb/CPAC/resources/configs/pipeline_config_anat-only.yml#L173-L175 to resolve the runtime error in https://github.com/FCP-INDI/cpac_run_logs/issues/10
* Moves https://github.com/FCP-INDI/C-PAC/blob/6b263d26203f1ac589d0ce1fe91e970d2c448fff/CPAC/pipeline/engine.py#L772 above https://github.com/FCP-INDI/C-PAC/blob/6b263d26203f1ac589d0ce1fe91e970d2c448fff/CPAC/pipeline/engine.py#L752-L770 to avoid 
   ```Python
   Traceback (most recent call last):
     File "/code/run.py", line 677, in <module>
       test_config = 1 if args.analysis_level == "test_config" else 0
     File "/code/CPAC/pipeline/cpac_runner.py", line 549, in run
       p_name, plugin, plugin_args, test_config)
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 348, in run_workflow
       subject_id, sub_dict, c, p_name, num_ants_cores
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 1106, in build_workflow
       rpool.gather_pipes(wf, cfg)
     File "/code/CPAC/pipeline/engine.py", line 784, in gather_pipes
       out_path = os.path.join(out_dir, container, subdir, filename)
   UnboundLocalError: local variable 'subdir' referenced before assignment
   ```

   in cases of no matches to the complex conditional tree
* Fixes a bug in generating resource usage reports (a directory was being passed where a full filepath was expected)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
