### PR TITLE
changed crashfile format to text

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -203,6 +203,9 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
             'log_directory': log_dir,
             'log_to_file': bool(getattr(c.pipeline_setup['log_directory'],
                                         'run_logging', True))
+        },
+        'execution': {
+            'crashfile_format': 'txt'
         }
     })
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -668,7 +668,7 @@ def initialize_nipype_wf(cfg, sub_data_dct, name=""):
     if name:
         name = f'_{name}'
 
-    workflow_name = f'cpac{name}_{sub_data_dct["subject_id"]}'
+    workflow_name = f'cpac{name}_{sub_data_dct["subject_id"]}_{sub_data_dct["unique_id"]}'
     wf = pe.Workflow(name=workflow_name)
     wf.base_dir = cfg.pipeline_setup['working_directory']['path']
     wf.config['execution'] = {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1450  by @ccraddock 

## Description
modifies the nipype config settings in cpac_pipeline.py to change the filetype of crashfiles to text

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
- run a CPAC pipeline known to crash
- rejoice in the human readable and grepable crashfiles!
- 
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x ] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x ] My commit messages follow best practices.
- [x ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x ] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
