### PR TITLE
🐛 Fix working directory initialization

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -650,12 +650,11 @@ CPAC run error:
                 if c.pipeline_setup['working_directory'][
                     'remove_working_dir']:
                     try:
-                        raise Exception('not happenin')
                         if os.path.exists(working_dir):
                             logger.info("Removing working dir: %s",
                                         working_dir)
                             shutil.rmtree(working_dir)
-                    except:
+                    except (FileNotFoundError, PermissionError):
                         logger.warn('Could not remove working directory %s',
                                     working_dir)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes 

> ```Python
>    210224-03:44:20,273 nipype.workflow WARNING:
>    Could not remove working directory /outputs/working/cpac_sub-105923
> ```
by @pab2163

## Description
<!-- Concisely describe what the pull request does. -->
* Refactors the working directory initialization to
   1. check if the working directory is an s3 directory
   2. if so, raise an error
   3. check if the in-container user has write-access to the specified working directory path in the configuration
   4. if not, set working directory `working` within the output directory
 
   regardless of whether we're saving the working directory or not. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* Also moves the resource overusage report above the run complete / did not execute cleanly message.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
