### PR TITLE
🔇 Comment out runtime_threads ⩼  threads

### DIFF
--- a/CPAC/utils/monitoring/draw_gantt_chart.py
+++ b/CPAC/utils/monitoring/draw_gantt_chart.py
@@ -499,7 +499,7 @@ def resource_overusage_report(cblog):
         > node.get('num_threads', 1) else None
     ] for node in [node for node in cb_dict_list if (
         node.get('runtime_memory_gb', 0) > node.get('estimated_memory_gb', 1)
-        or node.get('runtime_threads', 0) - 1 > node.get('num_threads', 1)
+        # or node.get('runtime_threads', 0) - 1 > node.get('num_threads', 1)
     )]}
     text_report = ''
     if excessive:
@@ -514,10 +514,12 @@ def resource_overusage_report(cblog):
                                '        runtime > estimated\n' \
                                f'        {excessive[node][0]} ' \
                                f'> {excessive[node][1]}\n'
-            if excessive[node][2]:
-                text_report += '      **threads**\n        runtime > limit\n' \
-                               f'        {excessive[node][2]} ' \
-                               f'> {excessive[node][3]}\n'
+            # JC: I'm not convinced 'runtime_threads' and 'threads' are
+            # comparable in nipype ~1.5.1
+            # if excessive[node][2]:
+            #     text_report += '      **threads**\n        runtime > limit\n' \
+            #                    f'        {excessive[node][2]} ' \
+            #                    f'> {excessive[node][3]}\n'
         text_report += dotted_line
     return text_report, excessive
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Drops the 
```
      **threads**
        runtime > limit
```
entries from the resource overusage report added in #1428. As mentioned in https://github.com/FCP-INDI/C-PAC/issues/1404#issuecomment-756389510 and https://github.com/nipy/nipype/pull/3290#issuecomment-756994047, I think the runtime threads are measuring something different than the estimated threads, so I don't think the comparison is intuitively meaningful. Also, the sheer number of nodes for which the runtime threads > estimated threads makes the report less manageable and obscures the memory overusage information.

### After this change:
```
nipype.workflow WARNING:
	 The following nodes used excessive resources:
---------------------------------------------

cpac_3699991
  .anat_skullstrip_ants
  .lap_tmpl
      **memory_gb**
        runtime > estimated
        0.5595245361328125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .mrg_tmpl
      **memory_gb**
        runtime > estimated
        0.3591728212890625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .res_tmpl
      **memory_gb**
        runtime > estimated
        0.528465271484375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .lap_target
      **memory_gb**
        runtime > estimated
        0.5269508359375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .mrg_target
      **memory_gb**
        runtime > estimated
        0.3600578310546875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .res_target
      **memory_gb**
        runtime > estimated
        0.4936714169921875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .init_aff
      **memory_gb**
        runtime > estimated
        0.402805328125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .norm
      **memory_gb**
        runtime > estimated
        3.054317474609375 > 3.0

cpac_3699991
  .anat_skullstrip_ants
  .thr_brainmask
      **memory_gb**
        runtime > estimated
        0.3685455322265625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .03_pad_mask
      **memory_gb**
        runtime > estimated
        0.3685455322265625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .dil_brainmask
      **memory_gb**
        runtime > estimated
        0.4382514951171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .get_brainmask
      **memory_gb**
        runtime > estimated
        0.73153305078125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .02_pad_segm
      **memory_gb**
        runtime > estimated
        0.368553162109375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .04_sel_labels
      **memory_gb**
        runtime > estimated
        0.430782318359375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .27_depad_csf
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .10_me_csf
      **memory_gb**
        runtime > estimated
        0.5296630859375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .06_get_gm
      **memory_gb**
        runtime > estimated
        0.82701873828125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .07_fill_gm
      **memory_gb**
        runtime > estimated
        1.2632637021484374 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .08_mult_gm
      **memory_gb**
        runtime > estimated
        0.690216064453125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .11_add_gm
      **memory_gb**
        runtime > estimated
        0.5609321591796875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .12_relabel_gm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .25_depad_gm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .05_get_wm
      **memory_gb**
        runtime > estimated
        0.823215484375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .09_relabel_wm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .26_depad_wm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .merge_tpms
      **memory_gb**
        runtime > estimated
        0.360801697265625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .13_add_gm_wm
      **memory_gb**
        runtime > estimated
        0.561180115234375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .24_depad_segm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .14_sel_labels2
      **memory_gb**
        runtime > estimated
        0.376407623046875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .15_add_7
      **memory_gb**
        runtime > estimated
        0.583221435546875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .16_me_7
      **memory_gb**
        runtime > estimated
        0.537895203125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .17_comp_7
      **memory_gb**
        runtime > estimated
        0.836151123046875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .18_md_7
      **memory_gb**
        runtime > estimated
        0.522487640625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .19_fill_7
      **memory_gb**
        runtime > estimated
        0.978492736328125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .20_add_7_2
      **memory_gb**
        runtime > estimated
        0.576255798828125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .21_md_7_2
      **memory_gb**
        runtime > estimated
        0.5230712890625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .22_me_7_2
      **memory_gb**
        runtime > estimated
        0.539005279296875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .23_depad_mask
      **memory_gb**
        runtime > estimated
        0.6026344296875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .msk_conform
      **memory_gb**
        runtime > estimated
        0.376407623046875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .sel_wm
      **memory_gb**
        runtime > estimated
        0.3685493466796875 > 0.2

cpac_3699991
  .segment_59
      **memory_gb**
        runtime > estimated
        1.86349105859375 > 1.5

cpac_3699991
  .warp_ts_to_T1template_150
  .apply_warp_warp_ts_to_T1template_150
      **memory_gb**
        runtime > estimated
        2.1888542177734376 > 2.0
---------------------------------------------
```

### Before this change:
```
nipype.workflow WARNING:
	 The following nodes used excessive resources:
---------------------------------------------

cpac_3699991
  .func_ingress_3699991_1
  .select_scan_params
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .edit_func_2
  .func_get_idx
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .func_deoblique_84
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .func_reorient_84
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .func_get_mean_RPI_74
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .unifize_88
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .combine_masks_88
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .gen_motion_stats_93
  .cal_DVARS
      **threads**
        runtime > limit
        6 > 1

cpac_3699991
  .func_normalize_106
      **threads**
        runtime > limit
        17 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .tCompCor_cosine_filter
      **threads**
        runtime > limit
        16 > 1

cpac_3699991
  .qc_snr_166
  .std_dev
      **threads**
        runtime > limit
        16 > 1

cpac_3699991
  .get_mcflirt_rms_abs_86
      **threads**
        runtime > limit
        6 > 1

cpac_3699991
  .func_motion_correct_mcflirt_76
      **threads**
        runtime > limit
        18 > 1

cpac_3699991
  .gen_motion_stats_93
  .calculate_FDJ
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .json_space-template_desc-mean_bold-sagittal-qc_205
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .id_string_space-template_desc-brain_bold-carpet-qc_201
      **threads**
        runtime > limit
        14 > 1

cpac_3699991
  .json_space-template_desc-brain_bold-carpet-qc_201
      **threads**
        runtime > limit
        16 > 1

cpac_3699991
  .json_framewise-displacement-jenkinson-plot-qc_181
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .id_string_movement-parameters-trans-qc_179
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .json_movement-parameters-trans-qc_179
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_movement-parameters-trans-qc_179
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .id_string_bold-snr-hist-qc_173
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .json_bold-snr-hist-qc_173
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .json_bold-snr-sagittal-qc_172
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .id_string_bold-snr-axial-qc_171
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .json_space-template_desc-mean_bold_157
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .id_string_space-template_desc-brain_bold_153
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .id_string_regressors_149
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .id_string_from-bold_to-template_mode-image_xfm_123
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .json_from-bold_to-template_mode-image_xfm_123
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .id_string_from-bold_to-T1w_mode-image_desc-linear_xfm_116
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .json_from-bold_to-T1w_mode-image_desc-linear_xfm_116
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .id_string_space-T1w_desc-mean_bold_115
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .id_string_desc-mean_bold_105
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .nii_desc-mean_bold_105
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .id_string_motion-params_104
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .json_motion-params_104
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .nii_motion-params_104
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .id_string_power-params_103
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .json_power-params_103
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .json_dvars_102
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .nii_dvars_102
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_dvars_102
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .json_framewise-displacement-jenkinson_101
      **threads**
        runtime > limit
        8 > 1

cpac_3699991
  .sinker_framewise-displacement-jenkinson_101
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .id_string_framewise-displacement-power_100
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .nii_framewise-displacement-power_100
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_framewise-displacement-power_100
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .id_string_space-bold_desc-brain_mask_109
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .json_space-bold_desc-brain_mask_109
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .nii_desc-motion_bold_88
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .sinker_desc-motion_bold_88
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nii_movement-parameters_79
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .sinker_movement-parameters_79
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .json_max-displacement_78
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nii_max-displacement_78
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_max-displacement_78
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .warp_bold_mask_to_T1template_158
  .interp_string
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .anat_skullstrip_ants
  .lap_tmpl
      **memory_gb**
        runtime > estimated
        0.5595245361328125 > 0.2
      **threads**
        runtime > limit
        5 > 1

cpac_3699991
  .anat_skullstrip_ants
  .mrg_tmpl
      **memory_gb**
        runtime > estimated
        0.3591728212890625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .res_tmpl
      **memory_gb**
        runtime > estimated
        0.528465271484375 > 0.2

cpac_3699991
  .qc_skullstrip_182
  .skull_edge
      **threads**
        runtime > limit
        33 > 1

cpac_3699991
  .qc_skullstrip_182
  .montage_skull
  .resample_o
      **threads**
        runtime > limit
        22 > 1

cpac_3699991
  .anat_skullstrip_ants
  .lap_target
      **memory_gb**
        runtime > estimated
        0.5269508359375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .mrg_target
      **memory_gb**
        runtime > estimated
        0.3600578310546875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .res_target
      **memory_gb**
        runtime > estimated
        0.4936714169921875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .init_aff
      **memory_gb**
        runtime > estimated
        0.402805328125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .norm
      **memory_gb**
        runtime > estimated
        3.054317474609375 > 3.0

cpac_3699991
  .anat_skullstrip_ants
  .thr_brainmask
      **memory_gb**
        runtime > estimated
        0.3685455322265625 > 0.2
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .03_pad_mask
      **memory_gb**
        runtime > estimated
        0.3685455322265625 > 0.2
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .anat_skullstrip_ants
  .dil_brainmask
      **memory_gb**
        runtime > estimated
        0.4382514951171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .get_brainmask
      **memory_gb**
        runtime > estimated
        0.73153305078125 > 0.2
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .02_pad_segm
      **memory_gb**
        runtime > estimated
        0.368553162109375 > 0.2
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .04_sel_labels
      **memory_gb**
        runtime > estimated
        0.430782318359375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .27_depad_csf
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .10_me_csf
      **memory_gb**
        runtime > estimated
        0.5296630859375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .06_get_gm
      **memory_gb**
        runtime > estimated
        0.82701873828125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .07_fill_gm
      **memory_gb**
        runtime > estimated
        1.2632637021484374 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .08_mult_gm
      **memory_gb**
        runtime > estimated
        0.690216064453125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .11_add_gm
      **memory_gb**
        runtime > estimated
        0.5609321591796875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .12_relabel_gm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .25_depad_gm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .05_get_wm
      **memory_gb**
        runtime > estimated
        0.823215484375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .09_relabel_wm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2
      **threads**
        runtime > limit
        5 > 1

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .26_depad_wm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .merge_tpms
      **memory_gb**
        runtime > estimated
        0.360801697265625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .13_add_gm_wm
      **memory_gb**
        runtime > estimated
        0.561180115234375 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .24_depad_segm
      **memory_gb**
        runtime > estimated
        0.36080551171875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .14_sel_labels2
      **memory_gb**
        runtime > estimated
        0.376407623046875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .15_add_7
      **memory_gb**
        runtime > estimated
        0.583221435546875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .16_me_7
      **memory_gb**
        runtime > estimated
        0.537895203125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .17_comp_7
      **memory_gb**
        runtime > estimated
        0.836151123046875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .18_md_7
      **memory_gb**
        runtime > estimated
        0.522487640625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .19_fill_7
      **memory_gb**
        runtime > estimated
        0.978492736328125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .20_add_7_2
      **memory_gb**
        runtime > estimated
        0.576255798828125 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .21_md_7_2
      **memory_gb**
        runtime > estimated
        0.5230712890625 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .22_me_7_2
      **memory_gb**
        runtime > estimated
        0.539005279296875 > 0.2
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .23_depad_mask
      **memory_gb**
        runtime > estimated
        0.6026344296875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .atropos_wf
  .msk_conform
      **memory_gb**
        runtime > estimated
        0.376407623046875 > 0.2

cpac_3699991
  .anat_skullstrip_ants
  .sel_wm
      **memory_gb**
        runtime > estimated
        0.3685493466796875 > 0.2

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .Anatomical_2mm_flirt
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .qc_skullstrip_182
  .montage_skull
  .montage_s
      **threads**
        runtime > limit
        6 > 1

cpac_3699991
  .qc_skullstrip_182
  .montage_skull
  .montage_a
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .anat_edge_175
      **threads**
        runtime > limit
        23 > 1

cpac_3699991
  .segment_59
      **memory_gb**
        runtime > estimated
        1.86349105859375 > 1.5

cpac_3699991
  .montage_csf_gm_wm_190
  .resample_o_wm
      **threads**
        runtime > limit
        23 > 1

cpac_3699991
  .GM_59
  .threshold_segmentmap_GM_59
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .montage_csf_gm_wm_190
  .resample_o_gm
      **threads**
        runtime > limit
        18 > 1

cpac_3699991
  .montage_csf_gm_wm_190
  .montage_s
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .montage_csf_gm_wm_190
  .montage_a
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .erode_CSF_mask_128
  .erode_mask
      **threads**
        runtime > limit
        16 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .CerebrospinalFluid_2mm_flirt
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .aCompCor_merge_masks
      **threads**
        runtime > limit
        19 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .aCompCor_union_masks
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .CerebrospinalFluid_merge_masks
      **threads**
        runtime > limit
        16 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .CerebrospinalFluid_union_masks
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .func_to_anat_bbreg_111
  .wm_bb_mask
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .tcompcor
  .std
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .tcompcor
  .merge_slice_masks
      **threads**
        runtime > limit
        14 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .tCompCor_pc
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nuisance_regressors_Regressor-1_134
  .aCompCor_cosine_filter
      **threads**
        runtime > limit
        18 > 1

cpac_3699991
  .nii_regressors_149
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .sinker_regressors_149
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .create_func_to_T1wtemplate_xfm_117
  .fsl_reg_2_itk
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .montage_anat_175
  .montage_s
      **threads**
        runtime > limit
        7 > 1

cpac_3699991
  .montage_anat_175
  .montage_a
      **threads**
        runtime > limit
        7 > 1

cpac_3699991
  .qc_snr_166
  .std_dev_anat
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .qc_snr_166
  .dp_snr
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .qc_snr_166
  .montage_snr
  .resample_o
      **threads**
        runtime > limit
        21 > 1

cpac_3699991
  .qc_snr_166
  .montage_snr
  .montage_s
      **threads**
        runtime > limit
        6 > 1

cpac_3699991
  .qc_snr_166
  .montage_snr
  .montage_a
      **threads**
        runtime > limit
        7 > 1

cpac_3699991
  .sinker_bold-snr-axial-qc_171
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .qc_snr_166
  .hist_snr
      **threads**
        runtime > limit
        8 > 1

cpac_3699991
  .sinker_from-bold_to-T1w_mode-image_desc-linear_xfm_116
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .get_csf_59
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .gather_WM_path
  .check_for_s3
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .id_string_dseg-sagittal-qc_195
      **threads**
        runtime > limit
        14 > 1

cpac_3699991
  .sinker_dseg-sagittal-qc_195
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .json_dseg-axial-qc_194
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .sinker_dseg-axial-qc_194
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .id_string_space-template_desc-brain_T1w-axial-qc_188
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .nii_desc-brain_T1w-sagittal-qc_185
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_desc-brain_T1w-sagittal-qc_185
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .json_desc-brain_T1w-axial-qc_184
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nii_desc-brain_T1w-axial-qc_184
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_desc-brain_T1w-axial-qc_184
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .nii_label-WM_desc-eroded_mask_133
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .sinker_label-WM_desc-eroded_mask_133
      **threads**
        runtime > limit
        15 > 1

cpac_3699991
  .json_label-CSF_desc-eroded_mask_130
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_label-CSF_desc-eroded_mask_130
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .json_space-T1w_desc-eroded_mask_127
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .json_label-GM_desc-preproc_mask_72
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .nii_label-GM_desc-preproc_mask_72
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_label-GM_desc-preproc_mask_72
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .id_string_label-CSF_desc-preproc_mask_71
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .nii_label-CSF_desc-preproc_mask_71
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .json_label-WM_mask_70
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .sinker_label-WM_mask_70
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .id_string_label-GM_mask_69
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .json_label-GM_mask_69
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nii_label-CSF_mask_68
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .sinker_label-CSF_mask_68
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .json_label-WM_probseg_67
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .json_label-GM_probseg_66
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .nii_label-CSF_probseg_65
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_label-CSF_probseg_65
      **threads**
        runtime > limit
        8 > 1

cpac_3699991
  .json_from-T1w_to-template_mode-image_desc-nonlinear_xfm_57
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .id_string_from-T1w_to-template_mode-image_xfm_53
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .id_string_space-template_desc-brain_T1w_52
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .nii_desc-brain_T1w_45
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .sinker_desc-brain_T1w_45
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .json_space-T1w_desc-brain_mask_42
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .nii_desc-reorient_T1w_40
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_desc-reorient_T1w_40
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .json_desc-preproc_T1w_41
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .sinker_desc-preproc_T1w_41
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .func_template_edge_202
      **threads**
        runtime > limit
        24 > 1

cpac_3699991
  .montage_mfi_202
  .resample_o
      **threads**
        runtime > limit
        26 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .cpac_3699991
  .anat_mni_ants_register
  .calc_ants_warp
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .montage_mni_anat_186
  .resample_u
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .nii_space-template_desc-brain_T1w_52
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .sinker_from-T1w_to-template_mode-image_desc-nonlinear_xfm_57
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .cpac_3699991
  .anat_mni_ants_register
  .select_forward_rigid
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .check_all_inv_transforms
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .inverse_all_transform_flags
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .create_func_to_T1wtemplate_xfm_117
  .write_composite_inv_xfm
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .warp_ts_to_T1template_150
  .apply_warp_warp_ts_to_T1template_150
      **memory_gb**
        runtime > estimated
        2.1888542177734376 > 2.0

cpac_3699991
  .nii_space-template_desc-brain_bold_153
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .warp_deriv_mask_to_T1template_162
  .single_ants_xfm_to_list
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .carpet_seg_196
  .carpet_plot
      **threads**
        runtime > limit
        17 > 1

cpac_3699991
  .nii_space-template_desc-brain_bold-carpet-qc_201
      **threads**
        runtime > limit
        1604 > 1

cpac_3699991
  .montage_mfi_202
  .resample_u
      **threads**
        runtime > limit
        25 > 1

cpac_3699991
  .montage_mfi_202
  .montage_s
      **threads**
        runtime > limit
        15 > 1

cpac_3699991
  .nii_space-template_desc-mean_bold-sagittal-qc_205
      **threads**
        runtime > limit
        8 > 1

cpac_3699991
  .sinker_space-template_desc-mean_bold-sagittal-qc_205
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .montage_mfi_202
  .montage_a
      **threads**
        runtime > limit
        8 > 1

cpac_3699991
  .nii_space-template_desc-mean_bold-axial-qc_204
      **threads**
        runtime > limit
        22 > 1

cpac_3699991
  .sinker_space-template_desc-mean_bold-axial-qc_204
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .nii_space-template_desc-mean_bold_157
      **threads**
        runtime > limit
        4 > 1

cpac_3699991
  .sinker_space-template_desc-mean_bold_157
      **threads**
        runtime > limit
        2 > 1

cpac_3699991
  .sinker_from-T1w_to-template_mode-image_xfm_53
      **threads**
        runtime > limit
        10 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .collect_inv_transforms
      **threads**
        runtime > limit
        11 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .check_inv_transforms
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .ANTS_T1_to_template_46
  .write_composite_invlinear_xfm
      **threads**
        runtime > limit
        13 > 1

cpac_3699991
  .sinker_from-T1w_to-template_mode-image_desc-linear_xfm_55
      **threads**
        runtime > limit
        3 > 1

cpac_3699991
  .anat_template_edge_186
      **threads**
        runtime > limit
        9 > 1

cpac_3699991
  .montage_mni_anat_186
  .resample_o
      **threads**
        runtime > limit
        12 > 1

cpac_3699991
  .montage_mni_anat_186
  .montage_s
      **threads**
        runtime > limit
        7 > 1

cpac_3699991
  .montage_mni_anat_186
  .montage_a
      **threads**
        runtime > limit
        6 > 1

cpac_3699991
  .sinker_space-template_desc-brain_T1w-axial-qc_188
      **threads**
        runtime > limit
        3 > 1
---------------------------------------------
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
