### PR TITLE
⚡️ Increase memory estimates for some overrunning Nodes

### DIFF
--- a/CPAC/anat_preproc/ants.py
+++ b/CPAC/anat_preproc/ants.py
@@ -17,7 +17,7 @@ from pkg_resources import resource_filename as pkgr_fn
 from packaging.version import parse as parseversion, Version
 
 # nipype
-from nipype.pipeline import engine as pe
+from CPAC.pipeline.nipype_pipeline_engine import engine as pe
 from nipype.interfaces import utility as niu
 from nipype.interfaces.fsl.maths import ApplyMask
 from nipype.interfaces.ants import N4BiasFieldCorrection, Atropos, MultiplyImages

--- a/CPAC/pipeline/nipype_pipeline_engine/__init__.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/__init__.py
@@ -4,9 +4,9 @@ for C-PAC-specific documentation.
 See https://nipype.readthedocs.io/en/latest/api/generated/nipype.pipeline.engine.html
 for Nipype's documentation.'''  # noqa E501
 from nipype.pipeline import engine as pe
-# import __all__ from nipype.pipeline.engine
+# import everything in nipype.pipeline.engine.__all__
 from nipype.pipeline.engine import *  # noqa F401
-# import DEFAULT_MEM_GB and override Node, MapNode
+# import our DEFAULT_MEM_GB and override Node, MapNode
 from .engine import DEFAULT_MEM_GB, Node, MapNode
 
 __all__ = [

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -2272,7 +2272,8 @@ def warp_timeseries_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
 
     apply_xfm = apply_transform(f'warp_ts_to_T1template_{pipe_num}', reg_tool,
                                 time_series=True, num_cpus=num_cpus,
-                                num_ants_cores=num_ants_cores)
+                                num_ants_cores=num_ants_cores,
+                                mem_gb=2.5)
 
     if reg_tool == 'ants':
         apply_xfm.inputs.inputspec.interpolation = cfg.registration_workflows[
@@ -2487,9 +2488,10 @@ def warp_timeseries_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
 
     num_ants_cores = cfg.pipeline_setup['system_config']['num_ants_threads']
 
-    apply_xfm = apply_transform('warp_ts_to_EPItemplate', reg_tool,
+    apply_xfm = apply_transform(f'warp_ts_to_EPItemplate_{pipe_num}', reg_tool,
                                 time_series=True, num_cpus=num_cpus,
-                                num_ants_cores=num_ants_cores)
+                                num_ants_cores=num_ants_cores,
+                                mem_gb=2.5)
 
     if reg_tool == 'ants':
         apply_xfm.inputs.inputspec.interpolation = cfg.registration_workflows[

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -575,8 +575,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     #  'probability_maps' output is a list of individual probability maps
     #      triggered by 'probability_maps' boolean input (-p)
 
-    segment = pe.Node(interface=fsl.FAST(), name=f'segment_{pipe_num}',
-                      mem_gb=1.5)
+    segment = pe.Node(interface=fsl.FAST(), name=f'segment_{pipe_num}')
     segment.inputs.img_type = 1
     segment.inputs.segments = True
     segment.inputs.probability_maps = True

--- a/CPAC/vmhc/vmhc.py
+++ b/CPAC/vmhc/vmhc.py
@@ -81,7 +81,8 @@ def warp_timeseries_to_sym_template(wf, cfg, strat_pool, pipe_num, opt=None):
 
     apply_xfm = apply_transform(f'warp_ts_to_sym_template_{pipe_num}',
                                 reg_tool, time_series=True, num_cpus=num_cpus,
-                                num_ants_cores=num_ants_cores)
+                                num_ants_cores=num_ants_cores,
+                                mem_gb=2.5)
 
     if reg_tool == 'ants':
         apply_xfm.inputs.inputspec.interpolation = cfg.registration_workflows[


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
#1457 by @shnizzedy includes a memory overusage report. This PR increases memory estimates for the affected nodes.
#1428 continued!

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* Replaces default nipype pipeline engine with 0.2GB default per-Node memory estimate with our 2.0 GB default per-Node memory estimate in ANTs https://github.com/FCP-INDI/C-PAC/blob/543d29a2763003a684a9ecc4cc47fdd6e1308e15/CPAC/anat_preproc/ants.py#L20
* Increases other overrunning Nodes estimates by 0.5 GB each.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
