### PR TITLE
🥅 Improve handling of invalid 'motion_estimate_filter'

### DIFF
--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1,7 +1,7 @@
 from itertools import chain, permutations
 from voluptuous import All, ALLOW_EXTRA, Any, In, Length, Match, Optional, \
                        Range, Required, Schema
-from voluptuous.validators import Maybe
+from voluptuous.validators import ExactSequence, Maybe
 from CPAC import __version__
 
 # 1 or more digits, optional decimal, 'e', optional '-', 1 or more digits
@@ -143,6 +143,8 @@ ANTs_parameters = [Any(
         },
     }, dict  # TODO: specify other valid ANTs parameters
 )]
+_url_version = 'nightly' if __version__.endswith(
+    '-dev') else f'v{__version__.lstrip("v")}'
 
 
 def permutation_message(key, options):
@@ -494,7 +496,8 @@ schema = Schema({
             },
             'motion_estimate_filter': Required(
                 Any({  # no motion estimate filter
-                    'run': Maybe(Any([False], False)),
+                    'run': Maybe(Any(
+                        ExactSequence([False]), ExactSequence([]), False)),
                     'filter_type': Maybe(In({'notch', 'lowpass'})),
                     'filter_order': Maybe(int),
                     'breathing_rate_min': Maybe(Number),
@@ -539,10 +542,9 @@ schema = Schema({
                     'filter_bandwidth': Maybe(Number),
                     Required('lowpass_cutoff'): Number,
                 },),
-                msg='`motion_estimate_filter` configuration is invalid. '
-                    f'See https://fcp-indi.github.io/docs/v{__version__}/'
-                    'user/func#motion_estimate_filter_valid_options '
-                    'for details.'
+                msg='`motion_estimate_filter` configuration is invalid. See '
+                    f'https://fcp-indi.github.io/docs/{_url_version}/user/'
+                    'func#motion_estimate_filter_valid_options for details.\n',
             ),
         },
         'distortion_correction': {

--- a/CPAC/pipeline/test/__init__.py
+++ b/CPAC/pipeline/test/__init__.py
@@ -1,4 +1,0 @@
-from . import test_cpac_group_runner
-from . import test_engine
-
-__all__ = ['run']

--- a/CPAC/pipeline/test/test_schema_validation.py
+++ b/CPAC/pipeline/test/test_schema_validation.py
@@ -1,0 +1,28 @@
+'''Tests for schema.py'''
+import pytest
+
+from CPAC.utils.configuration import Configuration
+from voluptuous.error import Invalid
+
+
+@pytest.mark.parametrize('run_value', [
+    True, False, [True], [False], [True, False], [False, True], None, []])
+def test_motion_estimates_and_correction(run_value):
+    '''Test that any truthy forkable option for 'run' throws the custom
+    human-readable exception for an invalid motion_estimate_filter.
+    '''
+    d = {
+        'FROM': 'default',
+        'functional_preproc': {'motion_estimates_and_correction': {
+             'motion_estimate_filter': {'run': run_value,
+                                        'filter_type': 'notch',
+                                        'filter_order': 0,
+                                        'breathing_rate_min': None,
+                                        'breathing_rate_max': 101.5}}}
+    }
+    if bool(run_value) and run_value not in [[False], []]:
+        with pytest.raises(Invalid) as e:
+            Configuration(d)
+        assert "func#motion_estimate_filter_valid_options" in str(e.value)
+    else:
+        Configuration(d)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes 

```Python
voluptuous.error.MultipleInvalid: not a valid value @ data['functional_preproc']['motion_estimates_and_correction']['motion_estimate_filter']['run'][0]
```

error message raised when `'run'` is set to `[True]` and something is invalid in the [`motion_estimate_filter` configuration](https://github.com/FCP-INDI/C-PAC/pull/1432#issue-568453434)

by @sgiavasis 

## Description
<!-- Concisely describe what the pull request does. -->

* Improves the specificity of validation for `motion_estimate_filter` by checking for `None`, `False`, and [`ExactSequence`](http://alecthomas.github.io/voluptuous/docs/_build/html/voluptuous.html#voluptuous.validators.ExactSequence)s `[]` and `[False]` as the only valid options for the no-estimate-filter option https://github.com/FCP-INDI/C-PAC/blob/e34beb8b7e10cd5116f5848ed6f0652b91c06ee1/CPAC/pipeline/schema.py#L498-L500 to throw
   ```Python
   voluptuous.error.MultipleInvalid: `motion_estimate_filter` configuration is invalid. See https://fcp-indi.github.io/docs/nightly/user/func#motion_estimate_filter_valid_options for details.
     for dictionary value @ data['functional_preproc']['motion_estimates_and_correction']['motion_estimate_filter']
   ```
   instead of the error above.
* Adds a parameterized test.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

For `motion_estimate_filter`, the schema includes a series of dictionary validators. In the version before this change,

https://github.com/FCP-INDI/C-PAC/blob/1f5bbd43617ab549ff777177592c39d14840eecf/CPAC/pipeline/schema.py#L495-L541

the "no motion estimate filter" dictionary's `'run'` key would validate against

https://github.com/FCP-INDI/C-PAC/blob/1f5bbd43617ab549ff777177592c39d14840eecf/CPAC/pipeline/schema.py#L497

with this order of operations:
1. check for `None`
2. check for the only value being either a list or the exact boolean value `False`
3. if a list, check that the list is a one-length list with the exact value `False`

The first 2 steps would raise the custom exception, but the 3rd would raise an exception for the value-inside-the-list, not for the overall dictionary.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

With an otherwise invalid configuration, iterate through the following values for `'run'`: https://github.com/FCP-INDI/C-PAC/blob/e34beb8b7e10cd5116f5848ed6f0652b91c06ee1/CPAC/pipeline/test/test_schema_validation.py#L9

If forkable-truthy ( https://github.com/FCP-INDI/C-PAC/blob/e34beb8b7e10cd5116f5848ed6f0652b91c06ee1/CPAC/pipeline/test/test_schema_validation.py#L23 ), check for "func#motion_estimate_filter_valid_options" (the end of the reference URL) in the error message.

Otherwise, validate without exeception.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop_v1.8_convergence` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
