### PR TITLE
Use AFNI to compute DVARS

### DIFF
--- a/CPAC/generate_motion_statistics/__init__.py
+++ b/CPAC/generate_motion_statistics/__init__.py
@@ -3,7 +3,8 @@ from .generate_motion_statistics import (motion_power_statistics,
                                         calculate_FD_J,
                                         gen_motion_parameters,
                                         gen_power_parameters,
-                                        calculate_DVARS)
+                                        calculate_DVARS,
+                                        ImageTo1D)
 
 __all__ = [
     'motion_power_statistics',
@@ -11,5 +12,6 @@ __all__ = [
     'calculate_FD_J',
     'gen_motion_parameters',
     'gen_power_parameters',
-    'calculate_DVARS'
+    'calculate_DVARS',
+    'ImageTo1D'
 ]

--- a/CPAC/generate_motion_statistics/test/test_dvars.py
+++ b/CPAC/generate_motion_statistics/test/test_dvars.py
@@ -1,0 +1,30 @@
+
+import os
+import numpy as np
+from CPAC.generate_motion_statistics import ImageTo1D, calculate_DVARS
+
+np.random.seed(10)
+
+def test_dvars():
+
+    os.chdir('/tmp')
+
+    img_data = np.random.uniform(-3000, 3000, (30, 35, 30, 120))
+    img = nb.Nifti1Image(img_data, np.eye(4))
+    nb.save(img, 'dvars_data.nii.gz')
+
+    mask_data = np.ones((30, 35, 30))
+    mask = nb.Nifti1Image(mask_data, np.eye(4))
+    nb.save(mask, 'dvars_mask.nii.gz')
+
+    node = ImageTo1D(method='dvars')
+    node.inputs.in_file = 'dvars_data.nii.gz'
+    node.inputs.mask = 'dvars_mask.nii.gz'
+    node.run()
+
+    calculate_DVARS('dvars_data.nii.gz', 'dvars_mask.nii.gz')
+
+    afni_result = np.loadtxt('dvars_data_3DtoT1.1D')[1:]
+    python_result = np.loadtxt('DVARS.txt')
+
+    assert np.close(afni_result, python_result, 1e-4)

--- a/dev/docker_data/required_afni_pkgs.txt
+++ b/dev/docker_data/required_afni_pkgs.txt
@@ -20,6 +20,7 @@ linux_openmp_64/3drefit
 linux_openmp_64/3dresample
 linux_openmp_64/3dROIstats
 linux_openmp_64/3dSkullStrip
+linux_openmp_64/3dTto1D
 linux_openmp_64/3dTcat
 linux_openmp_64/3dTcorr1D
 linux_openmp_64/3dTcorrelate


### PR DESCRIPTION
## Fixes

Given the strange problem with DVARS, I've implemented its computation using AFNI 3dTto1d. The problem vanished!
Fixes #1301 by @sgiavasis 

## Description
Instead of relying on Python code, this PR replaces the current DVARS code with an interface for AFNI's implementation of DVARS. Hopefully, it is more optimized given it is compiled etc. The pipeline does not hang anymore.

## Tests
Yes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
