### PR TITLE
Fix: a tale of a bug and a bad fix - the DVARS issue

### DIFF
--- a/CPAC/generate_motion_statistics/generate_motion_statistics.py
+++ b/CPAC/generate_motion_statistics/generate_motion_statistics.py
@@ -547,7 +547,7 @@ def DVARS_strip_t0(file_1D):
     x = np.loadtxt(file_1D)
     x = x[1:]
     np.savetxt('dvars_strip.1D', x)
-    return os.path.abs('dvars_strip.1D')
+    return os.path.abspath('dvars_strip.1D')
 
 
 class ImageTo1DInputSpec(AFNICommandInputSpec):

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,6 +204,7 @@ ENV PATH=/usr/local/miniconda/bin:$PATH
 
 # install conda dependencies
 RUN conda update conda -y && \
+    conda install nomkl && \
     conda install -y  \
         blas \
         cython \

--- a/variant-lite.Dockerfile
+++ b/variant-lite.Dockerfile
@@ -201,6 +201,7 @@ ENV PATH=/usr/local/miniconda/bin:$PATH
 
 # install conda dependencies
 RUN conda update conda -y && \
+    conda install nomkl && \
     conda install -y  \
         blas \
         cython \


### PR DESCRIPTION
## Fixes

Playing around with the Docker container, trying to understand the DVARS issue (#1301), I got to a point in which a python interpreter console started to throw me errors when I've imported NumPy, complaining about problems loading the Intel MKL libs.

So, the DVARS was stucking the pipeline after raising a segfault. The weird thing is that, for ABIDE I, the problem was not present:
```
    s3://fcp-indi/data/Projects/ABIDE/RawDataBIDS/NYU/ \
    --n_cpus 8 \
    --mem_gb 16 \
    --output_dir s3://cnl-cpac-batch/abide-8.16 -- 0051159
```

however, for CORR and Rockland, the problem presents itself as described in every execution:
```
    s3://fcp-indi/data/Projects/RocklandSample/RawDataBIDSLatest \
    --n_cpus 8 \
    --mem_gb 16 \
    --output_dir s3://cnl-cpac-batch/rockland-8.16 -- A00085066
```
and
```
    s3://fcp-indi/data/Projects/CORR/RawDataBIDS/NKI_TRT/ \
    --n_cpus 8 \
    --mem_gb 16 \
    --output_dir s3://cnl-cpac-batch/corr-8.16 -- 2475376
```

One hypothesis is that the problem is the image resolutions, so to have this execution difference. Anyway, the solution I've found was to force conda to not use MKL, but to rely on openblas. From there, C-PAC works normally for me.

All the tests were run in the last C-PAC docker image (1.8.0), in AWS Batch.

ALSO there was a bug on my AFNI DVARS implementation, small stuff. Just calling `os.path.abspath` by the wrong name.

Fixes #1301 by @sgiavasis 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
