### PR TITLE
Fix/1.8.1 modularity fixes 1

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -600,8 +600,8 @@ def freesurfer_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 def anatomical_init(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "anatomical_init",
-     "config": "None",
-     "switch": "None",
+     "config": ["anatomical_preproc"],
+     "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
      "inputs": ["T1w"],
@@ -824,7 +824,7 @@ def brain_mask_afni(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_afni",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "3dSkullStrip",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
@@ -840,7 +840,7 @@ def brain_mask_acpc_afni(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_acpc_afni",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "3dSkullStrip",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
@@ -861,7 +861,7 @@ def brain_mask_fsl(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_fsl",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "BET",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
@@ -877,7 +877,7 @@ def brain_mask_acpc_fsl(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_acpc_fsl",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "BET",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
@@ -898,7 +898,7 @@ def brain_mask_niworkflows_ants(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_niworkflows_ants",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "niworkflows-ants",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
@@ -915,7 +915,7 @@ def brain_mask_acpc_niworkflows_ants(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_acpc_niworkflows_ants",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "niworkflows-ants",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
@@ -937,7 +937,7 @@ def brain_mask_unet(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_unet",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "UNet",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"],
@@ -956,7 +956,7 @@ def brain_mask_acpc_unet(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_acpc_unet",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "UNet",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"],
@@ -980,7 +980,7 @@ def brain_mask_freesurfer(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_freesurfer",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "Freesurfer",
      "inputs": ["space-T1w_desc-brain_mask",
@@ -999,7 +999,7 @@ def brain_mask_acpc_freesurfer(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_mask_acpc_freesurfer",
      "config": ["anatomical_preproc", "brain_extraction"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "using",
      "option_val": "Freesurfer",
      "inputs": ["space-T1w_desc-brain_mask",
@@ -1020,8 +1020,8 @@ def brain_mask_acpc_freesurfer(wf, cfg, strat_pool, pipe_num, opt=None):
 def brain_extraction(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "brain_extraction",
-     "config": "None",
-     "switch": "None",
+     "config": ["anatomical_preproc", "brain_extraction"],
+     "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
      "inputs": [(["desc-preproc_T1w", "desc-reorient_T1w", "T1w"],

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -932,8 +932,8 @@ def func_slice_time(wf, cfg, strat_pool, pipe_num, opt=None):
 def func_reorient(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "func_reorient",
-     "config": "None",
-     "switch": "None",
+     "config": ["functional_preproc"],
+     "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
      "inputs": [["desc-preproc_bold", "bold"]],

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -1979,7 +1979,7 @@ def nuisance_regression_complete(wf, cfg, strat_pool, pipe_num, opt=None):
     Node Block:
     {"name": "nuisance_regression",
      "config": ["nuisance_corrections", "2-nuisance_regression"],
-     "switch": "create_regressors",
+     "switch": ["create_regressors"],
      "option_key": "Regressors",
      "option_val": "USER-DEFINED",
      "inputs": [(["desc-cleaned_bold", "desc-brain_bold", "desc-motion_bold",

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -1979,7 +1979,7 @@ def nuisance_regression_complete(wf, cfg, strat_pool, pipe_num, opt=None):
     Node Block:
     {"name": "nuisance_regression",
      "config": ["nuisance_corrections", "2-nuisance_regression"],
-     "switch": "None",
+     "switch": "create_regressors",
      "option_key": "Regressors",
      "option_val": "USER-DEFINED",
      "inputs": [(["desc-cleaned_bold", "desc-brain_bold", "desc-motion_bold",

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -772,7 +772,7 @@ class ResourcePool(object):
         if not cfg.pipeline_setup['output_directory']['write_debugging_outputs']:
             excl.append('motion-basefile')
             substring_excl.append(['desc-reginput', 'bold'])
-            
+
         if not cfg.pipeline_setup['output_directory']['write_func_outputs']:
             avail_bolds = []
             for resource in self.rpool.keys():
@@ -833,6 +833,7 @@ class ResourcePool(object):
                 for item in bool_list:
                     if not item:
                         break
+                else:
                     drop = True
                 if drop:
                     break
@@ -906,6 +907,7 @@ class ResourcePool(object):
                 for item in bool_list:
                     if not item:
                         break
+                else:
                     drop = True
                 if drop:
                     break
@@ -1378,6 +1380,7 @@ def ingress_raw_func_data(wf, rpool, cfg, data_paths, unique_id, part_id,
 def ingress_output_dir(cfg, rpool, unique_id, creds_path=None):
 
     out_dir = cfg.pipeline_setup['output_directory']['path']
+    source = False
 
     if cfg.pipeline_setup['output_directory']['pull_source_once']:
         if os.path.isdir(cfg.pipeline_setup['output_directory']['path']):
@@ -1385,6 +1388,7 @@ def ingress_output_dir(cfg, rpool, unique_id, creds_path=None):
                 if cfg.pipeline_setup['output_directory']['source_outputs_dir']:
                     out_dir = cfg.pipeline_setup['output_directory'][
                         'source_outputs_dir']
+                    source = True
                 else:
                     out_dir = cfg.pipeline_setup['output_directory']['path']
             else:
@@ -1393,28 +1397,40 @@ def ingress_output_dir(cfg, rpool, unique_id, creds_path=None):
             if cfg.pipeline_setup['output_directory']['source_outputs_dir']:
                 out_dir = cfg.pipeline_setup['output_directory'][
                     'source_outputs_dir']
+                source = True
     else:
         if cfg.pipeline_setup['output_directory']['source_outputs_dir']:
             out_dir = cfg.pipeline_setup['output_directory'][
                 'source_outputs_dir']
+            source = True
         else:
             out_dir = cfg.pipeline_setup['output_directory']['path']
 
-    if os.path.isdir(out_dir):
-        if not os.listdir(out_dir):
+    if not source:
+        if os.path.isdir(out_dir):
+            if not os.listdir(out_dir):
+                print(f"\nOutput directory {out_dir} does not exist yet, "
+                      f"initializing.")
+                return rpool
+        else:
             print(f"\nOutput directory {out_dir} does not exist yet, "
                   f"initializing.")
             return rpool
+            
+        cpac_dir = os.path.join(out_dir,
+                                f'cpac_{cfg.pipeline_setup["pipeline_name"]}',
+                                unique_id)
     else:
-        print(f"\nOutput directory {out_dir} does not exist yet, "
-              f"initializing.")
-        return rpool
+        if os.path.isdir(out_dir):
+            if not os.listdir(out_dir):
+                raise Exception(f"\nSource directory {out_dir} does not exist!")
+        
+        cpac_dir = os.path.join(out_dir,
+                                unique_id)
 
-    print(f"\nPulling outputs from {out_dir}.\n")
+    print(f"\nPulling outputs from {cpac_dir}.\n")
 
-    cpac_dir = os.path.join(out_dir,
-                            f'cpac_{cfg.pipeline_setup["pipeline_name"]}',
-                            unique_id)
+
     cpac_dir_anat = os.path.join(cpac_dir, 'anat')
     cpac_dir_func = os.path.join(cpac_dir, 'func')
 
@@ -1465,6 +1481,7 @@ def ingress_output_dir(cfg, rpool, unique_id, creds_path=None):
         #                    'session in this directory?\n\nDirectory: '
         #                    f'{cpac_dir_anat}\nFilepath: {filepath}\n\n')
         suffix = data_label.split('_')[-1]
+        desc_val = None
         for tag in data_label.split('_'):
             if 'desc-' in tag:
                 desc_val = tag
@@ -1479,29 +1496,31 @@ def ingress_output_dir(cfg, rpool, unique_id, creds_path=None):
                             f'{filepath}.\n\n')
 
         json_info = read_json(jsonpath)
-        if 'CpacProvenance' in json_info:
-            # it's a C-PAC output, let's check for pipe_idx/strat integer
-            # suffixes in the desc- entries.
-            only_desc = str(desc_val)
-            
-            if only_desc[-1].isdigit():
-                for idx in range(0, 3):
-                    # let's stop at 3, please don't run >999 strategies okay?
-                    if only_desc[-1].isdigit():
-                        only_desc = only_desc[:-1]
-            
-                if only_desc[-1] == '-':
-                    only_desc = only_desc.rstrip('-')
-                else:
-                    raise Exception('\n[!] Something went wrong with either '
-                                    'reading in the output directory or when '
-                                    'it was written out previously.\n\nGive '
-                                    'this to your friendly local C-PAC '
-                                    f'developer:\n\n{unique_data_label}\n')
 
-                # remove the integer at the end of the desc-* variant, we will get
-                # the unique pipe_idx from the CpacProvenance below
-                data_label = data_label.replace(desc_val, only_desc)
+        if 'CpacProvenance' in json_info:
+            if desc_val:
+                # it's a C-PAC output, let's check for pipe_idx/strat integer
+                # suffixes in the desc- entries.
+                only_desc = str(desc_val)
+            
+                if only_desc[-1].isdigit():
+                    for idx in range(0, 3):
+                        # let's stop at 3, please don't run >999 strategies okay?
+                        if only_desc[-1].isdigit():
+                            only_desc = only_desc[:-1]
+            
+                    if only_desc[-1] == '-':
+                        only_desc = only_desc.rstrip('-')
+                    else:
+                        raise Exception('\n[!] Something went wrong with either '
+                                        'reading in the output directory or when '
+                                        'it was written out previously.\n\nGive '
+                                        'this to your friendly local C-PAC '
+                                        f'developer:\n\n{unique_data_label}\n')
+
+                    # remove the integer at the end of the desc-* variant, we will get
+                    # the unique pipe_idx from the CpacProvenance below
+                    data_label = data_label.replace(desc_val, only_desc)
 
             # preserve cpac provenance/pipe_idx
             pipe_idx = rpool.generate_prov_string(json_info['CpacProvenance'])

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -253,6 +253,7 @@ schema = Schema({
                 'be populated if \'run\' is not set to Off',
         ),
         'brain_extraction': {
+            'run': bool,
             'using': [In(valid_options['brain_extraction']['using'])],
             'AFNI-3dSkullStrip': {
                 'mask_vol': bool,
@@ -594,6 +595,7 @@ schema = Schema({
         },
         '2-nuisance_regression': {
             'run': forkable,
+            'create_regressors': bool,
             'Regressors': Maybe([Schema({
                 'Name': Required(str),
                 'Censor': {

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -1966,9 +1966,9 @@ def coregistration_prep_vol(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "coregistration_prep_vol",
      "config": ["registration_workflows", "functional_registration",
-                "coregistration", "func_input_prep"],
-     "switch": "None",
-     "option_key": "input",
+                "coregistration"],
+     "switch": ["run"],
+     "option_key": ["func_input_prep", "input"],
      "option_val": "Selected_Functional_Volume",
      "inputs": ["desc-brain_bold"],
      "outputs": ["desc-reginput_bold"]}
@@ -1998,9 +1998,9 @@ def coregistration_prep_mean(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "coregistration_prep_mean",
      "config": ["registration_workflows", "functional_registration",
-                "coregistration", "func_input_prep"],
-     "switch": "None",
-     "option_key": "input",
+                "coregistration"],
+     "switch": ["run"],
+     "option_key": ["func_input_prep", "input"],
      "option_val": "Mean_Functional",
      "inputs": ["desc-mean_bold"],
      "outputs": ["desc-reginput_bold"]}

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -226,6 +226,8 @@ anatomical_preproc:
     T1w_brain_ACPC_template: None
 
   brain_extraction:
+  
+    run: On
 
     # using: ['3dSkullStrip', 'BET', 'UNet', 'niworkflows-ants']
     # this is a fork option
@@ -1037,6 +1039,9 @@ nuisance_corrections:
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+    
+    # switch to Off if nuisance regression is off and you don't want to write out the regressors
+    create_regressors: On
 
     # Select which nuisance signal corrections to apply
     Regressors:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1489 by @SucyLi 

## Description
Collection of modularity and convenience updates and fixes.

- Fixes output directory ingressing.
- Allows turning `Off`:
  - Anatomical initialization (deoblique & reorient)
  - T1 brain masking
  - BOLD/functional initialization (deoblique & reorient)
  - Coregistration input data prep (shouldn't run if coregistration is off)
  - Nuisance regressor creation
    - (convenience measure so users don't have to delete their `Regressors:` field just to avoid it)

## Technical details
- Note, the ability to turn off node blocks that every CPAC pipeline traditionally always uses (like deoblique/reorient) is meant to move closer to making it easy and seamless to run any node blocks either alone or in any custom order.
- New default pipeline config additions do not/should not impact behavior.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
