### PR TITLE
Multiple run switches and EPI-template registration cleanup

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1178,8 +1178,8 @@ def motion_estimate_filter(wf, cfg, strat_pool, pipe_num, opt=None):
 def calc_motion_stats(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "calc_motion_stats",
-     "config": "None",
-     "switch": "None",
+     "config": ["functional_preproc"],
+     "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
      "inputs": [("desc-motion_bold",
@@ -1754,7 +1754,7 @@ def func_mean(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "func_mean",
      "config": ["functional_preproc"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
      "inputs": ["desc-brain_bold"],
@@ -1781,7 +1781,7 @@ def func_normalize(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "func_normalize",
      "config": ["functional_preproc"],
-     "switch": "None",
+     "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
      "inputs": [("desc-brain_bold",

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -1786,20 +1786,82 @@ def ICA_AROMA_ANTsreg(wf, cfg, strat_pool, pipe_num, opt=None):
     return (wf, outputs)
 
 
-def ICA_AROMA_EPIreg(wf, cfg, strat_pool, pipe_num, opt=None):
+def ICA_AROMA_FSLEPIreg(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     Node Block:
-    {"name": "ICA_AROMA_EPIreg",
-     "config": ["nuisance_corrections", "1-ICA-AROMA"],
-     "switch": ["run"],
+    {"name": "ICA_AROMA_FSLEPIreg",
+     "config": "None",
+     "switch": [["nuisance_corrections", "1-ICA-AROMA", "run"],
+                ["registration_workflows", "functional_registration",
+                 "EPI_registration", "run"]],
+     "option_key": "None",
+     "option_val": "None",
+     "inputs": [["desc-brain_bold", "desc-motion_bold",
+                 "desc-preproc_bold", "bold"],
+                "from-bold_to-EPItemplate_mode-image_xfm"],
+     "outputs": ["desc-cleaned_bold"]}
+    '''
+
+    xfm_prov = strat_pool.get_cpac_provenance('from-bold_to-EPItemplate_mode-image_xfm')
+    reg_tool = check_prov_for_regtool(xfm_prov)
+
+    if reg_tool != 'fsl':
+        return (wf, None)
+
+    aroma_preproc = create_aroma(tr=None, wf_name=f'create_aroma_{pipe_num}')
+
+    aroma_preproc.inputs.params.denoise_type = \
+        cfg.nuisance_corrections['1-ICA-AROMA']['denoising_type']
+
+    node, out = strat_pool.get_data(["desc-brain_bold", "desc-motion_bold",
+                                     "desc-preproc_bold", "bold"])
+    wf.connect(node, out, aroma_preproc, 'inputspec.denoise_file')
+
+    node, out = strat_pool.get_data("from-bold_to-EPItemplate_mode-image_xfm")
+    wf.connect(node, out, aroma_preproc, 'inputspec.fnirt_warp_file')
+
+    if cfg.nuisance_corrections['1-ICA-AROMA']['denoising_type'] == 'nonaggr':
+        node, out = (aroma_preproc, 'outputspec.nonaggr_denoised_file')
+    elif cfg.nuisance_corrections['1-ICA-AROMA']['denoising_type'] == 'aggr':
+        node, out = (aroma_preproc, 'outputspec.aggr_denoised_file')
+
+    outputs = {
+        'desc-cleaned_bold': (node, out)
+    }
+
+    return (wf, outputs)
+    
+    
+def ICA_AROMA_ANTsEPIreg(wf, cfg, strat_pool, pipe_num, opt=None):
+    '''
+    Node Block:
+    {"name": "ICA_AROMA_ANTsEPIreg",
+     "config": "None",
+     "switch": [["nuisance_corrections", "1-ICA-AROMA", "run"],
+                ["registration_workflows", "functional_registration",
+                 "EPI_registration", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [(["desc-brain_bold", "desc-motion_bold",
                   "desc-preproc_bold", "bold"],
-                 "from-bold_to-template_mode-image_xfm"),
+                 "desc-mean_bold",
+                 "from-bold_to-EPItemplate_mode-image_xfm",
+                 "from-EPItemplate_to-bold_mode-image_xfm"),
                 "EPI_template"],
      "outputs": ["desc-cleaned_bold"]}
     '''
+
+    xfm_prov = strat_pool.get_cpac_provenance(
+        'from-bold_to-EPItemplate_mode-image_xfm')
+    reg_tool = check_prov_for_regtool(xfm_prov)
+
+    if reg_tool != 'ants':
+        return (wf, None)
+        
+    num_cpus = cfg.pipeline_setup['system_config'][
+        'max_cores_per_participant']
+
+    num_ants_cores = cfg.pipeline_setup['system_config']['num_ants_threads']
 
     aroma_preproc = create_aroma(tr=None, wf_name=f'create_aroma_{pipe_num}')
     aroma_preproc.inputs.params.denoise_type = \
@@ -1812,13 +1874,29 @@ def ICA_AROMA_EPIreg(wf, cfg, strat_pool, pipe_num, opt=None):
 
     wf.connect(node, out, aroma_preproc, 'inputspec.denoise_file')
 
+    apply_xfm = apply_transform(f'ICA-AROMA_ANTs_EPItemplate_to_bold_{pipe_num}',
+                                reg_tool=reg_tool, time_series=True,
+                                num_cpus=num_cpus,
+                                num_ants_cores=num_ants_cores)
+    apply_xfm.inputs.inputspec.interpolation = cfg.registration_workflows[
+            'functional_registration']['func_registration_to_template'][
+            'ANTs_pipelines']['interpolation']
+
     if cfg.nuisance_corrections['1-ICA-AROMA']['denoising_type'] == 'nonaggr':
         node, out = (aroma_preproc, 'outputspec.nonaggr_denoised_file')
     elif cfg.nuisance_corrections['1-ICA-AROMA']['denoising_type'] == 'aggr':
         node, out = (aroma_preproc, 'outputspec.aggr_denoised_file')
 
+    wf.connect(node, out, apply_xfm, 'inputspec.input_image')
+
+    node, out = strat_pool.get_data("desc-mean_bold")
+    wf.connect(node, out, apply_xfm, 'inputspec.reference')
+
+    node, out = strat_pool.get_data('from-EPItemplate_to-bold_mode-image_xfm')
+    wf.connect(node, out, apply_xfm, 'inputspec.transform')
+    
     outputs = {
-        'desc-cleaned_bold': (node, out)
+        'desc-cleaned_bold': (apply_xfm, 'outputspec.output_image')
     }
 
     return (wf, outputs)
@@ -1827,9 +1905,12 @@ def ICA_AROMA_EPIreg(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_T1w(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_T1w",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_anatomical_brain_mask"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "create_regressors"],
+                ["nuisance_corrections", "2-nuisance_regression",
+                "regressor_masks", "erode_anatomical_brain_mask",
+                "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [("space-T1w_desc-brain_mask",
@@ -1861,9 +1942,11 @@ def erode_mask_T1w(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_CSF(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_CSF",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_csf"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "create_regressors"],
+                ["nuisance_corrections", "2-nuisance_regression",
+                "regressor_masks", "erode_csf", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [(["label-CSF_desc-preproc_mask",
@@ -1901,9 +1984,11 @@ def erode_mask_CSF(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_GM(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_GM",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_gm"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "create_regressors"],
+                ["nuisance_corrections", "2-nuisance_regression",
+                "regressor_masks", "erode_gm", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [["label-GM_desc-preproc",
@@ -1937,9 +2022,11 @@ def erode_mask_GM(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_WM(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_WM",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_wm"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "create_regressors"],
+                ["nuisance_corrections", "2-nuisance_regression",
+                "regressor_masks", "erode_wm", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [(["label-WM_desc-preproc_mask",
@@ -2176,9 +2263,12 @@ def nuisance_regression_complete(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_bold(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_bold",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_anatomical_brain_mask"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "regressor_masks", "erode_anatomical_brain_mask",
+                 "run"],
+                ["registration_workflows", "functional_registration",
+                 "EPI_registration", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [("space-bold_desc-brain_mask",
@@ -2210,9 +2300,11 @@ def erode_mask_bold(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_boldCSF(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_boldCSF",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_csf"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "regressor_masks", "erode_csf", "run"],
+                ["registration_workflows", "functional_registration",
+                 "EPI_registration", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [(["space-bold_label-CSF_desc-preproc_mask",
@@ -2250,9 +2342,11 @@ def erode_mask_boldCSF(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_boldGM(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_boldGM",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_gm"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "regressor_masks", "erode_gm", "run"],
+                ["registration_workflows", "functional_registration",
+                 "EPI_registration", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [["space-bold_label-GM_desc-preproc",
@@ -2286,9 +2380,11 @@ def erode_mask_boldGM(wf, cfg, strat_pool, pipe_num, opt=None):
 def erode_mask_boldWM(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "erode_mask_boldWM",
-     "config": ["nuisance_corrections", "2-nuisance_regression",
-                "regressor_masks", "erode_wm"],
-     "switch": ["run"],
+     "config": "None",
+     "switch": [["nuisance_corrections", "2-nuisance_regression",
+                 "regressor_masks", "erode_wm", "run"],
+                ["registration_workflows", "functional_registration",
+                 "EPI_registration", "run"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [(["space-bold_label-WM_desc-preproc_mask",
@@ -2328,7 +2424,7 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     Node Block:
     {"name": "nuisance_regression_EPItemplate",
      "config": ["nuisance_corrections", "2-nuisance_regression"],
-     "switch": "None",
+     "switch": ["create_regressors"],
      "option_key": "Regressors",
      "option_val": "USER-DEFINED",
      "inputs": [(["desc-cleaned_bold", "desc-brain_bold", "desc-motion_bold",
@@ -2345,8 +2441,8 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
                   "space-bold_label-WM_mask"],
                  ["space-bold_label-GM_desc-eroded_mask", "space-bold_label-GM_desc-preproc_mask",
                   "space-bold_label-GM_mask"],
-                 "from-template_to-bold_mode-image_desc-linear_xfm",
-                 "from-bold_to-template_mode-image_desc-linear_xfm"),
+                 "from-EPItemplate_to-bold_mode-image_desc-linear_xfm",
+                 "from-bold_to-EPItemplate_mode-image_desc-linear_xfm"),
                 "lateral_ventricles_mask",
                 "TR"],
      "outputs": ["regressors",
@@ -2354,7 +2450,7 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
-        'from-template_to-bold_mode-image_desc-linear_xfm')
+        'from-EPItemplate_to-bold_mode-image_desc-linear_xfm')
     reg_tool = check_prov_for_regtool(xfm_prov)
 
     use_ants = reg_tool == 'ants'
@@ -2400,7 +2496,7 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
         wf.connect(node, out,
                    regressors, 'inputspec.lat_ventricles_mask_file_path')
 
-    node, out = strat_pool.get_data('from-bold_to-template_mode-image_desc-linear_xfm')
+    node, out = strat_pool.get_data('from-bold_to-EPItemplate_mode-image_desc-linear_xfm')
     wf.connect(node, out, regressors, 'inputspec.func_to_anat_linear_xfm_file_path')
 
     # invert func2anat matrix to get anat2func_linear_xfm
@@ -2413,10 +2509,10 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(anat2func_linear_xfm, 'out_file',
                regressors, 'inputspec.anat_to_func_linear_xfm_file_path')
 
-    node, out = strat_pool.get_data('from-template_to-bold_mode-image_desc-linear_xfm')
+    node, out = strat_pool.get_data('from-EPItemplate_to-bold_mode-image_desc-linear_xfm')
     wf.connect(node, out, regressors, 'inputspec.mni_to_anat_linear_xfm_file_path')
 
-    node, out = strat_pool.get_data('from-bold_to-template_mode-image_desc-linear_xfm')
+    node, out = strat_pool.get_data('from-bold_to-EPItemplate_mode-image_desc-linear_xfm')
     wf.connect(node, out, regressors, 'inputspec.anat_to_mni_linear_xfm_file_path')
 
     node, out = strat_pool.get_data('movement-parameters')

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1009,7 +1009,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
             [register_ANTs_EPI_to_template, register_FSL_EPI_to_template]
         ]
         pipeline_blocks += EPI_reg_blocks
-        
+
     if 'EPI_Template' in cfg.segmentation['tissue_segmentation'][
         'Template_Based']['template_for_segmentation']:
         if not rpool.check_rpool('space-bold_label-CSF_mask') or \

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -437,6 +437,7 @@ schema = Schema({
             },
             'func_registration_to_template': {
                 'run': bool,
+                'run_EPI': bool,
                 'output_resolution': {
                     'func_preproc_outputs': All(
                         str, Match(resolution_regex)),

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -389,7 +389,7 @@ schema = Schema({
                 },
             },
             'applywarp': {
-                'using': In({'ANTS', 'FSL'}),
+                'using': In({'ANTS', 'FSL', 'ABCD-FSL'}),
             },
         },
         'functional_registration': {

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -988,7 +988,7 @@ def create_wf_calculate_ants_warp(
 
 
 def FSL_registration_connector(wf_name, cfg, orig="T1w", opt=None,
-                               symmetric=False):
+                               symmetric=False, template="T1w"):
 
     wf = pe.Workflow(name=wf_name)
 
@@ -1009,6 +1009,10 @@ def FSL_registration_connector(wf_name, cfg, orig="T1w", opt=None,
     if symmetric:
         sym = 'sym'
         symm = '_symmetric'
+        
+    tmpl = ''
+    if template == 'EPI':
+        tmpl = 'EPI'
 
     if opt == 'FSL' or opt == 'FSL-linear':
 
@@ -1046,13 +1050,13 @@ def FSL_registration_connector(wf_name, cfg, orig="T1w", opt=None,
                    write_invlin_composite_xfm, 'premat')
 
         outputs = {
-            f'space-{sym}template_desc-brain_{orig}': (
+            f'space-{sym}{tmpl}template_desc-brain_{orig}': (
                 flirt_reg_anat_mni, 'outputspec.output_brain'),
-            f'from-{orig}_to-{sym}template_mode-image_desc-linear_xfm': (
+            f'from-{orig}_to-{sym}{tmpl}template_mode-image_desc-linear_xfm': (
                 write_lin_composite_xfm, 'out_file'),
-            f'from-{sym}template_to-{orig}_mode-image_desc-linear_xfm': (
+            f'from-{sym}{tmpl}template_to-{orig}_mode-image_desc-linear_xfm': (
                 write_invlin_composite_xfm, 'out_file'),
-            f'from-{orig}_to-{sym}template_mode-image_xfm': (
+            f'from-{orig}_to-{sym}{tmpl}template_mode-image_xfm': (
                 write_lin_composite_xfm, 'out_file')
         }
 
@@ -1086,9 +1090,9 @@ def FSL_registration_connector(wf_name, cfg, orig="T1w", opt=None,
 
         # NOTE: this is an UPDATE because of the opt block above
         added_outputs = {
-            f'space-{sym}template_desc-brain_{orig}': (
+            f'space-{sym}{tmpl}template_desc-brain_{orig}': (
                 fnirt_reg_anat_mni, 'outputspec.output_brain'),
-            f'from-{orig}_to-{sym}template_mode-image_xfm': (
+            f'from-{orig}_to-{sym}{tmpl}template_mode-image_xfm': (
                 fnirt_reg_anat_mni, 'outputspec.nonlinear_xfm')
         }
         outputs.update(added_outputs)
@@ -1096,8 +1100,8 @@ def FSL_registration_connector(wf_name, cfg, orig="T1w", opt=None,
     return (wf, outputs)
 
 
-def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
-                                symmetric=False):
+def ANTs_registration_connector(wf_name, cfg, params, orig="T1w",
+                                symmetric=False, template="T1w"):
 
     wf = pe.Workflow(name=wf_name)
 
@@ -1117,6 +1121,10 @@ def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
     if symmetric:
         sym = 'sym'
         symm = '_symmetric'
+        
+    tmpl = ''
+    if template == 'EPI':
+        tmpl = 'EPI'
 
     if params is None:
         err_msg = '\n\n[!] C-PAC says: \nYou have selected ANTs as your ' \
@@ -1182,7 +1190,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
         mem_gb=1.5)
     write_composite_linear_xfm.inputs.print_out_composite_warp_file = True
     write_composite_linear_xfm.inputs.output_image = \
-        "from-T1w_to-template_mode-image_desc-linear_xfm.nii.gz"
+        "from-T1w_to-{sym}{tmpl}template_mode-image_desc-linear_xfm.nii.gz"
 
     wf.connect(inputNode, 'input_brain',
                write_composite_linear_xfm, 'input_image')
@@ -1228,7 +1236,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
         mem_gb=1.5)
     write_composite_invlinear_xfm.inputs.print_out_composite_warp_file = True
     write_composite_invlinear_xfm.inputs.output_image = \
-        "from-template_to-T1w_mode-image_desc-linear_xfm.nii.gz"
+        "from-{sym}{tmpl}template_to-T1w_mode-image_desc-linear_xfm.nii.gz"
 
     wf.connect(inputNode, 'reference_brain',
                write_composite_invlinear_xfm, 'input_image')
@@ -1290,7 +1298,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
         mem_gb=1.5)
     write_composite_xfm.inputs.print_out_composite_warp_file = True
     write_composite_xfm.inputs.output_image = \
-        "from-T1w_to-template_mode-image_xfm.nii.gz"
+        "from-T1w_to-{sym}{tmpl}template_mode-image_xfm.nii.gz"
 
     wf.connect(inputNode, 'input_brain', write_composite_xfm, 'input_image')
 
@@ -1340,7 +1348,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
         mem_gb=1.5)
     write_composite_inv_xfm.inputs.print_out_composite_warp_file = True
     write_composite_inv_xfm.inputs.output_image = \
-        "from-template_to-T1w_mode-image_xfm.nii.gz"
+        "from-{sym}{tmpl}template_to-T1w_mode-image_xfm.nii.gz"
 
     wf.connect(inputNode, 'reference_brain',
                write_composite_inv_xfm, 'input_image')
@@ -1399,17 +1407,17 @@ def ANTs_registration_connector(wf_name, cfg, params, orig='T1w',
                write_composite_inv_xfm, 'invert_transform_flags')
 
     outputs = {
-        f'from-{orig}_to-{sym}template_mode-image_xfm': (
+        f'from-{orig}_to-{sym}{tmpl}template_mode-image_xfm': (
             write_composite_xfm, 'output_image'),
-        f'from-{sym}template_to-{orig}_mode-image_xfm': (
+        f'from-{sym}{tmpl}template_to-{orig}_mode-image_xfm': (
             write_composite_inv_xfm, 'output_image'),
-        f'from-{orig}_to-{sym}template_mode-image_desc-linear_xfm': (
+        f'from-{orig}_to-{sym}{tmpl}template_mode-image_desc-linear_xfm': (
             write_composite_linear_xfm, 'output_image'),
-        f'from-{sym}template_to-{orig}_mode-image_desc-linear_xfm': (
+        f'from-{sym}{tmpl}template_to-{orig}_mode-image_desc-linear_xfm': (
             write_composite_invlinear_xfm, 'output_image'),
-        f'from-{orig}_to-{sym}template_mode-image_desc-nonlinear_xfm': (
+        f'from-{orig}_to-{sym}{tmpl}template_mode-image_desc-nonlinear_xfm': (
             ants_reg_anat_mni, 'outputspec.warp_field'),
-        f'from-{sym}template_to-{orig}_mode-image_desc-nonlinear_xfm': (
+        f'from-{sym}{tmpl}template_to-{orig}_mode-image_desc-nonlinear_xfm': (
             ants_reg_anat_mni, 'outputspec.inverse_warp_field')
     }
 
@@ -1575,7 +1583,7 @@ def register_FSL_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
 
     fsl, outputs = FSL_registration_connector('register_FSL_anat_to_'
                                               f'template_{pipe_num}', cfg,
-                                              'T1w', opt)
+                                              orig='T1w', opt=opt)
 
     fsl.inputs.inputspec.interpolation = cfg.registration_workflows[
         'anatomical_registration']['registration']['FSL-FNIRT'][
@@ -1645,8 +1653,8 @@ def register_symmetric_FSL_anat_to_template(wf, cfg, strat_pool, pipe_num,
 
     fsl, outputs = FSL_registration_connector('register_FSL_anat_to_'
                                               f'template_symmetric_'
-                                              f'{pipe_num}', cfg, 'T1w', opt,
-                                              symmetric=True)
+                                              f'{pipe_num}', cfg, orig='T1w',
+                                              opt=opt, symmetric=True)
 
     fsl.inputs.inputspec.interpolation = cfg.registration_workflows[
         'anatomical_registration']['registration']['FSL-FNIRT'][
@@ -1706,15 +1714,16 @@ def register_FSL_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
                  "space-bold_desc-brain_mask"),
                 "EPI_template",
                 "EPI_template_mask"],
-     "outputs": ["space-template_desc-brain_bold",
-                 "from-bold_to-template_mode-image_desc-linear_xfm",
-                 "from-template_to-bold_mode-image_desc-linear_xfm",
-                 "from-bold_to-template_mode-image_xfm"]}
+     "outputs": ["space-EPItemplate_desc-brain_bold",
+                 "from-bold_to-EPItemplate_mode-image_desc-linear_xfm",
+                 "from-EPItemplate_to-bold_mode-image_desc-linear_xfm",
+                 "from-bold_to-EPItemplate_mode-image_xfm"]}
     '''
 
     fsl, outputs = FSL_registration_connector('register_FSL_EPI_to_'
                                               f'template_{pipe_idx}', cfg,
-                                              opt, 'bold')
+                                              orig='bold', opt=opt,
+                                              template='EPI')
 
     fsl.inputs.inputspec.interpolation = cfg['registration_workflows'][
         'functional_registration']['EPI_registration']['FSL-FNIRT'][
@@ -1777,7 +1786,7 @@ def register_ANTs_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
 
     ants, outputs = ANTs_registration_connector('ANTS_T1_to_template_'
                                                 f'{pipe_num}', cfg,
-                                                params, 'T1w')
+                                                params, orig='T1w')
 
     ants.inputs.inputspec.interpolation = cfg.registration_workflows[
         'anatomical_registration']['registration']['ANTs']['interpolation']
@@ -1827,6 +1836,149 @@ def register_ANTs_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
     return (wf, outputs)
 
 
+def register_symmetric_ANTs_anat_to_template(wf, cfg, strat_pool, pipe_num,
+                                             opt=None):
+    '''
+    {"name": "register_symmetric_ANTs_anat_to_template",
+     "config": ["registration_workflows", "anatomical_registration"],
+     "switch": ["run"],
+     "option_key": ["registration", "using"],
+     "option_val": "ANTS",
+     "inputs": [(["desc-brain_T1w", "space-longitudinal_desc-brain_T1w"],
+                 ["space-T1w_desc-brain_mask",
+                  "space-longitudinal_desc-brain_mask"],
+                 ["desc-preproc_T1w", "desc-reorient_T1w", "T1w",
+                  "space-longitudinal_desc-reorient_T1w"]),
+                "T1w_template_symmetric",
+                "T1w_brain_template_symmetric",
+                "dilated_symmetric_brain_mask",
+                "label-lesion_mask"],
+     "outputs": ["space-symtemplate_desc-brain_T1w",
+                 "from-T1w_to-symtemplate_mode-image_desc-linear_xfm",
+                 "from-symtemplate_to-T1w_mode-image_desc-linear_xfm",
+                 "from-T1w_to-symtemplate_mode-image_desc-nonlinear_xfm",
+                 "from-symtemplate_to-T1w_mode-image_desc-nonlinear_xfm",
+                 "from-T1w_to-symtemplate_mode-image_xfm",
+                 "from-symtemplate_to-T1w_mode-image_xfm",
+                 "from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm",
+                 "from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm",
+                 "from-longitudinal_to-symtemplate_mode-image_desc-nonlinear_xfm",
+                 "from-symtemplate_to-longitudinal_mode-image_desc-nonlinear_xfm",
+                 "from-longitudinal_to-symtemplate_mode-image_xfm",
+                 "from-symtemplate_to-longitudinal_mode-image_xfm"]}
+    '''
+
+    params = cfg.registration_workflows['anatomical_registration'][
+        'registration']['ANTs']['T1_registration']
+
+    ants, outputs = ANTs_registration_connector('ANTS_T1_to_template_'
+                                                f'symmetric_{pipe_num}', cfg,
+                                                params, orig='T1w',
+                                                symmetric=True)
+
+    ants.inputs.inputspec.interpolation = cfg.registration_workflows[
+        'anatomical_registration']['registration']['ANTs']['interpolation']
+
+    connect, brain = \
+        strat_pool.get_data(['desc-brain_T1w',
+                             'space-longitudinal_desc-brain_T1w'],
+                            report_fetched=True)
+    node, out = connect
+    wf.connect(node, out, ants, 'inputspec.input_brain')
+
+    node, out = strat_pool.get_data('T1w_brain_template_symmetric')
+    wf.connect(node, out, ants, 'inputspec.reference_brain')
+
+    node, out = strat_pool.get_data(["desc-preproc_T1w",
+                                     "desc-reorient_T1w", "T1w",
+                                     "space-longitudinal_desc-reorient_T1w"])
+    wf.connect(node, out, ants, 'inputspec.input_head')
+
+    node, out = strat_pool.get_data('T1w_template_symmetric')
+    wf.connect(node, out, ants, 'inputspec.reference_head')
+
+    node, out = strat_pool.get_data(["space-T1w_desc-brain_mask",
+                                     "space-longitudinal_desc-brain_mask"])
+    wf.connect(node, out, ants, 'inputspec.input_mask')
+
+    node, out = strat_pool.get_data('dilated_symmetric_brain_mask')
+    wf.connect(node, out, ants, 'inputspec.reference_mask')
+
+    if strat_pool.check_rpool('label-lesion_mask'):
+        node, out = strat_pool.get_data('label-lesion_mask')
+        wf.connect(node, out, ants, 'inputspec.lesion_mask')
+
+    if 'space-longitudinal' in brain:
+        for key in outputs.keys():
+            if 'from-T1w' in key:
+                new_key = key.replace('from-T1w', 'from-longitudinal')
+                outputs[new_key] = outputs[key]
+                del outputs[key]
+            if 'to-T1w' in key:
+                new_key = key.replace('to-T1w', 'to-longitudinal')
+                outputs[new_key] = outputs[key]
+                del outputs[key]
+
+    return (wf, outputs)
+
+
+def register_ANTs_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
+    '''Directly register the mean functional to an EPI template. No T1w
+    involved.
+
+    Node Block:
+    {"name": "register_ANTs_EPI_to_template",
+     "config": ["registration_workflows", "functional_registration",
+                "EPI_registration"],
+     "switch": ["run"],
+     "option_key": "using",
+     "option_val": "ANTS",
+     "inputs": [(["desc-reginput_bold", "desc-mean_bold"],
+                 "space-bold_desc-brain_mask"),
+                "EPI_template",
+                "EPI_template_mask"],
+     "outputs": ["space-EPItemplate_desc-brain_bold",
+                 "from-bold_to-EPItemplate_mode-image_desc-linear_xfm",
+                 "from-EPItemplate_to-bold_mode-image_desc-linear_xfm",
+                 "from-bold_to-EPItemplate_mode-image_desc-nonlinear_xfm",
+                 "from-EPItemplate_to-bold_mode-image_desc-nonlinear_xfm",
+                 "from-bold_to-EPItemplate_mode-image_xfm",
+                 "from-EPItemplate_to-bold_mode-image_xfm"]}
+    '''
+
+    params = cfg.registration_workflows['functional_registration'][
+        'EPI_registration']['ANTs']['parameters']
+
+    ants, outputs = ANTs_registration_connector('ANTS_T1_to_EPI_template'
+                                                f'_{pipe_num}', cfg, params,
+                                                orig='bold', template='EPI')                                                
+
+    ants.inputs.inputspec.interpolation = cfg.registration_workflows[
+        'functional_registration']['EPI_registration']['ANTs'][
+        'interpolation']
+
+    node, out = strat_pool.get_data(['desc-reginput_bold', 'desc-mean_bold'])
+    wf.connect(node, out, ants, 'inputspec.input_brain')
+
+    node, out = strat_pool.get_data('EPI_template')
+    wf.connect(node, out, ants, 'inputspec.reference_brain')
+
+    node, out = strat_pool.get_data(['desc-reginput_bold', 'desc-mean_bold'])
+    wf.connect(node, out, ants, 'inputspec.input_head')
+
+    node, out = strat_pool.get_data('EPI_template')
+    wf.connect(node, out, ants, 'inputspec.reference_head')
+
+    node, out = strat_pool.get_data('space-bold_desc-brain_mask')
+    wf.connect(node, out, ants, 'inputspec.input_mask')
+
+    if strat_pool.check_rpool('EPI_template_mask'):
+        node, out = strat_pool.get_data('EPI_template_mask')
+        wf.connect(node, out, ants, 'inputspec.reference_mask')
+
+    return (wf, outputs)
+    
+    
 def applywarp_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "applywarp_anat_to_template",
@@ -2014,148 +2166,6 @@ def applywarp_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
             'space-template_desc-T1w_mask': (fsl_apply_warp_t1_brain_mask_to_template, 'out_file'),
             'from-T1w_to-template_mode-image_xfm': (merge_xfms, 'merged_file')
         }
-
-    return (wf, outputs)
-
-
-def register_symmetric_ANTs_anat_to_template(wf, cfg, strat_pool, pipe_num,
-                                             opt=None):
-    '''
-    {"name": "register_symmetric_ANTs_anat_to_template",
-     "config": ["registration_workflows", "anatomical_registration"],
-     "switch": ["run"],
-     "option_key": ["registration", "using"],
-     "option_val": "ANTS",
-     "inputs": [(["desc-brain_T1w", "space-longitudinal_desc-brain_T1w"],
-                 ["space-T1w_desc-brain_mask",
-                  "space-longitudinal_desc-brain_mask"],
-                 ["desc-preproc_T1w", "desc-reorient_T1w", "T1w",
-                  "space-longitudinal_desc-reorient_T1w"]),
-                "T1w_template_symmetric",
-                "T1w_brain_template_symmetric",
-                "dilated_symmetric_brain_mask",
-                "label-lesion_mask"],
-     "outputs": ["space-symtemplate_desc-brain_T1w",
-                 "from-T1w_to-symtemplate_mode-image_desc-linear_xfm",
-                 "from-symtemplate_to-T1w_mode-image_desc-linear_xfm",
-                 "from-T1w_to-symtemplate_mode-image_desc-nonlinear_xfm",
-                 "from-symtemplate_to-T1w_mode-image_desc-nonlinear_xfm",
-                 "from-T1w_to-symtemplate_mode-image_xfm",
-                 "from-symtemplate_to-T1w_mode-image_xfm",
-                 "from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm",
-                 "from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm",
-                 "from-longitudinal_to-symtemplate_mode-image_desc-nonlinear_xfm",
-                 "from-symtemplate_to-longitudinal_mode-image_desc-nonlinear_xfm",
-                 "from-longitudinal_to-symtemplate_mode-image_xfm",
-                 "from-symtemplate_to-longitudinal_mode-image_xfm"]}
-    '''
-
-    params = cfg.registration_workflows['anatomical_registration'][
-        'registration']['ANTs']['T1_registration']
-
-    ants, outputs = ANTs_registration_connector('ANTS_T1_to_template_'
-                                                f'symmetric_{pipe_num}', cfg,
-                                                params, 'T1w', True)
-
-    ants.inputs.inputspec.interpolation = cfg.registration_workflows[
-        'anatomical_registration']['registration']['ANTs']['interpolation']
-
-    connect, brain = \
-        strat_pool.get_data(['desc-brain_T1w',
-                             'space-longitudinal_desc-brain_T1w'],
-                            report_fetched=True)
-    node, out = connect
-    wf.connect(node, out, ants, 'inputspec.input_brain')
-
-    node, out = strat_pool.get_data('T1w_brain_template_symmetric')
-    wf.connect(node, out, ants, 'inputspec.reference_brain')
-
-    node, out = strat_pool.get_data(["desc-preproc_T1w",
-                                     "desc-reorient_T1w", "T1w",
-                                     "space-longitudinal_desc-reorient_T1w"])
-    wf.connect(node, out, ants, 'inputspec.input_head')
-
-    node, out = strat_pool.get_data('T1w_template_symmetric')
-    wf.connect(node, out, ants, 'inputspec.reference_head')
-
-    node, out = strat_pool.get_data(["space-T1w_desc-brain_mask",
-                                     "space-longitudinal_desc-brain_mask"])
-    wf.connect(node, out, ants, 'inputspec.input_mask')
-
-    node, out = strat_pool.get_data('dilated_symmetric_brain_mask')
-    wf.connect(node, out, ants, 'inputspec.reference_mask')
-
-    if strat_pool.check_rpool('label-lesion_mask'):
-        node, out = strat_pool.get_data('label-lesion_mask')
-        wf.connect(node, out, ants, 'inputspec.lesion_mask')
-
-    if 'space-longitudinal' in brain:
-        for key in outputs.keys():
-            if 'from-T1w' in key:
-                new_key = key.replace('from-T1w', 'from-longitudinal')
-                outputs[new_key] = outputs[key]
-                del outputs[key]
-            if 'to-T1w' in key:
-                new_key = key.replace('to-T1w', 'to-longitudinal')
-                outputs[new_key] = outputs[key]
-                del outputs[key]
-
-    return (wf, outputs)
-
-
-def register_ANTs_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
-    '''Directly register the mean functional to an EPI template. No T1w
-    involved.
-
-    Node Block:
-    {"name": "register_ANTs_EPI_to_template",
-     "config": ["registration_workflows", "functional_registration",
-                "EPI_registration"],
-     "switch": ["run"],
-     "option_key": "using",
-     "option_val": "ANTS",
-     "inputs": [(["desc-reginput_bold", "desc-mean_bold"],
-                 "space-bold_desc-brain_mask"),
-                "EPI_template",
-                "EPI_template_mask"],
-     "outputs": ["space-template_desc-brain_bold",
-                 "from-bold_to-template_mode-image_desc-linear_xfm",
-                 "from-template_to-bold_mode-image_desc-linear_xfm",
-                 "from-bold_to-template_mode-image_desc-nonlinear_xfm",
-                 "from-template_to-bold_mode-image_desc-nonlinear_xfm",
-                 "from-bold_to-template_mode-image_xfm",
-                 "from-template_to-bold_mode-image_xfm"]}
-    '''
-
-    params = cfg.registration_workflows['functional_registration'][
-        'EPI_registration']['ANTs']['parameters']
-
-    ants, outputs = ANTs_registration_connector('ANTS_T1_to_EPI_template'
-                                                f'_{pipe_num}', cfg, params,
-                                                'bold')
-
-    ants.inputs.inputspec.interpolation = cfg.registration_workflows[
-        'functional_registration']['EPI_registration']['ANTs'][
-        'interpolation']
-
-    node, out = strat_pool.get_data(['desc-reginput_bold', 'desc-mean_bold'])
-    wf.connect(node, out, ants, 'inputspec.input_brain')
-
-    node, out = strat_pool.get_data('EPI_template')
-    wf.connect(node, out, ants, 'inputspec.reference_brain')
-
-    node, out = strat_pool.get_data(['desc-reginput_bold', 'desc-mean_bold'])
-    wf.connect(node, out, ants, 'inputspec.input_head')
-
-    node, out = strat_pool.get_data('EPI_template')
-    wf.connect(node, out, ants, 'inputspec.reference_head')
-
-    node, out = strat_pool.get_data('space-bold_desc-brain_mask')
-    wf.connect(node, out, ants, 'inputspec.input_mask')
-
-    if strat_pool.check_rpool('EPI_template_mask'):
-        node, out = strat_pool.get_data('EPI_template_mask')
-        wf.connect(node, out, ants, 'inputspec.reference_mask')
 
     return (wf, outputs)
 
@@ -2483,8 +2493,8 @@ def warp_timeseries_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
      "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "T1_template",
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [(["desc-cleaned_bold", "desc-brain_bold",
                   "desc-motion_bold", "desc-preproc_bold", "bold"],
                  "from-bold_to-template_mode-image_xfm"),
@@ -2763,6 +2773,7 @@ def warp_timeseries_to_T1template_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
 
     return (wf, outputs)
 
+
 def warp_bold_mean_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     Node Block:
@@ -2770,8 +2781,8 @@ def warp_bold_mean_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
      "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "T1_template",
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [("desc-mean_bold",
                  "from-bold_to-template_mode-image_xfm"),
                 "T1w_brain_template_funcreg"],
@@ -2825,8 +2836,8 @@ def warp_bold_mask_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
      "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "T1_template",
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [("space-bold_desc-brain_mask",
                  "from-bold_to-template_mode-image_xfm"),
                 "T1w_brain_template_funcreg"],
@@ -2875,8 +2886,8 @@ def warp_deriv_mask_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
      "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "T1_template",
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [("space-bold_desc-brain_mask",
                  "from-bold_to-template_mode-image_xfm"),
                 "T1w_brain_template_deriv"],
@@ -2922,21 +2933,21 @@ def warp_timeseries_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "transform_timeseries_to_EPItemplate",
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
-     "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "EPI_template",
+     "switch": ["run_EPI"],
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [(["desc-cleaned_bold", "desc-brain_bold",
                   "desc-preproc_bold", "bold"],
-                 "from-bold_to-template_mode-image_xfm"),
+                 "from-bold_to-EPItemplate_mode-image_xfm"),
                 "EPI_template"],
-     "outputs": ["space-template_desc-cleaned_bold",
-                 "space-template_desc-brain_bold",
-                 "space-template_desc-preproc_bold",
-                 "space-template_bold"]}
+     "outputs": ["space-EPItemplate_desc-cleaned_bold",
+                 "space-EPItemplate_desc-brain_bold",
+                 "space-EPItemplate_desc-preproc_bold",
+                 "space-EPItemplate_bold"]}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
-        'from-bold_to-template_mode-image_xfm')
+        'from-bold_to-EPItemplate_mode-image_xfm')
     reg_tool = check_prov_for_regtool(xfm_prov)
 
     num_cpus = cfg.pipeline_setup['system_config'][
@@ -2968,11 +2979,11 @@ def warp_timeseries_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data("EPI_template")
     wf.connect(node, out, apply_xfm, 'inputspec.reference')
 
-    node, out = strat_pool.get_data("from-bold_to-template_mode-image_xfm")
+    node, out = strat_pool.get_data("from-bold_to-EPItemplate_mode-image_xfm")
     wf.connect(node, out, apply_xfm, 'inputspec.transform')
 
     outputs = {
-        f'space-template_{resource}': (apply_xfm, 'outputspec.output_image')
+        f'space-EPItemplate_{resource}': (apply_xfm, 'outputspec.output_image')
     }
 
     return (wf, outputs)
@@ -2984,17 +2995,17 @@ def warp_bold_mean_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "transform_bold_mean_to_EPItemplate",
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
-     "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "EPI_template",
+     "switch": ["run_EPI"],
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [("desc-mean_bold",
-                 "from-bold_to-template_mode-image_xfm"),
+                 "from-bold_to-EPItemplate_mode-image_xfm"),
                 "EPI_template"],
-     "outputs": ["space-template_desc-mean_bold"]}
+     "outputs": ["space-EPItemplate_desc-mean_bold"]}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
-        'from-bold_to-template_mode-image_xfm')
+        'from-bold_to-EPItemplate_mode-image_xfm')
     reg_tool = check_prov_for_regtool(xfm_prov)
 
     num_cpus = cfg.pipeline_setup['system_config'][
@@ -3022,11 +3033,11 @@ def warp_bold_mean_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data("EPI_template")
     wf.connect(node, out, apply_xfm, 'inputspec.reference')
 
-    node, out = strat_pool.get_data("from-bold_to-template_mode-image_xfm")
+    node, out = strat_pool.get_data("from-bold_to-EPItemplate_mode-image_xfm")
     wf.connect(node, out, apply_xfm, 'inputspec.transform')
 
     outputs = {
-        'space-template_desc-mean_bold':
+        'space-EPItemplate_desc-mean_bold':
             (apply_xfm, 'outputspec.output_image')
     }
 
@@ -3039,17 +3050,17 @@ def warp_bold_mask_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "transform_bold_mask_to_EPItemplate",
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
-     "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "EPI_template",
+     "switch": ["run_EPI"],
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [("space-bold_desc-brain_mask",
-                 "from-bold_to-template_mode-image_xfm"),
+                 "from-bold_to-EPItemplate_mode-image_xfm"),
                 "EPI_template"],
-     "outputs": ["space-template_desc-bold_mask"]}
+     "outputs": ["space-EPItemplate_desc-bold_mask"]}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
-        'from-bold_to-template_mode-image_xfm')
+        'from-bold_to-EPItemplate_mode-image_xfm')
     reg_tool = check_prov_for_regtool(xfm_prov)
 
     num_cpus = cfg.pipeline_setup['system_config'][
@@ -3070,11 +3081,11 @@ def warp_bold_mask_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data("EPI_template")
     wf.connect(node, out, apply_xfm, 'inputspec.reference')
 
-    node, out = strat_pool.get_data("from-bold_to-template_mode-image_xfm")
+    node, out = strat_pool.get_data("from-bold_to-EPItemplate_mode-image_xfm")
     wf.connect(node, out, apply_xfm, 'inputspec.transform')
 
     outputs = {
-        'space-template_desc-bold_mask':
+        'space-EPItemplate_desc-bold_mask':
             (apply_xfm, 'outputspec.output_image')
     }
 
@@ -3086,20 +3097,20 @@ def warp_deriv_mask_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     the derivative outputs.
 
     Node Block:
-    {"name": "transform_bold_mask_to_EPItemplate",
+    {"name": "transform_deriv_mask_to_EPItemplate",
      "config": ["registration_workflows", "functional_registration",
                 "func_registration_to_template"],
-     "switch": ["run"],
-     "option_key": ["target_template", "using"],
-     "option_val": "EPI_template",
+     "switch": ["run_EPI"],
+     "option_key": "None",
+     "option_val": "None",
      "inputs": [("space-bold_desc-brain_mask",
-                 "from-bold_to-template_mode-image_xfm"),
+                 "from-bold_to-EPItemplate_mode-image_xfm"),
                 "EPI_template"],
-     "outputs": ["space-template_res-derivative_desc-bold_mask"]}
+     "outputs": ["space-EPItemplate_res-derivative_desc-bold_mask"]}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
-        'from-bold_to-template_mode-image_xfm')
+        'from-bold_to-EPItemplate_mode-image_xfm')
     reg_tool = check_prov_for_regtool(xfm_prov)
 
     num_cpus = cfg.pipeline_setup['system_config'][
@@ -3120,11 +3131,11 @@ def warp_deriv_mask_to_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data("EPI_template")
     wf.connect(node, out, apply_xfm, 'inputspec.reference')
 
-    node, out = strat_pool.get_data("from-bold_to-template_mode-image_xfm")
+    node, out = strat_pool.get_data("from-bold_to-EPItemplate_mode-image_xfm")
     wf.connect(node, out, apply_xfm, 'inputspec.transform')
 
     outputs = {
-        f'space-template_res-derivative_desc-bold_mask':
+        f'space-EPItemplate_res-derivative_desc-bold_mask':
             (apply_xfm, 'outputspec.output_image')
     }
 

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -1710,7 +1710,7 @@ def register_FSL_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
      "switch": ["run"],
      "option_key": "using",
      "option_val": ["FSL", "FSL-linear"],
-     "inputs": [(["desc-reginput_bold', 'desc-mean_bold"],
+     "inputs": [(["desc-reginput_bold", "desc-mean_bold"],
                  "space-bold_desc-brain_mask"),
                 "EPI_template",
                 "EPI_template_mask"],
@@ -1733,13 +1733,13 @@ def register_FSL_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
         'functional_registration']['EPI_registration']['FSL-FNIRT'][
         'fnirt_config']
 
-    node, out = strat_pool.get_data(["desc-reginput_bold', 'desc-mean_bold"])
+    node, out = strat_pool.get_data(["desc-reginput_bold", "desc-mean_bold"])
     wf.connect(node, out, fsl, 'inputspec.input_brain')
 
     node, out = strat_pool.get_data('EPI_template')
     wf.connect(node, out, fsl, 'inputspec.reference_brain')
 
-    node, out = strat_pool.get_data(["desc-reginput_bold', 'desc-mean_bold"])
+    node, out = strat_pool.get_data(["desc-reginput_bold", "desc-mean_bold"])
     wf.connect(node, out, fsl, 'inputspec.input_head')
 
     node, out = strat_pool.get_data('EPI_template')

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -193,8 +193,9 @@ registration_workflows:
 
     applywarp: 
 
-      # using: ANTS or FSL. Choose the applywarp tool regardless of which tool to calculate transforms
-      using: FSL
+      # Choose the applywarp tool regardless of which tool to calculate transform
+      # using: 'ANTS', 'FSL' or 'ABCD-FSL'
+      using: ABCD-FSL
 
   functional_registration: 
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1,0 +1,1413 @@
+%YAML 1.1
+---
+# CPAC Pipeline Configuration YAML file
+# Version 1.8.0
+#
+# http://fcp-indi.github.io for more info.
+#
+# Tip: This file can be edited manually with a text editor for quick modifications.
+
+pipeline_setup:
+
+  # Name for this pipeline configuration - useful for identification.
+  pipeline_name: cpac-blank-template
+  
+  output_directory:
+
+    # Directory where C-PAC should write out processed data, logs, and crash reports.
+    # - If running in a container (Singularity/Docker), you can simply set this to an arbitrary
+    #   name like '/output', and then map (-B/-v) your desired output directory to that label.
+    # - If running outside a container, this should be a full path to a directory.
+    path: /output
+
+    # (Optional) Path to a BIDS-Derivatives directory that already has outputs.
+    #   - This option is intended to ingress already-existing resources from an output
+    #     directory without writing new outputs back into the same directory.
+    #   - If provided, C-PAC will ingress the already-computed outputs from this directory and
+    #     continue the pipeline from where they leave off.
+    #   - If left as 'None', C-PAC will ingress any already-computed outputs from the
+    #     output directory you provide above in 'path' instead, the default behavior.
+    source_outputs_dir: None
+
+    # Set to True to make C-PAC ingress the outputs from the primary output directory if they
+    # exist, even if a source_outputs_dir is provided
+    #   - Setting to False will pull from source_outputs_dir every time, over-writing any
+    #     calculated outputs in the main output directory
+    #   - C-PAC will still pull from source_outputs_dir if the main output directory is
+    #     empty, however
+    pull_source_once: True
+
+    # Include extra versions and intermediate steps of functional preprocessing in the output directory.
+    write_func_outputs: False
+
+    # Include extra outputs in the output directory that may be of interest when more information is needed.
+    write_debugging_outputs: False
+
+    # Output directory format and structure.
+    # Options: default, ndmg
+    output_tree: "default"
+
+    # Generate quality control pages containing preprocessing and derivative outputs.
+    generate_quality_control_images: True
+
+  working_directory:
+
+    # Directory where C-PAC should store temporary and intermediate files.
+    # - This directory must be saved if you wish to re-run your pipeline from where you left off (if not completed).
+    # - NOTE: As it stores all intermediate files, this directory can grow to become very
+    #   large, especially for data with a large amount of TRs.
+    # - If running in a container (Singularity/Docker), you can simply set this to an arbitrary
+    #   name like '/work', and then map (-B/-v) your desired output directory to that label.
+    # - If running outside a container, this should be a full path to a directory.
+    # - This can be written to '/tmp' if you do not intend to save your working directory.
+    path: /tmp
+
+    # Deletes the contents of the Working Directory after running.
+    # This saves disk space, but any additional preprocessing or analysis will have to be completely re-run.
+    remove_working_dir: True
+
+  log_directory:
+
+    # Whether to write log details of the pipeline run to the logging files.
+    run_logging: True
+
+    path: /logs
+
+  crash_log_directory:
+
+    # Directory where CPAC should write crash logs.
+    path: /crash
+
+  system_config:
+
+    # Select Off if you intend to run CPAC on a single machine.
+    # If set to On, CPAC will attempt to submit jobs through the job scheduler / resource manager selected below.
+    on_grid:
+
+      run: Off
+
+      # Sun Grid Engine (SGE), Portable Batch System (PBS), or Simple Linux Utility for Resource Management (SLURM).
+      # Only applies if you are running on a grid or compute cluster.
+      resource_manager: SGE
+
+      SGE:
+        # SGE Parallel Environment to use when running CPAC.
+        # Only applies when you are running on a grid or compute cluster using SGE.
+        parallel_environment:  mpi_smp
+
+        # SGE Queue to use when running CPAC.
+        # Only applies when you are running on a grid or compute cluster using SGE.
+        queue:  all.q
+
+    # The maximum amount of memory each participant's workflow can allocate.
+    # Use this to place an upper bound of memory usage.
+    # - Warning: 'Memory Per Participant' multiplied by 'Number of Participants to Run Simultaneously'
+    #   must not be more than the total amount of RAM.
+    # - Conversely, using too little RAM can impede the speed of a pipeline run.
+    # - It is recommended that you set this to a value that when multiplied by
+    #   'Number of Participants to Run Simultaneously' is as much RAM you can safely allocate.
+    maximum_memory_per_participant: 1
+
+    # The maximum amount of cores (on a single machine) or slots on a node (on a cluster/grid)
+    # to allocate per participant.
+    # - Setting this above 1 will parallelize each participant's workflow where possible.
+    #   If you wish to dedicate multiple cores to ANTS-based anatomical registration (below),
+    #   this value must be equal or higher than the amount of cores provided to ANTS.
+    # - The maximum number of cores your run can possibly employ will be this setting multiplied
+    #   by the number of participants set to run in parallel (the 'Number of Participants to Run
+    #   Simultaneously' setting).
+    max_cores_per_participant: 1
+
+    # The number of cores to allocate to ANTS-based anatomical registration per participant.
+    # - Multiple cores can greatly speed up this preprocessing step.
+    # - This number cannot be greater than the number of cores per participant.
+    num_ants_threads: 1
+
+    # The number of cores to allocate to processes that use OpenMP.
+    num_OMP_threads: 1
+
+    # The number of participant workflows to run at the same time.
+    # - The maximum number of cores your run can possibly employ will be this setting
+    #   multiplied by the number of cores dedicated to each participant (the 'Maximum Number of Cores Per Participant' setting).
+    num_participants_at_once: 1
+
+    # Full path to the FSL version to be used by CPAC.
+    # If you have specified an FSL path in your .bashrc file, this path will be set automatically.
+    FSLDIR:  /usr/share/fsl/5.0
+
+  Amazon-AWS:
+
+    # If setting the 'Output Directory' to an S3 bucket, insert the path to your AWS credentials file here.
+    aws_output_bucket_credentials:
+
+    # Enable server-side 256-AES encryption on data to the S3 bucket
+    s3_encryption: False
+
+  Debugging:
+
+    # Verbose developer messages.
+    verbose: Off
+
+
+# PREPROCESSING
+# -------------
+surface_analysis:
+
+  # Will run Freesurfer for surface-based analysis. Will output traditional Freesurfer derivatives.
+  # If you wish to employ Freesurfer outputs for brain masking or tissue segmentation in the voxel-based pipeline,
+  # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
+  run_freesurfer: Off
+
+
+longitudinal_template_generation:
+
+  # If you have multiple T1w's, you can generate your own run-specific custom
+  # T1w template to serve as an intermediate to the standard template for
+  # anatomical registration.
+
+  # This runs before the main pipeline as it requires multiple T1w sessions
+  # at once.
+  run: Off
+
+  # Freesurfer longitudinal template algorithm using FSL FLIRT
+  # Method to average the dataset at each iteration of the template creation
+  # Options: median, mean or std
+  average_method: median
+
+  # Degree of freedom for FLIRT in the template creation
+  # Options: 12 (affine), 9 (traditional), 7 (global rescale) or 6 (rigid body)
+  dof: 12
+
+  # Interpolation parameter for FLIRT in the template creation
+  # Options: trilinear, nearestneighbour, sinc or spline
+  interp: trilinear
+
+  # Cost function for FLIRT in the template creation
+  # Options: corratio, mutualinfo, normmi, normcorr, leastsq, labeldiff or bbr
+  cost: corratio
+
+  # Number of threads used for one run of the template generation algorithm
+  thread_pool: 2
+
+  # Threshold of transformation distance to consider that the loop converged
+  # (-1 means numpy.finfo(np.float64).eps and is the default)
+  convergence_threshold: -1
+
+
+anatomical_preproc:
+
+  run: Off
+
+  # Non-local means filtering via ANTs DenoiseImage
+  non_local_means_filtering: 
+
+    # this is a fork option
+    run: [Off]
+
+    # options: 'Gaussian' or 'Rician'
+    noise_model: 'Gaussian'
+
+  # N4 bias field correction via ANTs
+  n4_bias_field_correction:
+
+    # this is a fork option
+    run: [Off]
+
+    # An integer to resample the input image to save computation time. Shrink factors <= 4 are commonly used.
+    shrink_factor: 2
+
+  acpc_alignment:
+
+    run: Off
+
+    # Run ACPC alignment before non-local means filtering or N4 bias
+    # correction
+    run_before_preproc: True
+
+    # ACPC size of brain in z-dimension in mm.
+    # Default: 150mm for human data.
+    brain_size: 150
+
+    # ACPC Target
+    # options: 'brain' or 'whole-head'
+    #   note: 'brain' requires T1w_brain_ACPC_template below to be populated
+    acpc_target: 'whole-head'
+
+    # ACPC aligned template
+    T1w_ACPC_template: /usr/share/fsl/5.0/data/standard/MNI152_T1_1mm.nii.gz
+    T1w_brain_ACPC_template: None
+
+  brain_extraction:
+  
+    run: Off
+
+    # using: ['3dSkullStrip', 'BET', 'UNet', 'niworkflows-ants']
+    # this is a fork option
+    using: ['3dSkullStrip']
+
+    # option parameters
+    AFNI-3dSkullStrip:
+
+      # Output a mask volume instead of a skull-stripped volume. The mask volume containes 0 to 6, which represents voxel's postion. If set to True, C-PAC will use this output to generate anatomical brain mask for further analysis.
+      mask_vol: False
+
+      # Set the threshold value controlling the brain vs non-brain voxels. Default is 0.6.
+      shrink_factor: 0.6
+
+      # Vary the shrink factor at every iteration of the algorithm. This prevents the likelihood of surface getting stuck in large pools of CSF before reaching the outer surface of the brain. Default is On.
+      var_shrink_fac: True
+
+      # The shrink factor bottom limit sets the lower threshold when varying the shrink factor. Default is 0.4, for when edge detection is used (which is On by default), otherwise the default value is 0.65.
+      shrink_factor_bot_lim: 0.4
+
+      # Avoids ventricles while skullstripping.
+      avoid_vent: True
+
+      # Set the number of iterations. Default is 250.The number of iterations should depend upon the density of your mesh.
+      n_iterations: 250
+
+      # While expanding, consider the voxels above and not only the voxels below
+      pushout: True
+
+      # Perform touchup operations at the end to include areas not covered by surface expansion.
+      touchup: True
+
+      # Give the maximum number of pixels on either side of the hole that can be filled. The default is 10 only if 'Touchup' is On - otherwise, the default is 0.
+      fill_hole: 10
+
+      # Perform nearest neighbor coordinate interpolation every few iterations. Default is 72.
+      NN_smooth: 72
+
+      # Perform final surface smoothing after all iterations. Default is 20.
+      smooth_final: 20
+
+      # Avoid eyes while skull stripping. Default is On.
+      avoid_eyes: True
+
+      # Use edge detection to reduce leakage into meninges and eyes. Default is On.
+      use_edge: True
+
+      # Speed of expansion.
+      exp_frac: 0.1
+
+      # Perform aggressive push to edge. This might cause leakage. Default is Off.
+      push_to_edge: False
+
+      # Use outer skull to limit expansion of surface into the skull in case of very strong shading artifacts. Use this only if you have leakage into the skull.
+      use_skull: Off
+
+      # Percentage of segments allowed to intersect surface. It is typically a number between 0 and 0.1, but can include negative values (which implies no testing for intersection).
+      perc_int: 0
+
+      # Number of iterations to remove intersection problems. With each iteration, the program automatically increases the amount of smoothing to get rid of intersections. Default is 4.
+      max_inter_iter: 4
+
+      # Multiply input dataset by FAC if range of values is too small.
+      fac: 1
+
+      # Blur dataset after spatial normalization. Recommended when you have lots of CSF in brain and when you have protruding gyri (finger like). If so, recommended value range is 2-4. Otherwise, leave at 0.
+      blur_fwhm: 0
+
+      # Set it as True if processing monkey data with AFNI
+      monkey: False
+
+    FSL-BET:
+
+      # Set the threshold value controling the brain vs non-brain voxels, default is 0.5
+      frac: 0.5
+
+      # Mask created along with skull stripping. It should be `On`, if selected functionalMasking :  ['Anatomical_Refined'] and `FSL` as skull-stripping method.
+      mask_boolean: On
+
+      # Mesh created along with skull stripping
+      mesh_boolean: Off
+
+      # Create a surface outline image
+      outline: Off
+
+      # Add padding to the end of the image, improving BET.Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      padding: Off
+
+      # Integer value of head radius
+      radius: 0
+
+      # Reduce bias and cleanup neck. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      reduce_bias: Off
+
+      # Eyes and optic nerve cleanup. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      remove_eyes: Off
+
+      # Robust brain center estimation. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      robust: Off
+
+      # Create a skull image
+      skull: Off
+
+      # Gets additional skull and scalp surfaces by running bet2 and betsurf. This is mutually exclusive with reduce_bias, robust, padding, remove_eyes
+      surfaces: Off
+
+      # Apply thresholding to segmented brain image and mask
+      threshold: Off
+
+      # Vertical gradient in fractional intensity threshold (-1,1)
+      vertical_gradient : 0.0
+
+    UNet:
+
+      # UNet model
+      unet_model : s3://fcp-indi/resources/cpac/resources/Site-All-T-epoch_36.model
+
+    niworkflows-ants:
+
+      # Template to be used during niworkflows-ants.
+      # It is not necessary to change this path unless you intend to use a non-standard template.
+
+      # niworkflows-ants Brain extraction template
+      template_path : /ants_template/oasis/T_template0.nii.gz
+
+      # niworkflows-ants probability mask
+      mask_path : /ants_template/oasis/T_template0_BrainCerebellumProbabilityMask.nii.gz
+
+      # niworkflows-ants registration mask (can be optional)
+      regmask_path : /ants_template/oasis/T_template0_BrainCerebellumRegistrationMask.nii.gz
+
+
+segmentation:
+
+  # Automatically segment anatomical images into white matter, gray matter,
+  # and CSF based on prior probability maps.
+  run: Off
+
+  tissue_segmentation:
+
+    # using: ['FSL-FAST', 'Template_Based', 'FreeSurfer', 'ANTs_Prior_Based']
+    # this is a fork point
+    using: ['FSL-FAST']
+
+    # option parameters
+    FSL-FAST:
+
+      thresholding:
+
+        # thresholding of the tissue segmentation probability maps
+        # options: 'Auto', 'Custom'
+        use: 'Auto'
+
+        Custom:
+          # Set the threshold value for the segmentation probability masks (CSF, White Matter, and Gray Matter)
+          # The values remaining will become the binary tissue masks.
+          # A good starting point is 0.95.
+
+          # CSF (cerebrospinal fluid) threshold.
+          CSF_threshold_value : 0.95
+
+          # White matter threshold.
+          WM_threshold_value : 0.95
+
+          # Gray matter threshold.
+          GM_threshold_value : 0.95
+
+      use_priors:
+
+        # Use template-space tissue priors to refine the binary tissue masks generated by segmentation.
+        run: On
+
+        # Full path to a directory containing binarized prior probability maps.
+        # These maps are included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
+        # It is not necessary to change this path unless you intend to use non-standard priors.
+        priors_path: $FSLDIR/data/standard/tissuepriors/2mm
+
+        # Full path to a binarized White Matter prior probability map.
+        # It is not necessary to change this path unless you intend to use non-standard priors.
+        WM_path: $priors_path/avg152T1_white_bin.nii.gz
+
+        # Full path to a binarized Gray Matter prior probability map.
+        # It is not necessary to change this path unless you intend to use non-standard priors.
+        GM_path: $priors_path/avg152T1_gray_bin.nii.gz
+
+        # Full path to a binarized CSF prior probability map.
+        # It is not necessary to change this path unless you intend to use non-standard priors.
+        CSF_path: $priors_path/avg152T1_csf_bin.nii.gz
+
+    Template_Based:
+
+      # These masks should be in the same space of your registration template, e.g. if
+      # you choose 'EPI Template' , below tissue masks should also be EPI template tissue masks.
+      #
+      # Options: ['T1_Template', 'EPI_Template']
+      template_for_segmentation: ['T1_Template']
+
+      # These masks are included as part of the 'Image Resource Files' package available
+      # on the Install page of the User Guide.
+
+      # Full path to a binarized White Matter mask.
+      WHITE: $FSLDIR/data/standard/tissuepriors/2mm/avg152T1_white_bin.nii.gz
+
+      # Full path to a binarized Gray Matter mask.
+      GRAY: $FSLDIR/data/standard/tissuepriors/2mm/avg152T1_gray_bin.nii.gz
+
+      # Full path to a binarized CSF mask.
+      CSF: $FSLDIR/data/standard/tissuepriors/2mm/avg152T1_csf_bin.nii.gz
+
+    ANTs_Prior_Based:
+
+      # Generate white matter, gray matter, CSF masks based on antsJointLabelFusion
+      # ANTs Prior-based Segmentation workflow that has shown optimal results for non-human primate data.
+
+      # The atlas image assumed to be used in ANTs Prior-based Segmentation.
+      template_brain_list :
+        - /monkey_seg/templates/JointLabelCouncil/MacaqueYerkes19_T1w_0.5mm/T1w_brain.nii.gz
+        - /monkey_seg/templates/JointLabelCouncil/J_Macaque_11mo_atlas_nACQ_194x252x160space_0.5mm/T1w_brain.nii.gz
+
+      # The atlas segmentation images.
+      # For performing ANTs Prior-based segmentation method
+      # the number of specified segmentations should be identical to the number of atlas brain image sets.
+      # eg.
+      # ANTs_prior_seg_template_brain_list :
+      #   - atlas1.nii.gz
+      #   - atlas2.nii.gz
+      # ANTs_prior_seg_template_segmentation_list:
+      #   - segmentation1.nii.gz
+      #   - segmentation1.nii.gz
+      template_segmentation_list:
+        - /monkey_seg/templates/JointLabelCouncil/MacaqueYerkes19_T1w_0.5mm/Segmentation.nii.gz
+        - /monkey_seg/templates/JointLabelCouncil/J_Macaque_11mo_atlas_nACQ_194x252x160space_0.5mm/Segmentation.nii.gz
+
+      # Label values corresponding to CSF/GM/WM in atlas file
+      # It is not necessary to change this values unless your CSF/GM/WM label values are different from Freesurfer Color Lookup Table.
+      # https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/AnatomicalROI/FreeSurferColorLUT
+
+      # Label value corresponding to CSF in multiatlas file
+      CSF_label : 24
+
+      # Label value corresponding to Left Gray Matter in multiatlas file
+      left_GM_label : 3
+
+      # Label value corresponding to Right Gray Matter in multiatlas file
+      right_GM_label : 42
+
+      # Label value corresponding to Left White Matter in multiatlas file
+      left_WM_label : 2
+
+      # Label value corresponding to Right White Matter in multiatlas file
+      right_WM_label : 41
+
+
+registration_workflows:
+
+  anatomical_registration:
+
+    run: Off
+
+    # The resolution to which anatomical images should be transformed during registration.
+    # This is the resolution at which processed anatomical files will be output.
+    resolution_for_anat: 2mm
+
+    # Template to be used during registration.
+    # It is not necessary to change this path unless you intend to use a non-standard template.
+    T1w_brain_template: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain.nii.gz
+
+    # Template to be used during registration.
+    # It is not necessary to change this path unless you intend to use a non-standard template.
+    T1w_template: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
+
+    # Template to be used during registration.
+    # It is not necessary to change this path unless you intend to use a non-standard template.
+    T1w_brain_template_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
+
+    # Register skull-on anatomical image to a template.
+    reg_with_skull: True
+
+    registration:
+
+      # using: ['ANTS', 'FSL', 'FSL-linear']
+      # this is a fork point
+      #   selecting both ['ANTS', 'FSL'] will run both and fork the pipeline
+      using: ['ANTS']
+
+      # option parameters
+      ANTs:
+
+        # If a lesion mask is available for a T1w image, use it to improve the ANTs' registration
+        # ANTS registration only.
+        use_lesion_mask: False
+
+        # ANTs parameters for T1-template-based registration
+        T1_registration:
+
+          - collapse-output-transforms: 0
+          - dimensionality: 3
+          - initial-moving-transform :
+             initializationFeature: 0
+
+          - transforms:
+             - Rigid:
+                 gradientStep : 0.1
+                 metric :
+                   type : MI
+                   metricWeight: 1
+                   numberOfBins : 32
+                   samplingStrategy : Regular
+                   samplingPercentage : 0.25
+                 convergence:
+                   iteration : 1000x500x250x100
+                   convergenceThreshold : 1e-08
+                   convergenceWindowSize : 10
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 8x4x2x1
+                 use-histogram-matching : True
+
+             - Affine:
+                 gradientStep : 0.1
+                 metric :
+                   type : MI
+                   metricWeight: 1
+                   numberOfBins : 32
+                   samplingStrategy : Regular
+                   samplingPercentage : 0.25
+                 convergence:
+                   iteration : 1000x500x250x100
+                   convergenceThreshold : 1e-08
+                   convergenceWindowSize : 10
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 8x4x2x1
+                 use-histogram-matching : True
+
+             - SyN:
+                 gradientStep : 0.1
+                 updateFieldVarianceInVoxelSpace : 3.0
+                 totalFieldVarianceInVoxelSpace : 0.0
+                 metric:
+                   type : CC
+                   metricWeight: 1
+                   radius : 4
+                 convergence:
+                   iteration : 100x100x70x20
+                   convergenceThreshold : 1e-09
+                   convergenceWindowSize : 15
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 6x4x2x1
+                 use-histogram-matching : True
+                 winsorize-image-intensities :
+                   lowerQuantile : 0.01
+                   upperQuantile : 0.99
+
+        # Interpolation method for writing out transformed anatomical images.
+        # Possible values: Linear, BSpline, LanczosWindowedSinc
+        interpolation: LanczosWindowedSinc
+
+      FSL-FNIRT:
+
+        # Configuration file to be used by FSL to set FNIRT parameters.
+        # It is not necessary to change this path unless you intend to use custom FNIRT parameters or a non-standard template.
+        fnirt_config: T1_2_MNI152_2mm
+
+        # Reference mask for FSL registration.
+        ref_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
+
+        # Interpolation method for writing out transformed anatomical images.
+        # Possible values: trilinear, sinc, spline
+        interpolation: sinc
+
+        # Identity matrix used during FSL-based resampling of anatomical-space data throughout the pipeline.
+        # It is not necessary to change this path unless you intend to use a different template.
+        identity_matrix: /usr/share/fsl/5.0/etc/flirtsch/ident.mat
+
+    applywarp:
+
+      # using: ANTS or FSL. Choose the applywarp tool regardless of which tool to calculate transforms
+      using: ANTS
+
+  functional_registration:
+
+    coregistration:
+      # functional (BOLD/EPI) registration to anatomical (structural/T1)
+
+      run: Off
+
+      func_input_prep:
+
+        # Choose whether to use the mean of the functional/EPI as the input to functional-to-anatomical registration or one of the volumes from the functional 4D timeseries that you choose.
+        # input: ['Mean Functional', 'Selected_Functional_Volume']
+        input: ['Mean_Functional']
+
+        Mean Functional:
+
+          # Run ANTs’ N4 Bias Field Correction on the input BOLD (EPI)
+          # this can increase tissue contrast which may improve registration quality in some data
+          n4_correct_func: False
+
+        Selected Functional Volume:
+
+          # Only for when 'Use as Functional-to-Anatomical Registration Input' is set to 'Selected Functional Volume'.
+          #Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
+          func_reg_input_volume: 0
+
+      boundary_based_registration:
+        # this is a fork point
+        #   run: [On, Off] - this will run both and fork the pipeline
+        run: [Off]
+
+        # Standard FSL 5.0 Scheduler used for Boundary Based Registration.
+        # It is not necessary to change this path unless you intend to use non-standard MNI registration.
+        bbr_schedule: /usr/share/fsl/5.0/etc/flirtsch/bbr.sch
+
+    EPI_registration:
+
+      # directly register the mean functional to an EPI template
+      #   instead of applying the anatomical T1-to-template transform to the functional data that has been
+      #   coregistered to anatomical/T1 space
+      run: Off
+
+      # using: ['ANTS', 'FSL', 'FSL-linear']
+      # this is a fork point
+      # ex. selecting both ['ANTS', 'FSL'] will run both and fork the pipeline
+      using: ['ANTS']
+
+      # EPI template for direct functional-to-template registration
+      # (bypassing coregistration and the anatomical-to-template transforms)
+      EPI_template: s3://fcp-indi/resources/cpac/resources/epi_hbn.nii.gz
+
+      # EPI template mask.
+      EPI_template_mask: None
+
+      ANTs:
+
+        # EPI registration configuration - synonymous with T1_registration
+        # parameters under anatomical registration above
+        parameters:
+
+          - collapse-output-transforms: 0
+          - dimensionality: 3
+          - initial-moving-transform :
+             initializationFeature: 0
+
+          - transforms:
+             - Rigid:
+                 gradientStep : 0.1
+                 metric :
+                   type : MI
+                   metricWeight: 1
+                   numberOfBins : 32
+                   samplingStrategy : Regular
+                   samplingPercentage : 0.25
+                 convergence:
+                   iteration : 1000x500x250x100
+                   convergenceThreshold : 1e-08
+                   convergenceWindowSize : 10
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 8x4x2x1
+                 use-histogram-matching : True
+
+             - Affine:
+                 gradientStep : 0.1
+                 metric :
+                   type : MI
+                   metricWeight: 1
+                   numberOfBins : 32
+                   samplingStrategy : Regular
+                   samplingPercentage : 0.25
+                 convergence:
+                   iteration : 1000x500x250x100
+                   convergenceThreshold : 1e-08
+                   convergenceWindowSize : 10
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 8x4x2x1
+                 use-histogram-matching : True
+
+             - SyN:
+                 gradientStep : 0.1
+                 updateFieldVarianceInVoxelSpace : 3.0
+                 totalFieldVarianceInVoxelSpace : 0.0
+                 metric:
+                   type : CC
+                   metricWeight: 1
+                   radius : 4
+                 convergence:
+                   iteration : 100x100x70x20
+                   convergenceThreshold : 1e-09
+                   convergenceWindowSize : 15
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 6x4x2x1
+                 use-histogram-matching : True
+                 winsorize-image-intensities :
+                   lowerQuantile : 0.01
+                   upperQuantile : 0.99
+
+        # Interpolation method for writing out transformed EPI images.
+        # Possible values: Linear, BSpline, LanczosWindowedSinc
+        interpolation: LanczosWindowedSinc
+
+      FSL-FNIRT:
+
+        # Configuration file to be used by FSL to set FNIRT parameters.
+        # It is not necessary to change this path unless you intend to use custom FNIRT parameters or a non-standard template.
+        fnirt_config: T1_2_MNI152_2mm
+
+        # Interpolation method for writing out transformed EPI images.
+        # Possible values: trilinear, sinc, spline
+        interpolation: sinc
+
+        # Identity matrix used during FSL-based resampling of BOLD-space data throughout the pipeline.
+        # It is not necessary to change this path unless you intend to use a different template.
+        identity_matrix: /usr/share/fsl/5.0/etc/flirtsch/ident.mat
+
+    func_registration_to_template:
+
+      # these options modify the application (to the functional data), not the calculation, of the
+      # T1-to-template and EPI-to-template transforms calculated earlier during registration
+      
+      # apply the functional-to-template (T1 template) registration transform to the functional data
+      run: Off
+      
+      # apply the functional-to-template (EPI template) registration transform to the functional data
+      run_EPI: Off
+
+      output_resolution:
+
+        # The resolution (in mm) to which the preprocessed, registered functional timeseries outputs are written into.
+        # NOTE:
+        #   selecting a 1 mm or 2 mm resolution might substantially increase your RAM needs- these resolutions should be selected with caution.
+        #   for most cases, 3 mm or 4 mm resolutions are suggested.
+        # NOTE:
+        #   this also includes the single-volume 3D preprocessed functional data,
+        #   such as the mean functional (mean EPI) in template space
+        func_preproc_outputs: 3mm
+
+        # The resolution (in mm) to which the registered derivative outputs are written into.
+        # NOTE:
+        #   this is for the single-volume functional-space outputs (i.e. derivatives)
+        #   thus, a higher resolution may not result in a large increase in RAM needs as above
+        func_derivative_outputs: 3mm
+
+      target_template:
+
+        # choose which template space to transform derivatives towards
+        # options: ['T1_template', 'EPI_template']
+        using: ['T1_template']
+
+        T1_template:
+
+          # Standard Skull Stripped Template. Used as a reference image for functional registration.
+          # This can be different than the template used as the reference/fixed for T1-to-template registration.
+          T1w_brain_template_funcreg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${func_resolution}_brain.nii.gz
+
+          # Standard Anatomical Brain Image with Skull.
+          # This can be different than the template used as the reference/fixed for T1-to-template registration.
+          T1w_template_funcreg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${func_resolution}.nii.gz
+
+          # Template to be used during registration.
+          # It is not necessary to change this path unless you intend to use a non-standard template.
+          T1w_brain_template_mask_funcreg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${func_resolution}_brain_mask.nii.gz
+
+          # a standard template for resampling if using float resolution
+          T1w_template_for_resample:  $FSLDIR/data/standard/MNI152_T1_1mm_brain.nii.gz
+
+        EPI_template:
+
+          # EPI template for direct functional-to-template registration
+          # (bypassing coregistration and the anatomical-to-template transforms)
+          EPI_template_funcreg: s3://fcp-indi/resources/cpac/resources/epi_hbn.nii.gz
+
+          # EPI template mask.
+          EPI_template_mask_funcreg: None
+
+          # a standard template for resampling if using float resolution
+          EPI_template_for_resample:  $FSLDIR/data/standard/MNI152_T1_1mm_brain.nii.gz
+
+      ANTs_pipelines:
+
+        # Interpolation method for writing out transformed functional images.
+        # Possible values: Linear, BSpline, LanczosWindowedSinc
+        interpolation: LanczosWindowedSinc
+
+      FNIRT_pipelines:
+
+        # Interpolation method for writing out transformed functional images.
+        # Possible values: trilinear, sinc, spline
+        interpolation: sinc
+
+        # Identity matrix used during FSL-based resampling of functional-space data throughout the pipeline.
+        # It is not necessary to change this path unless you intend to use a different template.
+        identity_matrix: /usr/share/fsl/5.0/etc/flirtsch/ident.mat
+
+
+functional_preproc:
+
+  run: Off
+
+  truncation:
+
+    # First timepoint to include in analysis.
+    # Default is 0 (beginning of timeseries).
+    # First timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
+    # Note: the selection here applies to all scans of all participants.
+    start_tr: 0
+
+    # Last timepoint to include in analysis.
+    # Default is None or End (end of timeseries).
+    # Last timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
+    # Note: the selection here applies to all scans of all participants.
+    stop_tr: None
+
+  scaling:
+
+    # Scale functional raw data, usually used in rodent pipeline
+    run: Off
+
+    # Scale the size of the dataset voxels by the factor.
+    scaling_factor: 10
+
+  despiking:
+
+    # Run AFNI 3dDespike
+    # this is a fork point
+    #   run: [On, Off] - this will run both and fork the pipeline
+    run: [Off]
+
+  slice_timing_correction:
+
+    # Interpolate voxel time courses so they are sampled at the same time points.
+    # this is a fork point
+    #   run: [On, Off] - this will run both and fork the pipeline
+    run: [Off]
+
+  motion_estimates_and_correction:
+
+    # calculate motion statistics BEFORE slice-timing correction
+    calculate_motion_first: Off
+
+    motion_correction:
+
+      # using: ['3dvolreg', 'mcflirt']
+      # this is a fork point
+      using: ['3dvolreg']
+
+      # option parameters
+      AFNI-3dvolreg:
+
+        # This option is useful when aligning high-resolution datasets that may need more alignment than a few voxels.
+        functional_volreg_twopass: On
+
+      # Choose motion correction reference. Options: mean, median, selected volume
+      motion_correction_reference: ['mean']
+
+      # Choose motion correction reference volume
+      motion_correction_reference_volume: 0
+
+    motion_estimate_filter:
+
+      # Filter physiological (respiration) artifacts from the head motion estimates.
+      # Adapted from DCAN Labs filter.
+      #     https://www.ohsu.edu/school-of-medicine/developmental-cognition-and-neuroimaging-lab
+      #     https://www.biorxiv.org/content/10.1101/337360v1.full.pdf
+      # this is a fork point
+      #   run: [On, Off] - this will run both and fork the pipeline
+      run: [Off]
+
+      # options: "notch", "lowpass"
+      filter_type: "notch"
+
+      # Number of filter coefficients.
+      filter_order: 4
+
+      # Dataset-wide respiratory rate data from breathing belt.
+      # Notch filter requires either:
+      #     "breathing_rate_min" and "breathing_rate_max"
+      # or
+      #     "center_frequency" and "filter_bandwitdh".
+      # Lowpass filter requires either:
+      #     "breathing_rate_min"
+      # or
+      #     "lowpass_cutoff".
+      # If "breathing_rate_min" (for lowpass and notch filter)
+      # and "breathing_rate_max" (for notch filter) are set,
+      # the values set in "lowpass_cutoff" (for lowpass filter),
+      # "center_frequency" and "filter_bandwidth" (for notch filter)
+      # options are ignored.
+
+      # Lowest Breaths-Per-Minute in dataset.
+      # For both notch and lowpass filters.
+      breathing_rate_min:
+
+      # Highest Breaths-Per-Minute in dataset.
+      # For notch filter.
+      breathing_rate_max:
+
+      # notch filter direct customization parameters
+
+      # mutually exclusive with breathing_rate options above.
+      # If breathing_rate_min and breathing_rate_max are provided,
+      # the following parameters will be ignored.
+
+      # the center frequency of the notch filter
+      center_frequency:
+
+      # the width of the notch filter
+      filter_bandwidth:
+
+      # lowpass filter direct customization parameter
+
+      # mutually exclusive with breathing_rate options above.
+      # If breathing_rate_min is provided, the following
+      # parameter will be ignored.
+
+      # the frequency cutoff of the filter
+      lowpass_cutoff:
+
+  distortion_correction:
+
+    # this is a fork point
+    #   run: [On, Off] - this will run both and fork the pipeline
+    run: [Off]
+
+    # using: ['PhaseDiff', 'Blip']
+    #   PhaseDiff - Perform field map correction using a single phase difference image, a subtraction of the two phase images from each echo. Default scanner for this method is SIEMENS.
+    #   Blip - Uses AFNI 3dQWarp to calculate the distortion unwarp for EPI field maps of opposite/same phase encoding direction.
+    #   NOTE:
+    #     this is NOT a fork point - instead, the technique used will depend on what type of distortion correction field data accompanies the dataset
+    #     for example, phase-difference field maps will lead to phase-difference distortion correction, and phase-encoding direction field maps will lead to blip-up/blip-down
+    using: ['PhaseDiff', 'Blip']
+
+    # option parameters
+    PhaseDiff:
+
+      # Since the quality of the distortion heavily relies on the skull-stripping step, we provide a choice of method ('AFNI' for AFNI 3dSkullStrip or 'BET' for FSL BET).
+      # Options: 'BET' or 'AFNI'
+      fmap_skullstrip_option: 'BET'
+
+      # Set the fraction value for the skull-stripping of the magnitude file. Depending on the data, a tighter extraction may be necessary in order to prevent noisy voxels from interfering with preparing the field map.
+      # The default value is 0.5.
+      fmap_skullstrip_BET_frac: 0.5
+
+      # Set the threshold value for the skull-stripping of the magnitude file. Depending on the data, a tighter extraction may be necessary in order to prevent noisy voxels from interfering with preparing the field map.
+      # The default value is 0.6.
+      fmap_skullstrip_AFNI_threshold:  0.6
+
+  func_masking:
+
+    # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based']
+    # this is a fork point
+    using: ['AFNI']
+
+    FSL-BET:
+
+      # Apply to 4D FMRI data, if bold_bet_functional_mean_boolean : Off.
+      # Mutually exclusive with functional, reduce_bias, robust, padding, remove_eyes, surfaces
+      # It must be 'on' if select 'reduce_bias', 'robust', 'padding', 'remove_eyes', or 'bet_surfaces' on
+      functional_mean_boolean: Off
+
+      # Set the threshold value controling the brain vs non-brain voxels.
+      frac: 0.3
+
+      # Mesh created along with skull stripping
+      mesh_boolean: Off
+
+      # Create a surface outline image
+      outline: Off
+
+      # Add padding to the end of the image, improving BET.Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      padding: Off
+
+      # Integer value of head radius
+      radius: 0
+
+      # Reduce bias and cleanup neck. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      reduce_bias: Off
+
+      # Eyes and optic nerve cleanup. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      remove_eyes: Off
+
+      # Robust brain center estimation. Mutually exclusive with functional,reduce_bias,robust,padding,remove_eyes,surfaces
+      robust: Off
+
+      # Create a skull image
+      skull: Off
+
+      # Gets additional skull and scalp surfaces by running bet2 and betsurf. This is mutually exclusive with reduce_bias, robust, padding, remove_eyes
+      surfaces: Off
+
+      # Apply thresholding to segmented brain image and mask
+      threshold: Off
+
+      # Vertical gradient in fractional intensity threshold (-1,1)
+      vertical_gradient: 0.0
+
+    Anatomical_Refined:
+
+      # Choose whether or not to dilate the anatomical mask if you choose 'Anatomical_Refined' as the functional masking option. It will dilate one voxel if enabled.
+      anatomical_mask_dilation: False
+
+
+nuisance_corrections:
+
+  1-ICA-AROMA:
+
+    # this is a fork point
+    #   run: [On, Off] - this will run both and fork the pipeline
+    run: [Off]
+
+    # Types of denoising strategy:
+    #   nonaggr: nonaggressive-partial component regression
+    #   aggr:    aggressive denoising
+    denoising_type: nonaggr
+
+  2-nuisance_regression:
+
+    # this is a fork point
+    #   run: [On, Off] - this will run both and fork the pipeline
+    run: [Off]
+    
+    # switch to Off if nuisance regression is off and you don't want to write out the regressors
+    create_regressors: Off
+
+    # Select which nuisance signal corrections to apply
+    Regressors: None
+
+    # Standard Lateral Ventricles Binary Mask
+    # used in CSF mask refinement for CSF signal-related regressions
+    lateral_ventricles_mask: $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
+
+    # Whether to run frequency filtering before or after nuisance regression.
+    # Options: 'After' or 'Before'
+    bandpass_filtering_order: 'After'
+
+    # Process and refine masks used to produce regressors and time series for
+    # regression.
+    regressor_masks:
+
+      erode_anatomical_brain_mask:
+
+        # Erode binarized anatomical brain mask. If choosing True, please also set seg_csf_use_erosion: True; regOption: niworkflows-ants.
+        run: Off
+
+        # Erosion proportion, if using erosion.
+        # Default proportion is 0 for anatomical brain mask.
+        # Recommend that do not use erosion in both proportion and millimeter method.
+        brain_mask_erosion_prop : 0
+
+        # Erode brain mask in millimeter, default of brain is 30 mm
+        # brain erosion default is using millimeter erosion method when use erosion for brain.
+        brain_mask_erosion_mm : 30
+
+        # Erode binarized brain mask in millimeter
+        brain_erosion_mm: 0
+
+      erode_csf:
+
+        # Erode binarized csf tissue mask.
+        run: Off
+
+        # Erosion proportion, if use erosion.
+        # Default proportion is 0 for CSF (cerebrospinal fluid)  mask.
+        # Recommend to do not use erosion in both proportion and millimeter method.
+        csf_erosion_prop : 0
+
+        # Erode brain mask in millimeter, default of csf is 30 mm
+        # CSF erosion default is using millimeter erosion method when use erosion for CSF.
+        csf_mask_erosion_mm: 30
+
+        # Erode binarized CSF (cerebrospinal fluid)  mask in millimeter
+        csf_erosion_mm: 0
+
+      erode_wm:
+
+        # Erode WM binarized tissue mask.
+        run: Off
+
+        # Erosion proportion, if use erosion.
+        # Default proportion is 0.6 for White Matter mask.
+        # Recommend to do not use erosion in both proportion and millimeter method.
+        # White Matter erosion default is using proportion erosion method when use erosion for White Matter.
+        wm_erosion_prop : 0.6
+
+        # Erode brain mask in millimeter, default of White Matter is 0 mm
+        wm_mask_erosion_mm: 0
+
+        # Erode binarized White Matter mask in millimeter
+        wm_erosion_mm: 0
+
+      erode_gm:
+
+        # Erode GM binarized tissue mask.
+        run: Off
+
+        # Erosion proportion, if use erosion.
+        # Recommend to do not use erosion in both proportion and millimeter method.
+        gm_erosion_prop : 0.6
+
+        # Erode brain mask in millimeter, default of csf is 30 mm
+        gm_mask_erosion_mm: 30
+
+        # Erode binarized White Matter mask in millimeter
+        gm_erosion_mm: 0
+
+
+# OUTPUTS AND DERIVATIVES
+# -----------------------
+post_processing:
+
+  spatial_smoothing:
+
+    # Smooth the derivative outputs.
+    # Set as ['nonsmoothed'] to disable smoothing. Set as both to get both.
+    #
+    # Options:
+    #     ['smoothed', 'nonsmoothed']
+    output: ['smoothed']
+
+    # Tool to use for smoothing.
+    # 'FSL' for FSL MultiImageMaths for FWHM provided
+    # 'AFNI' for AFNI 3dBlurToFWHM for FWHM provided
+    smoothing_method: ['FSL']
+
+    # Full Width at Half Maximum of the Gaussian kernel used during spatial smoothing.
+    # this is a fork point
+    #   i.e. multiple kernels - fwhm: [4,6,8]
+    fwhm: [4]
+
+  z-scoring:
+
+    # z-score standardize the derivatives. This may be needed for group-level analysis.
+    # Set as ['raw'] to disable z-scoring. Set as both to get both.
+    #
+    # Options:
+    #     ['z-scored', 'raw']
+    output: ['z-scored']
+
+
+timeseries_extraction:
+
+  run: Off
+
+  # Enter paths to region-of-interest (ROI) NIFTI files (.nii or .nii.gz) to be used for time-series extraction, and then select which types of analyses to run.
+  # Denote which analyses to run for each ROI path by listing the names below. For example, if you wish to run Avg and SpatialReg, you would enter: '/path/to/ROI.nii.gz': Avg, SpatialReg
+  # available analyses:
+  #   /path/to/atlas.nii.gz: Avg, Voxel, SpatialReg, PearsonCorr, PartialCorr
+  tse_roi_paths:
+    /cpac_templates/CC400.nii.gz: Avg
+    /cpac_templates/aal_mask_pad.nii.gz: Avg
+    /cpac_templates/CC200.nii.gz: Avg
+    /cpac_templates/tt_mask_pad.nii.gz: Avg
+    /cpac_templates/PNAS_Smith09_rsn10.nii.gz: SpatialReg
+    /cpac_templates/ho_mask_pad.nii.gz: Avg
+    /cpac_templates/rois_3mm.nii.gz: Avg
+    /ndmg_atlases/label/Human/AAL_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/CAPRSC_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/DKT_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/DesikanKlein_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/HarvardOxfordcort-maxprob-thr25_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/HarvardOxfordsub-maxprob-thr25_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Juelich_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/MICCAI_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Schaefer1000_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Schaefer200_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Schaefer300_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Schaefer400_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Talairach_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Brodmann_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Desikan_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Glasser_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Slab907_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Yeo-17-liberal_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Yeo-17_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Yeo-7-liberal_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+    /ndmg_atlases/label/Human/Yeo-7_space-MNI152NLin6_res-1x1x1.nii.gz: Avg
+
+  # Functional time-series and ROI realignment method: ['ROI_to_func'] or ['func_to_ROI']
+  # 'ROI_to_func' will realign the atlas/ROI to functional space (fast)
+  # 'func_to_ROI' will realign the functional time series to the atlas/ROI space
+  #
+  #     NOTE: in rare cases, realigning the ROI to the functional space may
+  #           result in small misalignments for very small ROIs - please double
+  #           check your data if you see issues
+  realignment: 'ROI_to_func'
+
+
+seed_based_correlation_analysis:
+
+  # SCA - Seed-Based Correlation Analysis
+  # For each extracted ROI Average time series, CPAC will generate a whole-brain correlation map.
+  # It should be noted that for a given seed/ROI, SCA maps for ROI Average time series will be the same.
+  run: Off
+
+  # Enter paths to region-of-interest (ROI) NIFTI files (.nii or .nii.gz) to be used for seed-based correlation analysis, and then select which types of analyses to run.
+  # Denote which analyses to run for each ROI path by listing the names below. For example, if you wish to run Avg and MultReg, you would enter: '/path/to/ROI.nii.gz': Avg, MultReg
+  # available analyses:
+  #   /path/to/atlas.nii.gz: Avg, DualReg, MultReg
+  sca_roi_paths:
+    /cpac_templates/PNAS_Smith09_rsn10.nii.gz: DualReg
+    /cpac_templates/CC400.nii.gz: Avg, MultReg
+    /cpac_templates/ez_mask_pad.nii.gz: Avg, MultReg
+    /cpac_templates/aal_mask_pad.nii.gz: Avg, MultReg
+    /cpac_templates/CC200.nii.gz: Avg, MultReg
+    /cpac_templates/tt_mask_pad.nii.gz: Avg, MultReg
+    /cpac_templates/ho_mask_pad.nii.gz: Avg, MultReg
+    /cpac_templates/rois_3mm.nii.gz: Avg, MultReg
+
+  # Normalize each time series before running Dual Regression SCA.
+  norm_timeseries_for_DR: True
+
+
+amplitude_low_frequency_fluctuation:
+
+  # ALFF & f/ALFF
+  # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and and fractional ALFF (f/ALFF) for all voxels.
+  run: Off
+
+  # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
+  highpass_cutoff: [0.01]
+
+  # Frequency cutoff (in Hz) for the low-pass filter used when calculating f/ALFF
+  lowpass_cutoff: [0.1]
+
+
+regional_homogeneity:
+
+  # ReHo
+  # Calculate Regional Homogeneity (ReHo) for all voxels.
+  run: Off
+
+  # Number of neighboring voxels used when calculating ReHo
+  # 7 (Faces)
+  # 19 (Faces + Edges)
+  # 27 (Faces + Edges + Corners)
+  cluster_size: 27
+
+
+voxel_mirrored_homotopic_connectivity:
+
+  # VMHC
+  # Calculate Voxel-mirrored Homotopic Connectivity (VMHC) for all voxels.
+  run: Off
+
+  symmetric_registration:
+
+    # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
+    # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
+    T1w_brain_template_symmetric: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_symmetric.nii.gz
+
+    # A reference symmetric brain template for resampling
+    T1w_brain_template_symmetric_for_resample: $FSLDIR/data/standard/MNI152_T1_1mm_brain_symmetric.nii.gz
+
+    # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
+    # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
+    T1w_template_symmetric: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_symmetric.nii.gz
+
+    # A reference symmetric skull template for resampling
+    T1w_template_symmetric_for_resample: $FSLDIR/data/standard/MNI152_T1_1mm_symmetric.nii.gz
+
+    # Included as part of the 'Image Resource Files' package available on the Install page of the User Guide.
+    # It is not necessary to change this path unless you intend to use a non-standard symmetric template.
+    dilated_symmetric_brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_symmetric_dil.nii.gz
+
+    # A reference symmetric brain mask template for resampling
+    dilated_symmetric_brain_mask_for_resample: $FSLDIR/data/standard/MNI152_T1_1mm_brain_mask_symmetric_dil.nii.gz
+
+
+network_centrality:
+
+  # Calculate Degree, Eigenvector Centrality, or Functional Connectivity Density.
+  run: Off
+
+  # Maximum amount of RAM (in GB) to be used when calculating Degree Centrality.
+  # Calculating Eigenvector Centrality will require additional memory based on the size of the mask or number of ROI nodes.
+  memory_allocation:  1.0
+
+  # Full path to a NIFTI file describing the mask. Centrality will be calculated for all voxels within the mask.
+  template_specification_file:  /cpac_templates/Mask_ABIDE_85Percent_GM.nii.gz
+
+  degree_centrality:
+
+    # Enable/Disable degree centrality by selecting the connectivity weights
+    #   weight_options: ['Binarized', 'Weighted']
+    # disable this type of centrality with:
+    #   weight_options: []
+    weight_options:  ['Binarized', 'Weighted']
+
+    # Select the type of threshold used when creating the degree centrality adjacency matrix.
+    # options:
+    #   'Significance threshold', 'Sparsity threshold', 'Correlation threshold'
+    correlation_threshold_option: 'Sparsity threshold'
+
+    # Based on the Threshold Type selected above, enter a Threshold Value.
+    # P-value for Significance Threshold
+    # Sparsity value for Sparsity Threshold
+    # Pearson's r value for Correlation Threshold
+    correlation_threshold: 0.001
+
+  eigenvector_centrality:
+
+    # Enable/Disable eigenvector centrality by selecting the connectivity weights
+    #   weight_options: ['Binarized', 'Weighted']
+    # disable this type of centrality with:
+    #   weight_options: []
+    weight_options: ['Weighted']
+
+    # Select the type of threshold used when creating the eigenvector centrality adjacency matrix.
+    # options:
+    #   'Significance threshold', 'Sparsity threshold', 'Correlation threshold'
+    correlation_threshold_option: 'Sparsity threshold'
+
+    # Based on the Threshold Type selected above, enter a Threshold Value.
+    # P-value for Significance Threshold
+    # Sparsity value for Sparsity Threshold
+    # Pearson's r value for Correlation Threshold
+    correlation_threshold: 0.001
+
+  local_functional_connectivity_density:
+
+    # Enable/Disable lFCD by selecting the connectivity weights
+    #   weight_options: ['Binarized', 'Weighted']
+    # disable this type of centrality with:
+    #   weight_options: []
+    weight_options: ['Binarized', 'Weighted']
+
+    # Select the type of threshold used when creating the lFCD adjacency matrix.
+    # options:
+    #   'Significance threshold', 'Correlation threshold'
+    correlation_threshold_option: 'Correlation threshold'
+
+    # Based on the Threshold Type selected above, enter a Threshold Value.
+    # P-value for Significance Threshold
+    # Sparsity value for Sparsity Threshold
+    # Pearson's r value for Correlation Threshold
+    correlation_threshold: 0.6
+
+
+# PACKAGE INTEGRATIONS
+# --------------------
+PyPEER:
+
+  # Training of eye-estimation models. Commonly used for movies data/naturalistic viewing.
+  run: Off
+
+  # PEER scan names to use for training
+  # Example: ['peer_run-1', 'peer_run-2']
+  eye_scan_names: []
+
+  # Naturalistic viewing data scan names to use for eye estimation
+  # Example: ['movieDM']
+  data_scan_names: []
+
+  # Template-space eye mask
+  eye_mask_path: $FSLDIR/data/standard/MNI152_T1_${func_resolution}_eye_mask.nii.gz
+
+  # PyPEER Stimulus File Path
+  # This is a file describing the stimulus locations from the calibration sequence.
+  stimulus_path: None
+
+  minimal_nuisance_correction:
+
+    # PyPEER Minimal nuisance regression
+    # Note: PyPEER employs minimal preprocessing - these choices do not reflect what runs in the main pipeline.
+    #       PyPEER uses non-nuisance-regressed data from the main pipeline.
+
+    # Global signal regression (PyPEER only)
+    peer_gsr: True
+
+    # Motion scrubbing (PyPEER only)
+    peer_scrub: False
+
+    # Motion scrubbing threshold (PyPEER only)
+    scrub_thresh: 0.2

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -771,14 +771,14 @@ def tissue_seg_EPI_template_based(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": ["tissue_segmentation", "using"],
      "option_val": "Template_Based",
      "inputs": [("desc-mean_bold",
-                 "from-template_to-bold_mode-image_desc-linear_xfm")],
+                 "from-EPItemplate_to-bold_mode-image_desc-linear_xfm")],
      "outputs": ["space-bold_label-CSF_mask",
                  "space-bold_label-GM_mask",
                  "space-bold_label-WM_mask"]}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
-        'from-template_to-bold_mode-image_desc-linear_xfm')
+        'from-EPItemplate_to-bold_mode-image_desc-linear_xfm')
     reg_tool = check_prov_for_regtool(xfm_prov)
     use_ants = reg_tool == 'ants'
 
@@ -801,7 +801,7 @@ def tissue_seg_EPI_template_based(wf, cfg, strat_pool, pipe_num, opt=None):
 
     node, out = \
         strat_pool.get_data(
-            'from-template_to-bold_mode-image_desc-linear_xfm')
+            'from-EPItemplate_to-bold_mode-image_desc-linear_xfm')
     wf.connect(node, out,
                csf_template2t1, 'inputspec.standard2highres_mat')
     wf.connect(node, out,

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -776,7 +776,12 @@ registration_workflows:
 
       # these options modify the application (to the functional data), not the calculation, of the
       # T1-to-template and EPI-to-template transforms calculated earlier during registration
+      
+      # apply the functional-to-template (T1 template) registration transform to the functional data
       run: On
+      
+      # apply the functional-to-template (EPI template) registration transform to the functional data
+      run_EPI: Off
 
       output_resolution:
 
@@ -796,17 +801,11 @@ registration_workflows:
         func_derivative_outputs: 3mm
 
       target_template:
-
-        # using: ['T1_template', 'EPI_template', 'ABCD']
-        # this is a fork point
-        # NOTE:
-        #   this will determine which registration transform to use to warp the functional
-        #   outputs and derivatives to template space.
-        #   if using 'ABCD', apply motion correction, func-to-anat, anat-to-template transforms 
-        #   on each of raw functional volume same as ABCD-options pipeline.
+      
+        # choose which template space to transform derivatives towards
+        # options: ['T1_template', 'EPI_template']
         using: ['T1_template']
 
-        # option parameters
         T1_template:
 
           # Standard Skull Stripped Template. Used as a reference image for functional registration.

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -622,7 +622,8 @@ registration_workflows:
 
     applywarp:
 
-      # using: ANTS or FSL. Choose the applywarp tool regardless of which tool to calculate transforms
+      # Choose the applywarp tool regardless of which tool to calculate transform
+      # using: 'ANTS', 'FSL' or 'ABCD-FSL'
       using: ANTS
 
   functional_registration:


### PR DESCRIPTION
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to:
- #1393 by @SucyLi 
- #1270 by @sgiavasis
- #1227 by @HechengJin0 

## Description
- Node blocks can now have multiple run switches.
- T1-template and EPI-template registration pathways are no longer two sides of the same fork, but are two separate pathways. They can still be both run within the same pipeline, however.
- Added a ["blank" pipeline config](https://github.com/FCP-INDI/C-PAC/blob/feature/abcd_v1.8-tswarp-changes/CPAC/resources/configs/pipeline_config_blank.yml) as a preconfig, intended to be imported for convenient minimal pipeline configs. All run switches are set to `Off` in this pipeline config.
- EPI template outputs now delineated with `space-EPItemplate`.
- There are still some FSL-pipeline issues in the target branch that need resolution (details below under Tests).

## Technical details
*Multiple run switches in a node block*
- Ordinarily, the pipeline config nest keys are listed in `config:` in the docstring, and the run switch key (intended as a boolean) is listed in `switch:`.
- Now, setting `config: "None"` and making `switch:` a list of lists, with each list being the full sequence of pipeline config keys down to the run switch, will make it so that all those switches must be set `On` for the node block to be connected into the pipeline. Ex:

https://github.com/FCP-INDI/C-PAC/blob/feature/abcd_v1.8-tswarp-changes/CPAC/nuisance/nuisance.py#L2300-L2314

```
     "config": "None",
     "switch": [["nuisance_corrections", "2-nuisance_regression",
                 "regressor_masks", "erode_csf", "run"],
                ["registration_workflows", "functional_registration",
                 "EPI_registration", "run"]],
```

- In the above example, the EPI-template-pipeline version of CSF mask erosion for nuisance regressor generation will only run if both the erosion and EPI registration are enabled.
- Future addition: adding the nuisance regressor creation switch as a third switch would also be a good addition, so that anyone who switches nuisance regressors off won't have to worry about switching the other keys off.

## Tests
- Tested and confirmed these additions run properly for both T1-template and EPI-template pipelines, for ANTs registration. The pipeline config:

```
FROM: pipeline_config_blank.yml

pipeline_setup:
  # Name for this pipeline configuration - useful for identification.
  pipeline_name: ANTs-T1-EPI

registration_workflows:

  anatomical_registration:
    run: On
    registration:
      using: ['ANTS']

  functional_registration:
  
    coregistration:
      run: On

    EPI_registration:
      run: On
      using: ['ANTS']
      EPI_template_mask: /data3/cnl/cpac_testing/resources/epi_hbn_automask.nii.gz

    func_registration_to_template:      
      # apply the functional-to-template (EPI template) registration transform to the functional data
      run: On
      run_EPI: On
      target_template:
        using: ['T1_template', 'EPI_template']

anatomical_preproc:
  run: On
  brain_extraction:
    run: On

functional_preproc:
  run: On
```

produced the appropriate registered outputs, with the T1 template registered T1w outputs under `anat`:

![Screen Shot 2021-04-29 at 4 05 48 PM](https://user-images.githubusercontent.com/4644673/116612057-11977000-a905-11eb-83ab-6484e64f0b1f.png)

and with both T1 template (`template`) and the EPI template space functional outputs under `func`:

![Screen Shot 2021-04-29 at 4 06 27 PM](https://user-images.githubusercontent.com/4644673/116612181-3855a680-a905-11eb-9ac7-b235b6c839de.png)

- There is a standing issue with FSL pipelines that exists in the target branch. Running with this pipeline config:

```
FROM: pipeline_config_blank.yml

pipeline_setup:
  # Name for this pipeline configuration - useful for identification.
  pipeline_name: FSL-T1-EPI

registration_workflows:

  anatomical_registration:
    run: On
    registration:
      using: ['FSL']
      
    applywarp:
      using: FSL

  functional_registration:
  
    coregistration:
      run: On

    EPI_registration:
      run: On
      using: ['FSL']
      EPI_template_mask: /data3/cnl/cpac_testing/resources/epi_hbn_automask.nii.gz

    func_registration_to_template:      
      # apply the functional-to-template (EPI template) registration transform to the functional data
      run: On
      run_EPI: On
      target_template:
        using: ['T1_template', 'EPI_template']

anatomical_preproc:
  run: On
  brain_extraction:
    run: On

functional_preproc:
  run: On
```

resulted in this error:

> Output directory /output/output does not exist yet, initializing.
> Connecting anatomical_init...
> 
> Connecting brain_mask_afni...
> 
> Connecting brain_extraction...
> 
> Connecting register_FSL_anat_to_template...
> 
> Connecting applywarp_anat_to_template...
> 
> Traceback (most recent call last):
>   File "/code/run.py", line 669, in <module>
>     test_config = 1 if args.analysis_level == "test_config" else 0
>   File "/code/CPAC/pipeline/cpac_runner.py", line 549, in run
>     p_name, plugin, plugin_args, test_config)
>   File "/code/CPAC/pipeline/cpac_pipeline.py", line 367, in run_workflow
>     subject_id, sub_dict, c, p_name, num_ants_cores
>   File "/code/CPAC/pipeline/cpac_pipeline.py", line 1156, in build_workflow
>     wf = connect_pipeline(wf, cfg, rpool, pipeline_blocks)
>   File "/code/CPAC/pipeline/cpac_pipeline.py", line 875, in connect_pipeline
>     wf = nb.connect_block(wf, cfg, rpool)
>   File "/code/CPAC/pipeline/engine.py", line 1229, in connect_block
>     pipe_x, opt)
>   File "/code/CPAC/registration/registration.py", line 2170, in applywarp_anat_to_template
>     return (wf, outputs)
> UnboundLocalError: local variable 'outputs' referenced before assignment

I believe this is related to the new `applywarp` feature in the target branch and will be an easy fix.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [ ] My commit messages follow best practices.
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
