### PR TITLE
🐛 Include index in name for each custom regressor file

### DIFF
--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -763,7 +763,9 @@ def create_regressor_workflow(nuisance_selectors,
             custom_dsort_check_s3_nodes = []
             custom_dsort_convolve_nodes = []
 
-            for custom_regressor in sorted(regressor_selector, key=lambda c: c['file']):
+            for file_num, custom_regressor in enumerate(sorted(
+                regressor_selector, key=lambda c: c['file']
+            )):
                 custom_regressor_file = custom_regressor['file']
 
                 custom_check_s3_node = pe.Node(Function(
@@ -778,15 +780,17 @@ def create_regressor_workflow(nuisance_selectors,
                     ],
                     function=check_for_s3,
                     as_module=True),
-                    name='custom_check_for_s3_%s' % name)
+                    name=f'custom_check_for_s3_{name}_{file_num}')
 
                 custom_check_s3_node.inputs.set(
                     file_path=custom_regressor_file,
                     img_type='func'
                 )
 
-                if custom_regressor_file.endswith('.nii.gz') or \
-                    custom_regressor_file.endswith('.nii'):
+                if (
+                    custom_regressor_file.endswith('.nii.gz') or
+                    custom_regressor_file.endswith('.nii')
+                ):
 
                     if custom_regressor.get('convolve'):
                         custom_dsort_convolve_nodes += [custom_check_s3_node]


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1479 by @zeosmar

## Description
<!-- Concisely describe what the pull request does. -->
Appends the index of each custom regressor file to the node name. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Prior to this change, when multiple custom regressor files were provided for a given regression, each would be assigned to a node with the same name.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
