### PR TITLE
:bug: Apply global UNDIFINED_SIZE in prerun check if FileNotFound

### DIFF
--- a/CPAC/pipeline/nipype_pipeline_engine/__init__.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/__init__.py
@@ -7,10 +7,12 @@ from nipype.pipeline import engine as pe
 # import everything in nipype.pipeline.engine.__all__
 from nipype.pipeline.engine import *  # noqa F401
 # import our DEFAULT_MEM_GB and override Node, MapNode
-from .engine import DEFAULT_MEM_GB, get_data_size, Node, MapNode, Workflow
+from .engine import DEFAULT_MEM_GB, get_data_size, Node, MapNode, \
+                    UNDEFINED_SIZE, Workflow
 
 __all__ = [
     interface for interface in dir(pe) if not interface.startswith('_')
-] + ['DEFAULT_MEM_GB', 'get_data_size', 'Node', 'MapNode', 'Workflow']
+] + ['DEFAULT_MEM_GB', 'get_data_size', 'Node', 'MapNode', 'UNDEFINED_SIZE',
+     'Workflow']
 
 del pe

--- a/CPAC/pipeline/nipype_pipeline_engine/engine.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/engine.py
@@ -16,6 +16,7 @@ from traits.trait_handlers import TraitListObject
 
 # set global default mem_gb
 DEFAULT_MEM_GB = 2.0
+UNDEFINED_SIZE = int(1e8)
 
 
 def _doctest_skiplines(docstring, lines_to_skip):
@@ -251,7 +252,7 @@ class Workflow(pe.Workflow):
                                     else:
                                         # TODO: handle S3 files
                                         # 1e8 is a small estimate
-                                        node._apply_mem_x(1e8)
+                                        node._apply_mem_x(UNDEFINED_SIZE)
 
 
 def get_data_size(filepath):

--- a/CPAC/pipeline/plugins/legacymultiproc.py
+++ b/CPAC/pipeline/plugins/legacymultiproc.py
@@ -2,6 +2,7 @@
 Nodes use too many resources."""
 from nipype.pipeline.plugins.legacymultiproc import (
     LegacyMultiProcPlugin as LegacyMultiProc, logger)
+from CPAC.pipeline.nipype_pipeline_engine import UNDEFINED_SIZE
 
 
 class LegacyMultiProcPlugin(LegacyMultiProc):
@@ -15,8 +16,12 @@ class LegacyMultiProcPlugin(LegacyMultiProc):
         overrun_message_mem = None
         overrun_message_th = None
         for node in graph.nodes():
-            if node.mem_gb > self.memory_gb:
-                tasks_mem_gb.append((node.name, node.mem_gb))
+            try:
+                node_memory_estimate = node.mem_gb
+            except FileNotFoundError:
+                node_memory_estimate = node._apply_mem_x(UNDEFINED_SIZE)
+            if node_memory_estimate > self.memory_gb:
+                tasks_mem_gb.append((node.name, node_memory_estimate))
             if node.n_procs > self.processors:
                 tasks_num_th.append((node.name, node.n_procs))
 


### PR DESCRIPTION
## Fixes
Related to #1480 by @shnizzedy 

## Description
Fixes FileNotFoundError `[Errno 2] The memory estimate for Node 'CerebrospinalFluid_2mm_flirt' depends on the input 'in_file' but no such file or directory: <undefined>`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
