### PR TITLE
[Feature] Estimate main process memory usage

### DIFF
--- a/CPAC/pipeline/plugins/legacymultiproc.py
+++ b/CPAC/pipeline/plugins/legacymultiproc.py
@@ -1,8 +1,27 @@
-"""Override Nipype's LegacyMultiproc's _prerun_check to tell which
-Nodes use too many resources."""
+"""
+
+Override Nipype's LegacyMultiproc:
+* _prerun_check to tell which Nodes use too many resources.
+* _check_resources to account for the main process' memory usage.
+
+"""
+
+import platform
+import resource
 from nipype.pipeline.plugins.legacymultiproc import (
     LegacyMultiProcPlugin as LegacyMultiProc, logger)
 from CPAC.pipeline.nipype_pipeline_engine import UNDEFINED_SIZE
+
+
+def get_peak_usage():
+    self_usage = resource.getrusage(resource.RUSAGE_SELF)
+    proc_peak = self_usage.ru_maxrss
+
+    # getrusage.ru_maxrss in bytes on Macs
+    if platform.system() == 'Darwin':
+        proc_peak /= 1024.
+
+    return proc_peak / 1024. / 1024.
 
 
 class LegacyMultiProcPlugin(LegacyMultiProc):
@@ -50,3 +69,16 @@ class LegacyMultiProcPlugin(LegacyMultiProc):
                 "Insufficient resources available for job:",
                 overrun_message_mem, overrun_message_th
             ] if msg is not None]))
+
+    def _check_resources(self, running_tasks):
+        """
+        Make sure there are resources available, accounting for Nipype memory usage
+        """
+
+        free_memory_gb, free_processors = super()._check_resources(running_tasks)
+
+        # Nipype memory usage
+        peak = get_peak_usage()
+        free_memory_gb -= peak
+
+        return free_memory_gb, free_processors


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1506 by @shnizzedy 

## Description
To precisely estimate memory usage in the node scheduling algorithm, the main process memory must be accounted for. In some scenarios, the resident memory can reach 3GB, which can cause malfunctioning in the pipeline execution. This PR accounts for the main process memory usage in the scheduling.

## Technical details
Using the `resource` package to get the peak of resident memory, the peak memory usage is subtracted from the memory available for nodes to run in the Multiproc plugin.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
- Several C-PAC runs on AWS

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
