### PR TITLE
[Bugfix] Consider participant ndx parameter when = 0

### DIFF
--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -606,7 +606,7 @@ elif args.analysis_level in ["test_config", "participant"]:
                                          args.participant_label,
                                          args.aws_input_creds)
 
-    if args.participant_ndx:
+    if args.participant_ndx is not None:
 
         participant_ndx = int(args.participant_ndx)
         if participant_ndx == -1:


### PR DESCRIPTION
## Fixes
Fixes #1526 by @anibalsolon 

## Description
The script considers the participant_ndx parameter when it is equal to 0.

## Technical details
0 evaluates to false, so it was like it was not being provided. Checking if it is None differentiates the scenarios of when it is zero and when it is not provided.

## Tests
```
 docker run fcpindi/c-pac:latest s3://fcp-indi/data/Projects/CORR/RawDataBIDS/IBA_TRT/ /output test_config --participant_ndx 0
```
runs only once.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
