### PR TITLE
🐛 Don't put `CSF_label` in a list of lists

### DIFF
--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -199,9 +199,11 @@ def _combine_labels(config_dict, list_to_combine, new_key):
             old_value = None
         if old_value is not None:
             any_old_values = True
-            if isinstance(old_value, list) and len(old_value) == 1:
-                old_value = old_value[0]
-            new_value.append(old_value)
+            if isinstance(old_value, (list, set, tuple)):
+                for value in old_value:
+                    new_value.append(value)
+            else:
+                new_value.append(old_value)
             config_dict = delete_nested_value(config_dict, _to_combine)
     if any_old_values:
         return set_nested_value(config_dict, new_key, new_value)
@@ -237,6 +239,7 @@ def _changes_1_8_0_to_1_8_1(config_dict):
     '''
     Examples
     --------
+    Starting with 1.8.0
     >>> zero = {'anatomical_preproc': {
     ...     'non_local_means_filtering': True,
     ...     'n4_bias_field_correction': True
@@ -252,9 +255,38 @@ def _changes_1_8_0_to_1_8_1(config_dict):
     ...             'right_GM_label': 2,
     ...             'left_WM_label': 3,
     ...             'right_WM_label': 4}}}}
-    >>> str(_changes_1_8_0_to_1_8_1(zero))
-    "{'anatomical_preproc': {'non_local_means_filtering': {'run': True}, 'n4_bias_field_correction': {'run': True}}, 'functional_preproc': {'motion_estimates_and_correction': {'motion_estimates': {'calculate_motion_first': False}}}, 'segmentation': {'tissue_segmentation': {'ANTs_Prior_Based': {'CSF_label': [0], 'GM_label': [1, 2], 'WM_label': [3, 4]}}}}"
-    '''  # noqa E501
+    >>> updated_apb = _changes_1_8_0_to_1_8_1(zero)[
+    ...     'segmentation']['tissue_segmentation']['ANTs_Prior_Based']
+    >>> updated_apb['CSF_label']
+    [0]
+    >>> updated_apb['GM_label']
+    [1, 2]
+    >>> updated_apb['WM_label']
+    [3, 4]
+
+    Starting with 1.8.1
+    >>> one = {'anatomical_preproc': {
+    ...     'non_local_means_filtering': True,
+    ...     'n4_bias_field_correction': True
+    ... }, 'functional_preproc': {
+    ...     'motion_estimates_and_correction': {
+    ...         'calculate_motion_first': False
+    ...     }
+    ... }, 'segmentation': {
+    ...     'tissue_segmentation': {
+    ...         'ANTs_Prior_Based': {
+    ...             'CSF_label': [0],
+    ...             'GM_label': [1, 2],
+    ...             'WM_label': [3, 4]}}}}
+    >>> updated_apb = _changes_1_8_0_to_1_8_1(one)[
+    ...     'segmentation']['tissue_segmentation']['ANTs_Prior_Based']
+    >>> updated_apb['CSF_label']
+    [0]
+    >>> updated_apb['GM_label']
+    [1, 2]
+    >>> updated_apb['WM_label']
+    [3, 4]
+    '''
     for key_sequence in {
         ('anatomical_preproc', 'non_local_means_filtering'),
         ('anatomical_preproc', 'n4_bias_field_correction')


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes a bug introduced in #1529 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->

Fixes bug that causes
```Python
Error details:
    expected int @ data['segmentation']['tissue_segmentation']['ANTs_Prior_Based']['CSF_label'][0]
```

if a 1.8.1-syntax config is provided.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

While `GM_label` and `WM_label` combined `left_` and `right_` items into new keys, `CSF_label` just changed from an integer to a list without any change to the label, so the updater function was thinking `CSF_label` needed to be updated if preset, giving dictionaries like

```Python
{'GM_label': [3, 42], 'WM_label': [2, 41], 'CSF_label': [[24]]}
```

 This PR updates the updater to check if a value is already a list, and if so, appends the value's items to the new list instead of the list itself. 

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/cfacfce1f8c3f785820b1f0680991cb45e36b0ab/CPAC/pipeline/schema.py#L267-L288

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
