### PR TITLE
Fixed a bug in the check_rpool() member function of ResourcePool.

### DIFF
--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -2154,7 +2154,7 @@ def nuisance_regression_complete(wf, cfg, strat_pool, pipe_num, opt=None):
                    'inputspec.anatomical_eroded_brain_mask_file_path')
 
     if strat_pool.check_rpool(["label-CSF_desc-eroded_mask",
-                               "label-CSF_desc-preproc_mask", 
+                               "label-CSF_desc-preproc_mask",
                                "label-CSF_mask"]):
         node, out = strat_pool.get_data(["label-CSF_desc-eroded_mask",
                                          "label-CSF_desc-preproc_mask", 
@@ -2162,10 +2162,10 @@ def nuisance_regression_complete(wf, cfg, strat_pool, pipe_num, opt=None):
         wf.connect(node, out, regressors, 'inputspec.csf_mask_file_path')
 
     if strat_pool.check_rpool(["label-WM_desc-eroded_mask",
-                               "label-WM_desc-preproc_mask", 
+                               "label-WM_desc-preproc_mask",
                                "label-WM_mask"]):
         node, out = strat_pool.get_data(["label-WM_desc-eroded_mask",
-                                         "label-WM_desc-preproc_mask", 
+                                         "label-WM_desc-preproc_mask",
                                          "label-WM_mask"])
         wf.connect(node, out, regressors, 'inputspec.wm_mask_file_path')
 

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -90,9 +90,9 @@ class ResourcePool(object):
         if not isinstance(resource, list):
             resource = [resource]
         for name in resource:
-            if name not in self.rpool:
-                return False
-        return True
+            if name in self.rpool:
+                return True
+        return False
 
     def get_pipe_number(self, pipe_idx):
         return self.pipe_list.index(pipe_idx)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes the recent WM and CSF regressor crash in the current `develop` branch.

## Description
The nature of the `check_rpool()` member function of `ResourcePool` would cause certain instances of "listed" inputs to return False when something further down the list was actually present.

## Tests
This should enable the fx-options preconfig to run properly without crashes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
