### PR TITLE
More exhaustive CpacProvenance - split nuisance - EPI-only streamlines

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -136,7 +136,8 @@ from CPAC.nuisance.nuisance import (
     ICA_AROMA_FSLreg,
     ICA_AROMA_ANTsEPIreg,
     ICA_AROMA_FSLEPIreg,
-    nuisance_regression_complete,
+    nuisance_regressors_generation,
+    nuisance_regression,
     erode_mask_T1w,
     erode_mask_CSF,
     erode_mask_GM,
@@ -1045,8 +1046,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
             bold_masking,
             calc_motion_stats,
             func_mean,
-            func_normalize,
-            func_mask_normalize
+            func_normalize#,
+            #func_mask_normalize
         ]
 
         # Distortion/Susceptibility Correction
@@ -1135,13 +1136,16 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                 'func_registration_to_template']['target_template']['using']:
             if cfg.registration_workflows['functional_registration'][
                 'func_registration_to_template']['apply_transform']['using'] == 'default':
-                nuisance.append((nuisance_regression_complete, ("desc-preproc_bold", ["desc-preproc_bold", "bold"])))
+                nuisance.append((nuisance_regressors_generation, ("desc-preproc_bold", ["desc-preproc_bold", "bold"])))
+                nuisance.append((nuisance_regression, ("desc-preproc_bold", ["desc-preproc_bold", "bold"])))
             elif cfg.registration_workflows['functional_registration'][
                 'func_registration_to_template']['apply_transform']['using'] == 'single_step_resampling':
-                nuisance.append((nuisance_regression_complete, ("desc-preproc_bold", "desc-stc_bold")))
+                nuisance.append((nuisance_regressors_generation, ("desc-preproc_bold", "desc-stc_bold")))
+                nuisance.append((nuisance_regression, ("desc-preproc_bold", "desc-stc_bold")))
             elif cfg.registration_workflows['functional_registration'][
                 'func_registration_to_template']['apply_transform']['using'] == 'abcd':
-                nuisance.append((nuisance_regression_complete, ("desc-preproc_bold", "bold")))
+                nuisance.append((nuisance_regressors_generation, ("desc-preproc_bold", "bold")))
+                nuisance.append((nuisance_regression, ("desc-preproc_bold", "bold")))
 
         if 'EPI_template' in \
             cfg.registration_workflows['functional_registration'][

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -158,27 +158,11 @@ class ResourcePool(object):
 
     def set_data(self, resource, node, output, json_info, pipe_idx, node_name,
                  fork=False, inject=False):
-        '''
-        pipe_idx, node_name = new_id
-        if f';{resource}:' not in pipe_idx:
-            pipe_idx = f'{pipe_idx};{resource}:'   # <--- doing this up here, now, because the del self.rpool[resource][pipe_idx] below should only get deleted for the same input/output tag!
-        if resource not in self.rpool.keys():
-            self.rpool[resource] = {}
-        else:
-            if not fork:     # <--- in the event of multiple strategies/options, this will run for every option; just keep in mind
-                if pipe_idx in self.rpool[resource].keys():  # <--- in case the resource name is now new, and not the original
-                    del self.rpool[resource][pipe_idx]  # <--- remove old keys so we don't end up with a new strat for every new node unit (unless we fork)
-        if pipe_idx[-1] == ';' or pipe_idx[-1] == ':':  # <--- if the ':', this kicks off when the pipe_idx is only something like 'T1w:', at the beginning
-            new_name = node_name                        #      but how do we manage new threads, mid-pipeline?
-        else:
-            new_name = f',{node_name}'
-        new_pipe_idx = f'{pipe_idx}{new_name}'
-        '''
         json_info = json_info.copy()
-
         cpac_prov = []
         if 'CpacProvenance' in json_info:
             cpac_prov = json_info['CpacProvenance']
+        current_prov_list = list(cpac_prov)
         new_prov_list = list(cpac_prov)   # <---- making a copy, it was already a list
         if not inject:
             new_prov_list.append(f'{resource}:{node_name}')
@@ -196,9 +180,23 @@ class ResourcePool(object):
             self.rpool[resource] = {}
         else:
             if not fork:     # <--- in the event of multiple strategies/options, this will run for every option; just keep in mind
+                search = False
+                if self.get_resource_from_prov(current_prov_list) == resource:
+                    pipe_idx = self.generate_prov_string(current_prov_list)[1] # CHANGING PIPE_IDX, BE CAREFUL DOWNSTREAM IN THIS FUNCTION
+                    if pipe_idx not in self.rpool[resource].keys():
+                        search = True
+                else:
+                    search = True
+                if search:
+                    for idx in current_prov_list:
+                        if self.get_resource_from_prov(idx) == resource:
+                            if isinstance(idx, list):
+                                pipe_idx = self.generate_prov_string(idx)[1] # CHANGING PIPE_IDX, BE CAREFUL DOWNSTREAM IN THIS FUNCTION
+                            elif isinstance(idx, str):
+                                pipe_idx = idx
+                            break
                 if pipe_idx in self.rpool[resource].keys():  # <--- in case the resource name is now new, and not the original
                     del self.rpool[resource][pipe_idx]  # <--- remove old keys so we don't end up with a new strat for every new node unit (unless we fork)
-
         if new_pipe_idx not in self.rpool[resource]:
             self.rpool[resource][new_pipe_idx] = {}
         if new_pipe_idx not in self.pipe_list:
@@ -832,7 +830,7 @@ class ResourcePool(object):
                     break
             if drop:
                 continue
-                
+            
             num_variant = 0
             if len(self.rpool[resource]) == 1:
                 num_variant = ""
@@ -1188,7 +1186,7 @@ class NodeBlock(object):
                         #    particularly, our custom 'CpacProvenance' field.
                         node_name = name
                         pipe_x = rpool.get_pipe_number(pipe_idx)
-                        
+
                         replaced_inputs = []
                         for interface in self.input_interface:
                             if isinstance(interface[1], list):
@@ -1277,14 +1275,6 @@ class NodeBlock(object):
                                 del new_json_info['subjson']
                             except KeyError:
                                 pass
-
-                            if strat_pool.check_rpool(label):
-                                # so we won't get extra forks if we are
-                                # merging strats (multiple inputs) plus the
-                                # output name is one of the input names
-                                old_pipe_prov = list(strat_pool.get_cpac_provenance(label))
-                                new_json_info['CpacProvenance'] = old_pipe_prov
-                                pipe_idx = strat_pool.generate_prov_string(old_pipe_prov)[1]
 
                             if fork or len(opts) > 1 or len(all_opts) > 1:
                                 if 'CpacVariant' not in new_json_info:

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -1179,9 +1179,9 @@ def create_wf_calculate_ants_warp(
                                                      'reference_brain',
                                                      'moving_skull',
                                                      'reference_skull',
-                                                     'reference_mask',
-                                                     'moving_mask',
                                                      'ants_para',
+                                                     'moving_mask',
+                                                     'reference_mask',
                                                      'fixed_image_mask',
                                                      'interp',
                                                      'reg_with_skull'],
@@ -2002,7 +2002,6 @@ def register_FSL_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, fsl, 'inputspec.input_head')
 
     node, out = strat_pool.get_data('template-ref-mask')
-
     wf.connect(node, out, fsl, 'inputspec.reference_mask')
 
     if 'space-longitudinal' in brain:

--- a/CPAC/registration/utils.py
+++ b/CPAC/registration/utils.py
@@ -57,8 +57,8 @@ def generate_inverse_transform_flags(transform_list):
     return inverse_transform_flags
 
 
-def hardcoded_reg(moving_brain, reference_brain, moving_skull,
-                  reference_skull, reference_mask, moving_mask, ants_para,
+def hardcoded_reg(moving_brain, reference_brain, moving_skull, reference_skull, 
+                  ants_para, moving_mask=None, reference_mask=None,
                   fixed_image_mask=None, interp=None, reg_with_skull=0):
     # TODO: expand transforms to cover all in ANTs para
 

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -15,10 +15,6 @@ pipeline_setup:
   # Name for this pipeline configuration - useful for identification.
   pipeline_name: analysis
 
-  log_directory: 
-
-    path: /tmp
-
   system_config: 
 
     # The maximum amount of memory each participant's workflow can allocate.
@@ -53,34 +49,7 @@ anatomical_preproc:
   run: Off
 
 segmentation: 
-
-  # Automatically segment anatomical images into white matter, gray matter,
-  # and CSF based on prior probability maps.
-  run: On
-
-  tissue_segmentation: 
-
-    using: ['Template_Based']
-
-    Template_Based: 
-
-      # These masks should be in the same space of your registration template, e.g. if
-      # you choose 'EPI Template' , below tissue masks should also be EPI template tissue masks.
-      #
-      # Options: ['T1_Template', 'EPI_Template']
-      template_for_segmentation: [EPI_Template]
-
-      # These masks are included as part of the 'Image Resource Files' package available
-      # on the Install page of the User Guide.
-
-      # Full path to a binarized White Matter mask.
-      WHITE: /template/chd8_functional_template_ventricles_ag.nii.gz
-
-      # Full path to a binarized Gray Matter mask.
-      GRAY: /template/chd8_functional_template_ventricles_ag.nii.gz
-
-      # Full path to a binarized CSF mask.
-      CSF: /template/chd8_functional_template_ventricles_ag.nii.gz
+  run: Off
 
 registration_workflows: 
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1494 by @XinhuiLi 

## Description
- Important change to the connection engine such that the strategy/resource provenance is now more exhaustive and allowed for nuisance regressor calculation, and nuisance regression itself, to be split.
- Split nuisance regressors and nuisance regression into two node blocks.
- Cleaned up required/optional inputs for nuisance regressors and regression to make it easier to run EPI-only or rodent pipelines.

## Technical details
- NOTE: It may seem there are extra regressor TSV outputs being written when nuisance is set to [On, Off], when the strategy includes bandpass filtering.
  - However, it is simply writing out the original regressors, and the bandpass filtered regressors - the filtered regressors will have the `nuisance_regression` label in `CpacVariant` alongside the regression strategy name.
  - This might be removed in the future, but it is not incorrect. It's just arguably overly thorough.

## Tests
- Run nuisance regression set to [On, Off], with either one strategy or multiple.
- Attempt running rodent pipeline.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
