### PR TITLE
Feature/rodent func skullstrip prepare

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1504,7 +1504,7 @@ def bold_mask_fsl(wf, cfg, strat_pool, pipe_num, opt=None):
             threshold_T = pe.Node(interface=fsl.ImageStats(),
                                     name=f'func_mean_skull_thr_value_{pipe_num}',
                                     iterfield=['in_file'])
-            threshold_T.inputs.op_string = "-mas %f " % (cfg.functional_preproc['func_masking']['FSL-BET']['functional_mean_thr']['threshold_value'])
+            threshold_T.inputs.op_string = "-p %f " % (cfg.functional_preproc['func_masking']['FSL-BET']['functional_mean_thr']['threshold_value'])
             
             wf.connect(func_skull_mean, 'out_file', threshold_T, 'in_file')
             

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1533,14 +1533,14 @@ def bold_mask_fsl(wf, cfg, strat_pool, pipe_num, opt=None):
             'functional_mean_bias_correction']:
 
             # fast --nopve -B ${subject}_tmean_thr.nii.gz
-            functional_mean_skull_fast = pe.Node(interface=fsl.FAST(),
-                                                    name=f'functional_mean_skull_fast_{pipe_num}')
-            functional_mean_skull_fast.inputs.no_pve = True
-            functional_mean_skull_fast.inputs.output_biascorrected = True
+            func_mean_skull_fast = pe.Node(interface=fsl.FAST(),
+                                                    name=f'func_mean_skull_fast_{pipe_num}')
+            func_mean_skull_fast.inputs.no_pve = True
+            func_mean_skull_fast.inputs.output_biascorrected = True
             
-            wf.connect(out_node, out_file, functional_mean_skull_fast, 'in_files')
+            wf.connect(out_node, out_file, func_mean_skull_fast, 'in_files')
             
-            out_node, out_file = (functional_mean_skull_fast, 'restored_image')
+            out_node, out_file = (func_mean_skull_fast, 'restored_image')
 
         wf.connect(out_node, out_file, func_get_brain_mask, 'in_file')
 

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -87,6 +87,11 @@ mutex = {  # mutually exclusive booleans
             'threshold': bool,
             'vertical_gradient': Range(min=-1, max=1, min_included=False,
                                        max_included=False),
+            'functional_mean_thr': {
+                'run': bool,
+                'threshold_value': Maybe(int),
+            },
+            'functional_mean_bias_correction': bool,
         }
     }
 }

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -193,6 +193,14 @@ functional_preproc:
       # It must be 'on' if select 'reduce_bias', 'robust', 'padding', 'remove_eyes', or 'bet_surfaces' on
       functional_mean_boolean: On
       
+      # Set an intensity threshold to improve skull stripping performances of FSL BET on rodent scans.
+      functional_mean_thr: 
+        run: On
+        threshold_value: 98
+
+      # Bias correct the functional mean image to improve skull stripping performances of FSL BET on rodent scans
+      functional_mean_bias_correction: On
+      
       # Integer value of head radius
       radius: 50
 

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -1114,6 +1114,14 @@ functional_preproc:
       # It must be 'on' if select 'reduce_bias', 'robust', 'padding', 'remove_eyes', or 'bet_surfaces' on
       functional_mean_boolean: Off
 
+      # Set an intensity threshold to improve skull stripping performances of FSL BET on rodent scans.
+      functional_mean_thr: 
+        run: Off
+        threshold_value: 98
+
+      # Bias correct the functional mean image to improve skull stripping performances of FSL BET on rodent scans
+      functional_mean_bias_correction: Off
+
       # Set the threshold value controling the brain vs non-brain voxels.
       frac: 0.3
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1414 by @HechengJin0 

## Description
<!-- Concisely describe what the pull request does. -->
threshold and fast-bias-correct func-mean-skull to improve fsl bet performance on rodent scans. 
**Proposed feature**
So the skullstripping steps should be : Tmean motion corrected image -> threshold at 98th percentile/10 (which is top 2% value/10) -> fast bias correction -> fsl-bet

## Tests

- [x] test run on lisa
sub-ag150519a functional mask improved. 0.918579->0.950603
/data3/cnl/rodent/cpac_run/output/run_2021/rodent_0712_2021_cpac182dev_preconfig_off_nuisance_improve_func_mask

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
