### PR TITLE
Nuisance regression flexibility for EPI-only pipelines

### DIFF
--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -418,6 +418,7 @@ def gather_nuisance(functional_file_path,
 def create_regressor_workflow(nuisance_selectors,
                               use_ants,
                               ventricle_mask_exist,
+                              all_bold=False,
                               name='nuisance_regressors'):
     """
     Workflow for the removal of various signals considered to be noise from resting state
@@ -1084,7 +1085,8 @@ def create_regressor_workflow(nuisance_selectors,
                         tissue_regressor_descriptor,
                         regressor_selector,
                         use_ants=use_ants,
-                        ventricle_mask_exist=ventricle_mask_exist
+                        ventricle_mask_exist=ventricle_mask_exist,
+                        all_bold=all_bold
                     )
 
                 regressor_mask_file_resource_keys += \
@@ -2494,10 +2496,10 @@ def erode_mask_boldWM(wf, cfg, strat_pool, pipe_num, opt=None):
     return (wf, outputs)
 
 
-def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
+def nuisance_regressors_generation_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     Node Block:
-    {"name": "nuisance_regression_EPItemplate",
+    {"name": "nuisance_regressors_generation_EPItemplate",
      "config": ["nuisance_corrections", "2-nuisance_regression"],
      "switch": ["create_regressors"],
      "option_key": "Regressors",
@@ -2520,9 +2522,7 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
                  "from-bold_to-EPItemplate_mode-image_desc-linear_xfm"),
                 "lateral-ventricles-mask",
                 "TR"],
-     "outputs": ["regressors",
-                 "desc-preproc_bold",
-                 "desc-cleaned_bold"]}
+     "outputs": ["regressors"]}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
@@ -2534,6 +2534,7 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
 
     regressors = create_regressor_workflow(opt, use_ants,
                                            ventricle_mask_exist=ventricle,
+                                           all_bold=True,
                                            name='nuisance_regressors_'
                                                 f'{opt["Name"]}_{pipe_num}')
 
@@ -2579,122 +2580,37 @@ def nuisance_regression_EPItemplate(wf, cfg, strat_pool, pipe_num, opt=None):
         wf.connect(node, out,
                    regressors, 'inputspec.lat_ventricles_mask_file_path')
 
-    node, out = strat_pool.get_data('from-bold_to-EPItemplate_mode-image_desc-linear_xfm')
-    wf.connect(node, out, regressors, 'inputspec.func_to_anat_linear_xfm_file_path')
+    if strat_pool.check_rpool('from-EPItemplate_to-bold_mode-image_desc-linear_xfm'):    
+        node, out = strat_pool.get_data('from-EPItemplate_to-bold_mode-image_desc-linear_xfm')
+        wf.connect(node, out, regressors, 'inputspec.mni_to_anat_linear_xfm_file_path')
+        wf.connect(node, out, regressors, 'inputspec.anat_to_func_linear_xfm_file_path')
 
-    # invert func2anat matrix to get anat2func_linear_xfm
-    anat2func_linear_xfm = pe.Node(interface=fsl.ConvertXFM(),
-                                   name=f'anat_to_func_linear_xfm_'
-                                        f'{opt["Name"]}_{pipe_num}')
-    anat2func_linear_xfm.inputs.invert_xfm = True
-    wf.connect(node, out, anat2func_linear_xfm, 'in_file')
+    if strat_pool.check_rpool('from-bold_to-EPItemplate_mode-image_desc-linear_xfm'):    
+        node, out = strat_pool.get_data('from-bold_to-EPItemplate_mode-image_desc-linear_xfm')
+        wf.connect(node, out, regressors, 'inputspec.anat_to_mni_linear_xfm_file_path')
+        wf.connect(node, out, regressors, 'inputspec.func_to_anat_linear_xfm_file_path')
 
-    wf.connect(anat2func_linear_xfm, 'out_file',
-               regressors, 'inputspec.anat_to_func_linear_xfm_file_path')
+    if strat_pool.check_rpool('movement-parameters'):    
+        node, out = strat_pool.get_data('movement-parameters')
+        wf.connect(node, out, regressors, 'inputspec.motion_parameters_file_path')
 
-    node, out = strat_pool.get_data('from-EPItemplate_to-bold_mode-image_desc-linear_xfm')
-    wf.connect(node, out, regressors, 'inputspec.mni_to_anat_linear_xfm_file_path')
+    if strat_pool.check_rpool('framewise-displacement-jenkinson'):    
+        node, out = strat_pool.get_data('framewise-displacement-jenkinson')
+        wf.connect(node, out, regressors, 'inputspec.fd_j_file_path')
 
-    node, out = strat_pool.get_data('from-bold_to-EPItemplate_mode-image_desc-linear_xfm')
-    wf.connect(node, out, regressors, 'inputspec.anat_to_mni_linear_xfm_file_path')
+    if strat_pool.check_rpool('framewise-displacement-power'):    
+        node, out = strat_pool.get_data('framewise-displacement-power')
+        wf.connect(node, out, regressors, 'inputspec.fd_p_file_path')
 
-    node, out = strat_pool.get_data('movement-parameters')
-    wf.connect(node, out, regressors, 'inputspec.motion_parameters_file_path')
-
-    node, out = strat_pool.get_data('framewise-displacement-jenkinson')
-    wf.connect(node, out, regressors, 'inputspec.fd_j_file_path')
-
-    node, out = strat_pool.get_data('framewise-displacement-power')
-    wf.connect(node, out, regressors, 'inputspec.fd_p_file_path')
-
-    node, out = strat_pool.get_data('dvars')
-    wf.connect(node, out, regressors, 'inputspec.dvars_file_path')
+    if strat_pool.check_rpool('dvars'):    
+        node, out = strat_pool.get_data('dvars')
+        wf.connect(node, out, regressors, 'inputspec.dvars_file_path')
 
     node, out = strat_pool.get_data('TR')
     wf.connect(node, out, regressors, 'inputspec.tr')
 
-    runswitch = cfg.nuisance_corrections['2-nuisance_regression']['run']
-    if not isinstance(runswitch, list):
-        runswitch = [runswitch]
-    if True in runswitch:
-        nuis = create_nuisance_regression_workflow(opt, name='nuisance_regression'
-                                                   f'_{opt["Name"]}_{pipe_num}')
-
-        node, out = strat_pool.get_data("space-bold_desc-brain_mask")
-        wf.connect(node, out, nuis, 'inputspec.functional_brain_mask_file_path')
-
-        wf.connect(regressors, 'outputspec.regressors_file_path',
-                   nuis, 'inputspec.regressor_file')
-
-        node, out = strat_pool.get_data("framewise-displacement-jenkinson")
-        wf.connect(node, out, nuis, 'inputspec.fd_j_file_path')
-
-        node, out = strat_pool.get_data("framewise-displacement-power")
-        wf.connect(node, out, nuis, 'inputspec.fd_p_file_path')
-
-        node, out = strat_pool.get_data("dvars")
-        wf.connect(node, out, nuis, 'inputspec.dvars_file_path')
-
-        if 'Bandpass' in opt:
-
-            filt = filtering_bold_and_regressors(opt, name=f'filtering_bold_and_'
-                                                 f'regressors_{opt["Name"]}_{pipe_num}')
-
-            filt.inputs.inputspec.nuisance_selectors = opt
-
-            wf.connect(regressors, 'outputspec.regressors_file_path',
-                       filt, 'inputspec.regressors_file_path')
-
-            node, out = strat_pool.get_data('space-bold_desc-brain_mask')
-            wf.connect(node, out,
-                       filt, 'inputspec.functional_brain_mask_file_path')
-
-            node, out = strat_pool.get_data('TR')
-            wf.connect(node, out, filt, 'inputspec.tr')
-
-            if cfg.nuisance_corrections['2-nuisance_regression'][
-                'bandpass_filtering_order'] == 'After':
-
-                node, out = strat_pool.get_data("desc-preproc_bold")
-                wf.connect(node, out, nuis, 'inputspec.functional_file_path')
-
-                wf.connect(nuis, 'outputspec.residual_file_path',
-                           filt, 'inputspec.functional_file_path')
-
-                outputs = {
-                    'desc-preproc_bold': (filt, 'outputspec.residual_file_path'),
-                    'desc-cleaned_bold': (filt, 'outputspec.residual_file_path'),
-                    'regressors': (filt, 'outputspec.residual_regressor')
-                }
-
-            elif cfg.nuisance_corrections['2-nuisance_regression'][
-                'bandpass_filtering_order'] == 'Before':
-
-                node, out = strat_pool.get_data("desc-preproc_bold")
-                wf.connect(node, out, filt, 'inputspec.functional_file_path')
-
-                wf.connect(filt, 'outputspec.residual_file_path',
-                           nuis, 'inputspec.functional_file_path')
-
-                outputs = {
-                    'desc-preproc_bold': (nuis, 'outputspec.residual_file_path'),
-                    'desc-cleaned_bold': (nuis, 'outputspec.residual_file_path'),
-                    'regressors': (filt, 'outputspec.residual_regressor')
-                }
-
-        else:
-            node, out = strat_pool.get_data("desc-preproc_bold")
-            wf.connect(node, out, nuis, 'inputspec.functional_file_path')
-            
-            outputs = {
-                'desc-preproc_bold': (nuis, 'outputspec.residual_file_path'),
-                'desc-cleaned_bold': (nuis, 'outputspec.residual_file_path'),
-                'regressors': (regressors, 'outputspec.regressors_file_path')
-            }
-
-    else:
-        outputs = {
-            'regressors': (regressors, 'outputspec.regressors_file_path')
-        }
+    outputs = {
+        'regressors': (regressors, 'outputspec.regressors_file_path')
+    }
 
     return (wf, outputs)

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -271,7 +271,8 @@ def generate_summarize_tissue_mask(nuisance_wf,
                                    regressor_descriptor,
                                    regressor_selector,
                                    use_ants=True,
-                                   ventricle_mask_exist=True):
+                                   ventricle_mask_exist=True,
+                                   all_bold=False):
     """
     Add tissue mask generation into pipeline according to the selector.
 
@@ -317,6 +318,10 @@ def generate_summarize_tissue_mask(nuisance_wf,
             pass
 
         elif step == 'resolution':
+        
+            if all_bold:
+                pass
+        
             mask_to_epi = pe.Node(interface=fsl.FLIRT(),
                                   name='{}_flirt'
                                        .format(node_mask_key),

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -142,7 +142,7 @@ from CPAC.nuisance.nuisance import (
     erode_mask_CSF,
     erode_mask_GM,
     erode_mask_WM,
-    nuisance_regression_EPItemplate,
+    nuisance_regressors_generation_EPItemplate,
     erode_mask_bold,
     erode_mask_boldCSF,
     erode_mask_boldGM,
@@ -1151,7 +1151,18 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
             cfg.registration_workflows['functional_registration'][
                 'func_registration_to_template']['target_template'][
                 'using']:
-                nuisance.append(nuisance_regression_EPItemplate)
+            if cfg.registration_workflows['functional_registration'][
+                'func_registration_to_template']['apply_transform']['using'] == 'default':
+                nuisance.append((nuisance_regressors_generation_EPItemplate, ("desc-preproc_bold", ["desc-preproc_bold", "bold"])))
+                nuisance.append((nuisance_regression, ("desc-preproc_bold", ["desc-preproc_bold", "bold"])))
+            elif cfg.registration_workflows['functional_registration'][
+                'func_registration_to_template']['apply_transform']['using'] == 'single_step_resampling':
+                nuisance.append((nuisance_regressors_generation_EPItemplate, ("desc-preproc_bold", "desc-stc_bold")))
+                nuisance.append((nuisance_regression, ("desc-preproc_bold", "desc-stc_bold")))
+            elif cfg.registration_workflows['functional_registration'][
+                'func_registration_to_template']['apply_transform']['using'] == 'abcd':
+                nuisance.append((nuisance_regressors_generation_EPItemplate, ("desc-preproc_bold", "bold")))
+                nuisance.append((nuisance_regression, ("desc-preproc_bold", "bold")))
 
         pipeline_blocks += nuisance
 

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -61,8 +61,8 @@ valid_options = {
         'segmentation': {
             'erode_mask': bool,
             'extraction_resolution': Any(
-                int, float, str), #All(str, Match(resolution_regex))
-            #),
+                int, float, 'Functional', All(str, Match(resolution_regex))
+            ),
             'include_delayed': bool,
             'include_delayed_squared': bool,
             'include_squared': bool,

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -61,8 +61,8 @@ valid_options = {
         'segmentation': {
             'erode_mask': bool,
             'extraction_resolution': Any(
-                int, float, All(str, Match(resolution_regex))
-            ),
+                int, float, str), #All(str, Match(resolution_regex))
+            #),
             'include_delayed': bool,
             'include_delayed_squared': bool,
             'include_squared': bool,

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -1558,7 +1558,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig="T1w",
         mem_x=(8969357042487455 / 1208925819614629174706176, 'input_image'))
     write_composite_linear_xfm.inputs.print_out_composite_warp_file = True
     write_composite_linear_xfm.inputs.output_image = \
-        "from-T1w_to-{sym}{tmpl}template_mode-image_desc-linear_xfm.nii.gz"
+        f"from-{orig}_to-{sym}{tmpl}template_mode-image_desc-linear_xfm.nii.gz"
 
     wf.connect(inputNode, 'input_brain',
                write_composite_linear_xfm, 'input_image')
@@ -1610,7 +1610,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig="T1w",
         mem_x=(1367826948979337 / 151115727451828646838272, 'input_image'))
     write_composite_invlinear_xfm.inputs.print_out_composite_warp_file = True
     write_composite_invlinear_xfm.inputs.output_image = \
-        "from-{sym}{tmpl}template_to-T1w_mode-image_desc-linear_xfm.nii.gz"
+        f"from-{sym}{tmpl}template_to-{orig}_mode-image_desc-linear_xfm.nii.gz"
 
     wf.connect(inputNode, 'reference_brain',
                write_composite_invlinear_xfm, 'input_image')
@@ -1672,7 +1672,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig="T1w",
         mem_gb=1.5)
     write_composite_xfm.inputs.print_out_composite_warp_file = True
     write_composite_xfm.inputs.output_image = \
-        f"from-T1w_to-{sym}{tmpl}template_mode-image_xfm.nii.gz"
+        f"from-{orig}_to-{sym}{tmpl}template_mode-image_xfm.nii.gz"
 
     wf.connect(inputNode, 'input_brain', write_composite_xfm, 'input_image')
 
@@ -1723,7 +1723,7 @@ def ANTs_registration_connector(wf_name, cfg, params, orig="T1w",
         mem_x=(6278549929741219 / 604462909807314587353088, 'input_image'))
     write_composite_inv_xfm.inputs.print_out_composite_warp_file = True
     write_composite_inv_xfm.inputs.output_image = \
-        "from-{sym}{tmpl}template_to-T1w_mode-image_xfm.nii.gz"
+        f"from-{sym}{tmpl}template_to-{orig}_mode-image_xfm.nii.gz"
 
     wf.connect(inputNode, 'reference_brain',
                write_composite_inv_xfm, 'input_image')
@@ -1782,6 +1782,8 @@ def ANTs_registration_connector(wf_name, cfg, params, orig="T1w",
                write_composite_inv_xfm, 'invert_transform_flags')
 
     outputs = {
+        f'space-{sym}template_desc-brain_{orig}': (
+            ants_reg_anat_mni, 'outputspec.normalized_output_brain'),
         f'from-{orig}_to-{sym}{tmpl}template_mode-image_xfm': (
             write_composite_xfm, 'output_image'),
         f'from-{sym}{tmpl}template_to-{orig}_mode-image_xfm': (
@@ -2377,7 +2379,7 @@ def register_ANTs_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
     params = cfg.registration_workflows['functional_registration'][
         'EPI_registration']['ANTs']['parameters']
 
-    ants, outputs = ANTs_registration_connector('ANTS_T1_to_EPI-template'
+    ants, outputs = ANTs_registration_connector('ANTS_bold_to_EPI-template'
                                                 f'_{pipe_num}', cfg, params,
                                                 orig='bold', template='EPI')                                                
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes an issue in the `develop` branch regarding EPI-only pipelines and nuisance.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- More work is needed to make it easier to use a ventricles mask for CSF regression, if a CSF mask is not present or if segmentation is not enabled.

## Tests
- [ ] Running an EPI-only pipeline with nuisance regression strategies.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
