### PR TITLE
🔊 Restore status callback

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -276,9 +276,6 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
     else:
         plugin_args = {'memory_gb': sub_mem_gb, 'n_procs': num_cores_per_sub}
 
-    if not plugin:
-        plugin = LegacyMultiProcPlugin(plugin_args)
-
     # perhaps in future allow user to set threads maximum
     # this is for centrality mostly
     # import mkl
@@ -484,6 +481,9 @@ Please, make yourself aware of how it works and its assumptions:
 
             if plugin_args['n_procs'] == 1:
                 plugin = 'Linear'
+
+            if not plugin:
+                plugin = LegacyMultiProcPlugin(plugin_args)
 
             try:
                 # Actually run the pipeline now, for the current subject

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -191,7 +191,7 @@ from CPAC.utils.utils import (
     check_system_deps,
 )
 
-from CPAC.utils.monitoring import log_nodes_cb, log_nodes_initial
+from CPAC.utils.monitoring import log_nodes_initial
 from CPAC.utils.monitoring.draw_gantt_chart import resource_report
 
 logger = logging.getLogger('nipype.workflow')
@@ -476,8 +476,6 @@ Please, make yourself aware of how it works and its assumptions:
                           "CPAC v%s, please install Nipype version 1.5.1\n" \
                           % (CPAC.__version__)
                 logger.error(err_msg)
-            else:
-                plugin_args['status_callback'] = log_nodes_cb
 
             if plugin_args['n_procs'] == 1:
                 plugin = 'Linear'

--- a/CPAC/pipeline/plugins/legacymultiproc.py
+++ b/CPAC/pipeline/plugins/legacymultiproc.py
@@ -11,6 +11,7 @@ import resource
 from nipype.pipeline.plugins.legacymultiproc import (
     LegacyMultiProcPlugin as LegacyMultiProc, logger)
 from CPAC.pipeline.nipype_pipeline_engine import UNDEFINED_SIZE
+from CPAC.utils.monitoring import log_nodes_cb
 
 
 def get_peak_usage():
@@ -25,7 +26,12 @@ def get_peak_usage():
 
 
 class LegacyMultiProcPlugin(LegacyMultiProc):
+    """Nipype's LegacyMultiprocPlugin with some modifications for C-PAC"""
     def __init__(self, plugin_args=None):
+        if not isinstance(plugin_args, dict):
+            plugin_args = {}
+        if 'status_callback' not in plugin_args:
+            plugin_args['status_callback'] = log_nodes_cb
         super().__init__(plugin_args)
 
     def _prerun_check(self, graph):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1480 & #1509 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Fixes a bug where multicore runs were not logging resource usage.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
In #1499, this initialization https://github.com/FCP-INDI/C-PAC/blob/44ac6a6ebd69ab908788deb2d5cfa09ce5ef6f2c/dev/docker_data/run.py#L667-L669 doesn't yet have https://github.com/FCP-INDI/C-PAC/blob/44ac6a6ebd69ab908788deb2d5cfa09ce5ef6f2c/CPAC/pipeline/cpac_pipeline.py#L445, so Nipype defaults to logging without monitoring. Instead of setting logging at that point, this PR updates our customized `LegacyMultiProcPlugin` to always initialize with resource montioring: https://github.com/FCP-INDI/C-PAC/blob/a1b72867d5e389df669115f4e2fefe0eb325cc69/CPAC/pipeline/plugins/legacymultiproc.py#L28-L35

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
