### PR TITLE
🔇 Prevent SetUpFreesurfer from trying to load Matlab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,7 +237,8 @@ COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 # set shell to BASH
 RUN mkdir -p /usr/lib/freesurfer
 ENV FREESURFER_HOME="/usr/lib/freesurfer" \
-    PATH="/usr/lib/freesurfer/bin:$PATH"
+    PATH="/usr/lib/freesurfer/bin:$PATH" \
+    NO_FSFAST=1
 SHELL ["/bin/bash", "-c"]
 RUN curl -fsSL --retry 5 https://dl.dropbox.com/s/nnzcfttc41qvt31/recon-all-freesurfer6-3.min.tgz \
     | tar -xz -C /usr/lib/freesurfer --strip-components 1 && \

--- a/variant-ABCD-HCP.Dockerfile
+++ b/variant-ABCD-HCP.Dockerfile
@@ -277,7 +277,8 @@ COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 # set shell to BASH
 RUN mkdir -p /usr/lib/freesurfer
 ENV FREESURFER_HOME="/usr/lib/freesurfer" \
-    PATH="/usr/lib/freesurfer/bin:$PATH"
+    PATH="/usr/lib/freesurfer/bin:$PATH" \
+    NO_FSFAST=1
 SHELL ["/bin/bash", "-c"]
 RUN apt-get install -y \
     bc \

--- a/variant-fMRIPrep-LTS.Dockerfile
+++ b/variant-fMRIPrep-LTS.Dockerfile
@@ -219,7 +219,8 @@ COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 # install FreeSurfer
 # set shell to BASH
 SHELL ["/bin/bash", "-c"]
-ENV FREESURFER_HOME=/usr/lib/freesurfer
+ENV FREESURFER_HOME=/usr/lib/freesurfer  \
+    NO_FSFAST=1
 RUN mkdir -p /usr/lib/freesurfer && \
     curl -sSL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz | tar zxv --no-same-owner -C /usr/lib \
     --exclude='freesurfer/diffusion' \


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Prevents FreeSurfer from looking for nonexistant `~/matlab/startup.m` during setup.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
References
* > it is not a problem if you're not going to run FS-FAST. If it 
bugs you, you can
setenv NO_FSFAST 1

   ― [:email: Re: [Freesurfer] Set Up question. Doug Greve](https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/msg29371.html)
* ```BASH
    echo "5. If NO_FSFAST is set (to anything), "
    echo "   then the startup.m stuff is ignored."
   ```
    ― [TimVanMourik/OpenFmriAnalysis@`8cec6d3`/Core/FreeSurferEnv.sh#L39-L40](https://github.com/TimVanMourik/OpenFmriAnalysis/blob/8cec6d3c21e7939515349946919708645138bcd3/Core/FreeSurferEnv.sh#L39-L40)

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
### Before

```
Loading 🐳 Docker
Loading 🐳 fcpindi/c-pac:nightly with these directory bindings:
  local                                       Docker                                  mode
  ------------------------------------------  --------------------------------------  ------
  /media/ebs/cpac_minimal-config              /media/ebs/cpac_minimal-config          rw
  /media/ebs/cpac_minimal-config              /outputs                                rw
  /media/ebs/cpac_minimal-config              /tmp                                    rw
  /media/ebs/cpac_minimal-config/outputs      /media/ebs/cpac_minimal-config/outputs  rw
  /media/ebs/CPAC_regtest_pack                /configs                                rw
  /media/ebs/cpac_minimal-config/outputs/log  /logs                                   rw
  /media/ebs/cpac_minimal-                    /output                                 rw
  config/outputs/outputs
Logging messages will refer to the Docker paths.

INFO: //matlab/startup.m does not exist ... creating
mkdir: cannot create directory ‘//matlab’: Permission denied
touch: cannot touch '//matlab/startup.m': No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 231: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 232: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 233: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 234: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 235: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 236: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 237: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 238: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 239: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 240: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 241: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 242: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 243: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 244: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 245: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 246: //matlab/startup.m: No such file or directory
/usr/lib/freesurfer/FreeSurferEnv.sh: line 247: //matlab/startup.m: No such file or directory
grep: //matlab/startup.m: No such file or directory
grep: //matlab/startup.m: No such file or directory
grep: //matlab/startup.m: No such file or directory
Running the 'fmriprep-options' pre-configured pipeline.
#### Running C-PAC
```

### After

```
Loading 🐳 Docker
Loading 🐳 fcpindi/c-pac:mute_matlab-freesurfer-warning with these directory bindings:
  local                                       Docker                                  mode
  ------------------------------------------  --------------------------------------  ------
  /media/ebs/cpac_minimal-config              /media/ebs/cpac_minimal-config          rw
  /media/ebs/cpac_minimal-config              /outputs                                rw
  /media/ebs/cpac_minimal-config              /tmp                                    rw
  /media/ebs/cpac_minimal-config/outputs      /media/ebs/cpac_minimal-config/outputs  rw
  /media/ebs/CPAC_regtest_pack                /configs                                rw
  /media/ebs/cpac_minimal-config/outputs/log  /crash                                  rw
  /media/ebs/cpac_minimal-                    /output                                 rw
  config/outputs/outputs
Logging messages will refer to the Docker paths.

Running the 'fmriprep-options' pre-configured pipeline.
#### Running C-PAC
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
