### PR TITLE
🔊 Restore resource logging for linear plugin

### DIFF
--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -15,6 +15,7 @@ from urllib.error import HTTPError
 from CPAC import __version__
 from CPAC.pipeline.plugins import LegacyMultiProcPlugin
 from CPAC.utils.configuration import Configuration
+from CPAC.utils.monitoring import log_nodes_cb
 from CPAC.utils.yaml_template import create_yaml_from_template, \
                                      upgrade_pipeline_to_1_8
 from CPAC.utils.utils import load_preconfig, update_nested_dict
@@ -682,11 +683,14 @@ elif args.analysis_level in ["test_config", "participant"]:
                 pass
 
         plugin_args = {
-            'n_procs': int(c['pipeline_setup']['system_config']['max_cores_per_participant']),
-            'memory_gb': int(c['pipeline_setup']['system_config']['maximum_memory_per_participant']),
+            'n_procs': int(c['pipeline_setup']['system_config'][
+                'max_cores_per_participant']),
+            'memory_gb': int(c['pipeline_setup']['system_config'][
+                'maximum_memory_per_participant']),
+            'status_callback': log_nodes_cb
         }
 
-        print ("Starting participant level processing")
+        print("Starting participant level processing")
         CPAC.pipeline.cpac_runner.run(
             data_config_file,
             pipeline_config_file,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1549 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
#1549 resolves the issue for MultiProc by moving the callback initialization into the the custom plugin initialization, but for Linear we use the built-in plugin. This PR restores the `status_callback` initialization in `plugin_args` in `run.py` to allow Linear to also log resource usage.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
