### PR TITLE
Update and fix fmriprep-opts preconfig related changes

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -718,14 +718,16 @@ def niworkflows_ants_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
         strat_pool.check_rpool('desc-reorient_T1w') or \
             strat_pool.check_rpool('T1w'): 
         outputs = {
-            'space-T1w_desc-brain_mask': (anat_skullstrip_ants, 'atropos_wf.copy_xform.out_mask')
+            'space-T1w_desc-brain_mask': (anat_skullstrip_ants, 'atropos_wf.copy_xform.out_mask'),
+            'desc-preproc_T1w': (anat_skullstrip_ants, 'copy_xform.out_file')
         }
 
     elif strat_pool.check_rpool('desc-preproc_T2w') or \
         strat_pool.check_rpool('desc-reorient_T2w') or \
             strat_pool.check_rpool('T2w'):
         outputs = {
-            'space-T2w_desc-brain_mask': (anat_skullstrip_ants, 'atropos_wf.copy_xform.out_mask')
+            'space-T2w_desc-brain_mask': (anat_skullstrip_ants, 'atropos_wf.copy_xform.out_mask'),
+            'desc-preproc_T2w': (anat_skullstrip_ants, 'copy_xform.out_file')
         }
 
     return (wf, outputs)
@@ -1647,7 +1649,8 @@ def brain_mask_niworkflows_ants(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": ["anatomical_preproc", "brain_extraction", "using"],
      "option_val": "niworkflows-ants",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
-     "outputs": ["space-T1w_desc-brain_mask"]}
+     "outputs": ["space-T1w_desc-brain_mask",
+                 "desc-preproc_T1w"]}
     '''
 
     wf, outputs = niworkflows_ants_brain_connector(wf, cfg, strat_pool,
@@ -1665,7 +1668,8 @@ def brain_mask_acpc_niworkflows_ants(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": ["anatomical_preproc", "brain_extraction", "using"],
      "option_val": "niworkflows-ants",
      "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"]],
-     "outputs": ["space-T1w_desc-acpcbrain_mask"]}
+     "outputs": ["space-T1w_desc-acpcbrain_mask",
+                 "desc-preproc_T1w"]}
     '''
 
     wf, wf_outputs = niworkflows_ants_brain_connector(wf, cfg, strat_pool,
@@ -1673,7 +1677,9 @@ def brain_mask_acpc_niworkflows_ants(wf, cfg, strat_pool, pipe_num, opt=None):
 
     outputs = {
         'space-T1w_desc-acpcbrain_mask':
-            wf_outputs['space-T1w_desc-brain_mask']
+            wf_outputs['space-T1w_desc-brain_mask'],
+        'desc-preproc_T1w':
+            wf_outputs['desc-preproc_T1w']
     }
 
     return (wf, outputs)

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1184,22 +1184,20 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
             apply_func_warp = False
 
     if apply_func_warp:
-        pipeline_blocks += [[warp_timeseries_to_T1template,
-                             warp_timeseries_to_T1template_abcd,
-                             warp_timeseries_to_T1template_dcan_nhp,
-                             single_step_resample_timeseries_to_T1template],
+
+        ts_to_T1template_block = [warp_timeseries_to_T1template,
+                                  warp_timeseries_to_T1template_dcan_nhp]
+
+        if cfg.nuisance_corrections['2-nuisance_regression']['create_regressors']:
+            ts_to_T1template_block += [(warp_timeseries_to_T1template_abcd, ('desc-cleaned_bold', 'bold'))]
+            ts_to_T1template_block += [(single_step_resample_timeseries_to_T1template, ('desc-cleaned_bold', 'desc-stc_bold'))]
+        else:
+            ts_to_T1template_block.append(warp_timeseries_to_T1template_abcd)
+            ts_to_T1template_block.append(single_step_resample_timeseries_to_T1template)
+
+        pipeline_blocks += [ts_to_T1template_block,
                             warp_bold_mean_to_T1template,
                             warp_bold_mean_to_EPItemplate]
-
-    # ABCD end-to-end pipeline
-    if cfg.registration_workflows['functional_registration']['func_registration_to_template'][
-        'apply_transform']['using'] == 'abcd' and cfg.nuisance_corrections['2-nuisance_regression']['create_regressors']:
-        pipeline_blocks += [(warp_timeseries_to_T1template_abcd, ('bold', 'desc-cleaned_bold'))]
-
-    # fMRIPrep end-to-end pipeline
-    if cfg.registration_workflows['functional_registration']['func_registration_to_template'][
-        'apply_transform']['using'] == 'single_step_resampling' and cfg.nuisance_corrections['2-nuisance_regression']['create_regressors']:
-        pipeline_blocks += [(single_step_resample_timeseries_to_T1template, ('desc-stc_bold', 'desc-cleaned_bold'))]
 
     if not rpool.check_rpool('space-template_desc-bold_mask'):
         pipeline_blocks += [warp_bold_mask_to_T1template,

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -360,7 +360,7 @@ nuisance_corrections:
     run: [Off]
 
     # switch to Off if nuisance regression is off and you don't want to write out the regressors
-    create_regressors: Off
+    create_regressors: On
 
     # Select which nuisance signal corrections to apply
     Regressors: 

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -74,15 +74,6 @@ pipeline_setup:
 
 anatomical_preproc: 
 
-  # N4 bias field correction via ANTs
-  n4_bias_field_correction:
-
-    # this is a fork option
-    run: [On]
-
-    # An integer to resample the input image to save computation time. Shrink factors <= 4 are commonly used.
-    shrink_factor: 2
-
   brain_extraction: 
 
     # using: ['3dSkullStrip', 'BET', 'UNet', 'niworkflows-ants']


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1567 by @sgiavasis
Fixes an error in `v1.8.1-develop`.

## Description
- Restores the original skull-stripped T1-brain output for the `niworkflows_ants` brain extraction workflow.
- Fixes an error (in `develop`) with the timeseries warp-to-template node block changes that would block the pipeline from running during `fmriprep-options` preconfig runs, if `create_regressors` was enabled.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
