### PR TITLE
Added argument num_ants_threads to run.py. 

### DIFF
--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -287,6 +287,11 @@ parser.add_argument('--mem_gb', type=float,
                          'takes precedence over '
                          'maximum_memory_per_participant in the pipeline '
                          'configuration file.')
+parser.add_argument('--num_ants_threads', type=int, default=1,
+                    help='The number of coresto allocate to ANTS-based anatomical '
+                        'registration per participant. Multiple cores can greatly '
+                        'speed up this preprocessing step. This number cannot be '
+                        'greater than the number of cores per participant.')                        
 
 parser.add_argument('--save_working_dir', nargs='?',
                     help='Save the contents of the working directory.', default=False)
@@ -552,6 +557,18 @@ elif args.analysis_level in ["test_config", "participant"]:
                 'max_cores_per_participant'] = args.n_cpus
             c['pipeline_setup']['system_config'][
                 'num_participants_at_once'] = 1
+
+    ##### Num_ants_threads code added here #####
+
+    if int(args.num_ants_threads) == 0:
+        try:
+            args.num_ants_threads = c['pipeline_setup', 'system_config',
+                                    'num_ants_threads']
+        except KeyError:
+            args.num_ants_threads = 3
+    c['pipeline_setup', 'system_config', 
+    'num_ants_threads'] = int(args.num_ants_threads)
+    #################################################
 
     c['pipeline_setup']['system_config']['num_ants_threads'] = min(
         c['pipeline_setup']['system_config']['max_cores_per_participant'],

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -287,8 +287,8 @@ parser.add_argument('--mem_gb', type=float,
                          'takes precedence over '
                          'maximum_memory_per_participant in the pipeline '
                          'configuration file.')
-parser.add_argument('--num_ants_threads', type=int, default=1,
-                    help='The number of coresto allocate to ANTS-based anatomical '
+parser.add_argument('--num_ants_threads', type=int, default=0,
+                    help='The number of cores to allocate to ANTS-based anatomical '
                         'registration per participant. Multiple cores can greatly '
                         'speed up this preprocessing step. This number cannot be '
                         'greater than the number of cores per participant.')                        
@@ -558,8 +558,6 @@ elif args.analysis_level in ["test_config", "participant"]:
             c['pipeline_setup']['system_config'][
                 'num_participants_at_once'] = 1
 
-    ##### Num_ants_threads code added here #####
-
     if int(args.num_ants_threads) == 0:
         try:
             args.num_ants_threads = c['pipeline_setup', 'system_config',
@@ -568,7 +566,6 @@ elif args.analysis_level in ["test_config", "participant"]:
             args.num_ants_threads = 3
     c['pipeline_setup', 'system_config', 
     'num_ants_threads'] = int(args.num_ants_threads)
-    #################################################
 
     c['pipeline_setup']['system_config']['num_ants_threads'] = min(
         c['pipeline_setup']['system_config']['max_cores_per_participant'],


### PR DESCRIPTION

## Fixes
This fix allows for use of parameter `num_ants_threads` in the command line, without having to modify a pipeline config. 
Fixes #1563  by @amygutierrez 

## Description
This pull request will allow for a parameter `--num_ants_threads {number}` to be used in the command line when creating a docker run. This is helpful to easily change the number of cores to allocate to ANTS-based anatomical registration per participant.

## Technical details
Added `parser.add_argument('num_ants_threads')` to lines 290 and added if-loop for different conditions in line 561 of code run.py

## Tests
Pulled this branch into the server and ran using s3://fcp-indi/data/Projects/ADHD200/RawDataBIDS/NYU dataset and 1 subject. Two separate runs were done. 
First docker run: 
`docker run --security-opt=apparmor:unconfined -v /home/agutierrez/Documents/C-PAC:/code -v /home/agutierrez/Documents/C-PAC/dev/docker_data/run.py:/code/run.py -v /home/agutierrez/Documents/C-PAC/dev/docker_data/run-with-freesurfer.sh:/code/run-with-freesurfer.sh -v /home/agutierrez/Documents/C-PAC/dev/docker_data/bids_utils.py:/code/bids_utils.py -v /home/agutierrez/Documents/C-PAC/dev/docker_data/default_pipeline.yml:/cpac_resources/default_pipeline.yml -v /data3/cnl/agutierrez/issue_runs/ants-argument1563:/output fcpindi/c-pac:nightly s3://fcp-indi/data/Projects/ADHD200/RawDataBIDS/NYU /output participant --save_working_dir --skip_bids_validator --n_cpus 1 --mem_gb 15 --num_ants_threads 2 --participant_label sub-0010001` 
Notice that the --n_cpus 1 and --num_ants_threads 2. This should result in num_ants_threads 1 in the config_pipeline.yml file, because the number of cores for ANTS-based anatomical registration can't be greater than the number of cores. 

Second docker run: 
`docker run --security-opt=apparmor:unconfined -v /home/agutierrez/Documents/C-PAC:/code -v /home/agutierrez/Documents/C-PAC/dev/docker_data/run.py:/code/run.py -v /home/agutierrez/Documents/C-PAC/dev/docker_data/run-with-freesurfer.sh:/code/run-with-freesurfer.sh -v /home/agutierrez/Documents/C-PAC/dev/docker_data/bids_utils.py:/code/bids_utils.py -v /home/agutierrez/Documents/C-PAC/dev/docker_data/default_pipeline.yml:/cpac_resources/default_pipeline.yml -v /data3/cnl/agutierrez/issue_runs/ants-argument1563_01:/output fcpindi/c-pac:nightly s3://fcp-indi/data/Projects/ADHD200/RawDataBIDS/NYU /output participant --save_working_dir --skip_bids_validator --n_cpus 2 --mem_gb 15 --num_ants_threads 2 --participant_label sub-0010001` This docker run should result in num_ants_threads 2 in the config_pipeline.yml file.

## Screenshots
pipeline_config.yml file from First docker run:
![image](https://user-images.githubusercontent.com/58920810/134716308-d73384e9-eab3-4d81-88a5-fa106070a1b6.png)

pipeline_config.yml file from Second docker run:
![image](https://user-images.githubusercontent.com/58920810/134716428-58df883d-c24b-4c8e-a8c5-4c3d7c5a3d04.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
