### PR TITLE
👷 CI: Fail on failure

### DIFF
--- a/dev/circleci_data/test_in_image.sh
+++ b/dev/circleci_data/test_in_image.sh
@@ -4,4 +4,8 @@ pip install -r /code/dev/circleci_data/requirements.txt
 # run test with coverage as module
 python -m coverage run --include */CPAC/*,*/run.py,*/bids_utils.py,*/dev/docker_data/* -m pytest --ignore-glob=*test_install.py --junitxml=test-results/junit.xml --doctest-modules dev/circleci_data /code/CPAC
 
+echo "$?" > test-results/exitcode
+
 echo "coverage saved to ${COVERAGE_FILE}"
+
+exit $(cat test-results/exitcode)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1598 by @shnizzedy 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Saves the exitcode of the test to a file, then reads that file as an exitcode at the end of the testing step.

The test that is failing here should be resolved in #1596.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![Failed: 1 test failed](https://user-images.githubusercontent.com/5974438/138892361-859ef6f3-f8e9-4937-8c3d-05f4cc28d891.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
