### PR TITLE
Use_priors correction: using xfm when turned On only

### DIFF
--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -604,11 +604,13 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     use_priors = cfg['segmentation']['tissue_segmentation'][
         'FSL-FAST']['use_priors']['run']
 
+    long = ''
+    if 'space-longitudinal' in resource:
+        long = 'space-longitudinal_'
+    
     if use_priors: 
-        long = ''
         xfm = 'from-template_to-T1w_mode-image_desc-linear_xfm'
         if 'space-longitudinal' in resource:
-            long = 'space-longitudinal_'
             xfm = 'from-template_to-longitudinal_mode-image_desc-linear_xfm'
         xfm_prov = strat_pool.get_cpac_provenance(xfm)
         reg_tool = check_prov_for_regtool(xfm_prov)

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -602,7 +602,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
                                'use'] == 'Custom'
 
     use_priors = cfg['segmentation']['tissue_segmentation'][
-        'FSL-FAST']['use_priors']['run'] =='On'
+        'FSL-FAST']['use_priors']['run']
 
     if use_priors: 
         long = ''
@@ -615,6 +615,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     else:
         xfm_prov = None
         reg_tool = None
+        xfm = None
 
 
     process_csf = process_segment_map(f'CSF_{pipe_num}', use_priors,

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -178,8 +178,7 @@ def process_segment_map(wf_name, use_priors, use_custom_threshold, reg_tool):
         # probability map
         input_1, value_1 = (inputNode, 'probability_tissue_map')
 
-    ####### Added This Line    
-    use_priors = cfg['segmentation']['tissue_segmentation']['FSL-FAST']['use_priors']['run']
+
 
     if use_priors:
         apply_xfm = apply_transform(f'seg_tissue_priors_template_to_T1',
@@ -603,7 +602,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
                                'use'] == 'Custom'
 
     use_priors = cfg['segmentation']['tissue_segmentation'][
-        'FSL-FAST']['use_priors']['run']
+        'FSL-FAST']['use_priors']['run'] =='On'
 
     if use_priors: 
         long = ''

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -601,7 +601,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
 
     use_priors = cfg['segmentation']['tissue_segmentation'][
         'FSL-FAST']['use_priors']['run']
-    xfm = None
+
     if use_priors: 
         long = ''
         xfm = 'from-template_to-T1w_mode-image_desc-linear_xfm'

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -601,7 +601,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
 
     use_priors = cfg['segmentation']['tissue_segmentation'][
         'FSL-FAST']['use_priors']['run']
-
+    xfm = None
     if use_priors: 
         long = ''
         xfm = 'from-template_to-T1w_mode-image_desc-linear_xfm'

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -675,10 +675,11 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, process_gm, 'inputspec.brain_mask')
     wf.connect(node, out, process_wm, 'inputspec.brain_mask')
 
-    node, out = strat_pool.get_data(xfm)
-    wf.connect(node, out, process_csf, 'inputspec.template_to_T1_xfm')
-    wf.connect(node, out, process_gm, 'inputspec.template_to_T1_xfm')
-    wf.connect(node, out, process_wm, 'inputspec.template_to_T1_xfm')
+    if use_priors:
+        node, out = strat_pool.get_data(xfm)
+        wf.connect(node, out, process_csf, 'inputspec.template_to_T1_xfm')
+        wf.connect(node, out, process_gm, 'inputspec.template_to_T1_xfm')
+        wf.connect(node, out, process_wm, 'inputspec.template_to_T1_xfm')
 
     wf.connect(segment, ('tissue_class_files', pick_wm_class_0),
                process_csf, 'inputspec.tissue_class_file')

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -594,11 +594,6 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = connect
     wf.connect(node, out, segment, 'in_files')
 
-    long = ''
-    xfm = 'from-template_to-T1w_mode-image_desc-linear_xfm'
-    if 'space-longitudinal' in resource:
-        long = 'space-longitudinal_'
-        xfm = 'from-template_to-longitudinal_mode-image_desc-linear_xfm'
 
     use_custom_threshold = cfg['segmentation']['tissue_segmentation'][
                                'FSL-FAST']['thresholding'][
@@ -607,8 +602,18 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     use_priors = cfg['segmentation']['tissue_segmentation'][
         'FSL-FAST']['use_priors']['run']
 
-    xfm_prov = strat_pool.get_cpac_provenance(xfm)
-    reg_tool = check_prov_for_regtool(xfm_prov)
+    if use_priors: 
+        long = ''
+        xfm = 'from-template_to-T1w_mode-image_desc-linear_xfm'
+        if 'space-longitudinal' in resource:
+            long = 'space-longitudinal_'
+            xfm = 'from-template_to-longitudinal_mode-image_desc-linear_xfm'
+        xfm_prov = strat_pool.get_cpac_provenance(xfm)
+        reg_tool = check_prov_for_regtool(xfm_prov)
+    else:
+        xfm_prov = None
+        reg_tool = None
+
 
     process_csf = process_segment_map(f'CSF_{pipe_num}', use_priors,
                                       use_custom_threshold, reg_tool)

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -178,6 +178,9 @@ def process_segment_map(wf_name, use_priors, use_custom_threshold, reg_tool):
         # probability map
         input_1, value_1 = (inputNode, 'probability_tissue_map')
 
+    ####### Added This Line    
+    use_priors = cfg['segmentation']['tissue_segmentation']['FSL-FAST']['use_priors']['run']
+
     if use_priors:
         apply_xfm = apply_transform(f'seg_tissue_priors_template_to_T1',
                                     reg_tool=reg_tool)


### PR DESCRIPTION
## Fixes
Making sure that if use_priors is used, that it uses xfm. otherwise, xfm = None.

## Description
<!-- Concisely describe what the pull request does. -->
This pull request will assign `...image_desc-linear_xfm` if `use_priors` is turned on. Otherwise, xfm is not used. 

## Tests
Used a blank default pipeline and set `use_priors` to `Off`. No longer receiving this error `KeyError: "When trying to connect node block 'tissue_seg_ants_prior' to workflow 'cpac_sub-5289383_ses-1' after node block 'correct_restore_brain_intensity_abcd': from-template_to-T1w_mode-image_desc-linear_xfm"` Since `use_priors` is off, then xfm is not being used, therefore `from-template_to-T1w_mode-image_desc-linear_xfm` should not be used either.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [ x] My commit messages follow best practices.
- [ x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
