### PR TITLE
Fix some T2 and NHP-related connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed [bug](https://github.com/FCP-INDI/C-PAC/issues/1620) in which the preprocessed T2w data would not be found in the resource pool when expected.
 - Fixed [bug](https://github.com/FCP-INDI/C-PAC/issues/1582) in which distortion correction-related field map ingress would raise `IndexError: list index out of range` when ingressing the field maps.
 - Fixed [bug](https://github.com/FCP-INDI/C-PAC/issues/1572) in which some nodes would raise `KeyError: 'in_file'` when estimating memory allocation
 - Improved memory management for multi-core node allocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated possible inputs for T2w processing and ACPC-alignment blocks to increase the modularity of these pipeline options.
 - `master` branch renamed `main`
 
 ### Deprecated

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1361,7 +1361,7 @@ def acpc_align_brain(wf, cfg, strat_pool, pipe_num, opt=None):
                  "T1w-ACPC-template",
                  "T1w-brain-ACPC-template")],
      "outputs": ["desc-preproc_T1w",
-                 "desc-acpcbrain_T1w"
+                 "desc-acpcbrain_T1w",
                  "from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm"]}
     '''
 
@@ -1386,9 +1386,9 @@ def acpc_align_brain(wf, cfg, strat_pool, pipe_num, opt=None):
 
     outputs = {
         'desc-preproc_T1w': (acpc_align, 'outputspec.acpc_aligned_head'),
-        'from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm': (
-            acpc_align, 'outputspec.from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm'),
         'desc-acpcbrain_T1w': (acpc_align, 'outputspec.acpc_aligned_brain'),
+        'from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm': (
+            acpc_align, 'outputspec.from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm')
     }
 
     return (wf, outputs)
@@ -1405,8 +1405,10 @@ def acpc_align_brain_with_mask(wf, cfg, strat_pool, pipe_num, opt=None):
                  "desc-tempbrain_T1w", "space-T1w_desc-brain_mask"),
                  "T1w-ACPC-template",
                  "T1w-brain-ACPC-template"],
-     "outputs": ["desc-preproc_T1w", "desc-acpcbrain_T1w",
-                 "space-T1w_desc-brain_mask", "space-T1w_desc-prebrain_mask"]}
+     "outputs": ["desc-preproc_T1w",
+                 "desc-acpcbrain_T1w",
+                 "space-T1w_desc-brain_mask",
+                 "space-T1w_desc-prebrain_mask"]}
     '''
 
     acpc_align = acpc_alignment(config=cfg,
@@ -1547,23 +1549,29 @@ def t1t2_bias_correction(wf, cfg, strat_pool, pipe_num, opt=None):
      "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
-     "inputs": [["desc-preproc_T1w", "desc-reorient_T1w", "T1w"], 
-                ["desc-preproc_T2w", "desc-reorient_T2w", "T2w"],
-                ["desc-acpcbrain_T1w"]],
-     "outputs": ["desc-preproc_T1w", "desc-brain_T1w", "desc-preproc_T2w", "desc-brain_T2w", "desc-biasfield_T1wT2w"]}
+     "inputs": [(["desc-preproc_T1w", "desc-reorient_T1w", "T1w"], 
+                 ["desc-preproc_T2w", "desc-reorient_T2w", "T2w"],
+                 "desc-acpcbrain_T1w")],
+     "outputs": ["desc-preproc_T1w",
+                 "desc-brain_T1w",
+                 "desc-preproc_T2w",
+                 "desc-brain_T2w",
+                 "desc-biasfield_T1wT2w"]}
     '''
 
     t1t2_bias_correction = BiasFieldCorrection_sqrtT1wXT1w(config=cfg, wf_name=f't1t2_bias_correction_{pipe_num}')
 
-    node, out = strat_pool.get_data(['desc-preproc_T1w', 'desc-reorient_T1w',
+    node, out = strat_pool.get_data(['desc-preproc_T1w',
+                                     'desc-reorient_T1w',
                                      'T1w'])
     wf.connect(node, out, t1t2_bias_correction, 'inputspec.T1w')
 
-    node, out = strat_pool.get_data(['desc-preproc_T2w', 'desc-reorient_T2w',
+    node, out = strat_pool.get_data(['desc-preproc_T2w',
+                                     'desc-reorient_T2w',
                                      'T2w'])
     wf.connect(node, out, t1t2_bias_correction, 'inputspec.T2w')
 
-    node, out = strat_pool.get_data(["desc-acpcbrain_T1w"])
+    node, out = strat_pool.get_data("desc-acpcbrain_T1w")
     wf.connect(node, out, t1t2_bias_correction, 'inputspec.T1w_brain')
 
     outputs = {
@@ -2046,8 +2054,8 @@ def acpc_align_head_T2(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": "None",
      "option_val": "None",
      "inputs": [["desc-preproc_T2w", "desc-reorient_T2w", "T2w"],
-                "T2w_ACPC_template"], 
-     "outputs": ["desc-preproc_T1w"]}
+                "T2w-ACPC-template"], 
+     "outputs": ["desc-preproc_T2w"]}
     '''
 
     acpc_align = acpc_alignment(config=cfg,
@@ -2060,7 +2068,7 @@ def acpc_align_head_T2(wf, cfg, strat_pool, pipe_num, opt=None):
                                      'T2w'])
     wf.connect(node, out, acpc_align, 'inputspec.anat_leaf')
 
-    node, out = strat_pool.get_data('T2w_ACPC_template') 
+    node, out = strat_pool.get_data('T2w-ACPC-template') 
     wf.connect(node, out, acpc_align, 'inputspec.template_head_for_acpc')
 
     outputs = {
@@ -2080,7 +2088,7 @@ def acpc_align_head_with_mask_T2(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": [(["desc-preproc_T2w", "desc-reorient_T2w", "T2w"],
                  "space-T2w_desc-brain_mask"),
-                "T2w_ACPC_template"],
+                "T2w-ACPC-template"],
      "outputs": ["desc-preproc_T2w",
                  "space-T2w_desc-brain_mask"]}
     '''
@@ -2095,7 +2103,7 @@ def acpc_align_head_with_mask_T2(wf, cfg, strat_pool, pipe_num, opt=None):
                                      'T2w'])
     wf.connect(node, out, acpc_align, 'inputspec.anat_leaf')
 
-    node, out = strat_pool.get_data('T2w_ACPC_template') 
+    node, out = strat_pool.get_data('T2w-ACPC-template') 
     wf.connect(node, out, acpc_align, 'inputspec.template_head_for_acpc')
 
     outputs = {
@@ -2117,8 +2125,8 @@ def acpc_align_brain_T2(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": [(["desc-preproc_T2w", "desc-reorient_T2w", "T2w"],
                  "desc-tempbrain_T2w",
-                 "T2w_ACPC_template",
-                 "T2w_brain_ACPC_template")],
+                 "T2w-ACPC-template",
+                 "T2w-brain-ACPC-template")],
      "outputs": ["desc-preproc_T2w", 
                  "desc-acpcbrain_T2w"]}
     '''
@@ -2136,15 +2144,15 @@ def acpc_align_brain_T2(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data('desc-tempbrain_T2w')
     wf.connect(node, out, acpc_align, 'inputspec.anat_brain')
 
-    node, out = strat_pool.get_data('T2w_ACPC_template') 
+    node, out = strat_pool.get_data('T2w-ACPC-template') 
     wf.connect(node, out, acpc_align, 'inputspec.template_head_for_acpc')
 
-    node, out = strat_pool.get_data('T2w_brain_ACPC_template') 
+    node, out = strat_pool.get_data('T2w-brain-ACPC-template') 
     wf.connect(node, out, acpc_align, 'inputspec.template_brain_for_acpc')
 
     outputs = {
         'desc-preproc_T2w': (acpc_align, 'outputspec.acpc_aligned_head'),
-        'desc-acpcbrain_T2w': (acpc_align, 'outputspec.acpc_aligned_brain'),
+        'desc-acpcbrain_T2w': (acpc_align, 'outputspec.acpc_aligned_brain')
     }
 
     return (wf, outputs)
@@ -2160,8 +2168,8 @@ def acpc_align_brain_with_mask_T2(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": [(["desc-preproc_T2w", "desc-reorient_T2w", "T2w"],
                  "desc-tempbrain_T2w", "space-T2w_desc-brain_mask"),
-                 "T2w_ACPC_template",
-                 "T2w_brain_ACPC_template"],
+                 "T2w-ACPC-template",
+                 "T2w-brain-ACPC-template"],
      "outputs": ["desc-preproc_T2w", "desc-acpcbrain_T2w",
                  "space-T2w_desc-brain_mask"]}
     '''
@@ -2182,10 +2190,10 @@ def acpc_align_brain_with_mask_T2(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data('space-T2w_desc-brain_mask')
     wf.connect(node, out, acpc_align, 'inputspec.brain_mask')
 
-    node, out = strat_pool.get_data('T2w_ACPC_template') 
+    node, out = strat_pool.get_data('T2w-ACPC-template') 
     wf.connect(node, out, acpc_align, 'inputspec.template_head_for_acpc')
 
-    node, out = strat_pool.get_data('T2w_brain_ACPC_template')  
+    node, out = strat_pool.get_data('T2w-brain-ACPC-template')  
     wf.connect(node, out, acpc_align, 'inputspec.template_brain_for_acpc')
 
     outputs = {
@@ -2416,10 +2424,10 @@ def brain_mask_T2(wf, cfg, strat_pool, pipe_num, opt=None):
      "switch": ["run_t2"],
      "option_key": "None",
      "option_val": "None",
-     "inputs": [["desc-reorient_T1w", "T1w", "desc-preproc_T1w"], 
-                ["desc-reorient_T2w", "T2w", "desc-preproc_T2w"],
-                "space-T1w_desc-brain_mask",
-                "space-T2w_desc-acpcbrain_mask"],
+     "inputs": [(["desc-reorient_T1w", "T1w", "desc-preproc_T1w"], 
+                 ["desc-reorient_T2w", "T2w", "desc-preproc_T2w"],
+                 ["space-T1w_desc-brain_mask", "space-T1w_desc-acpcbrain_mask"],
+                 "space-T2w_desc-acpcbrain_mask")],
      "outputs": ["space-T2w_desc-brain_mask"]}
     '''
 
@@ -2439,11 +2447,14 @@ def brain_mask_T2(wf, cfg, strat_pool, pipe_num, opt=None):
         node, out = strat_pool.get_data(['desc-preproc_T2w','desc-reorient_T2w', 'T2w'])
         wf.connect(node, out, brain_mask_T2, 'inputspec.T2w')
 
-    node, out = strat_pool.get_data(["space-T1w_desc-brain_mask"])
+    node, out = strat_pool.get_data(["space-T1w_desc-brain_mask",
+                                     "space-T1w_desc-acpcbrain_mask"])
     wf.connect(node, out, brain_mask_T2, 'inputspec.T1w_mask')
+    
     outputs = {
         'space-T2w_desc-brain_mask': (brain_mask_T2, 'outputspec.T2w_mask')
     }
+    
     return (wf, outputs)
  
 

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1757,8 +1757,9 @@ def bold_mask_anatomical_refined(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "Anatomical_Refined",
      "inputs": ["bold",
                 ["desc-preproc_bold", "bold"],
-                "desc-brain_T1w",
-                "space-T1w_desc-brain_mask"],
+                ("desc-brain_T1w",
+                 ["space-T1w_desc-brain_mask",
+                  "space-T1w_desc-acpcbrain_mask"])],
      "outputs": ["space-bold_desc-brain_mask"]}
     '''
 
@@ -1767,7 +1768,8 @@ def bold_mask_anatomical_refined(wf, cfg, strat_pool, pipe_num, opt=None):
                                   name=f'anat_brain_mask_bin_{pipe_num}')
     anat_brain_mask_bin.inputs.op_string = '-bin'
 
-    node, out = strat_pool.get_data('space-T1w_desc-brain_mask')
+    node, out = strat_pool.get_data(['space-T1w_desc-brain_mask',
+                                     'space-T1w_desc-acpcbrain_mask'])
     wf.connect(node, out, anat_brain_mask_bin, 'in_file')
 
     # fill holes of anat mask
@@ -2061,8 +2063,8 @@ def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
     func_tmp_brain_mask.inputs.outputtype = 'NIFTI_GZ'
 
     node, out = strat_pool.get_data(["desc-motion_bold", 
-                                    "desc-preproc_bold",
-                                    "bold"])
+                                     "desc-preproc_bold",
+                                     "bold"])
     wf.connect(node, out, func_tmp_brain_mask, 'in_file')
 
     # Extract 8th volume as func ROI
@@ -2072,8 +2074,8 @@ def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
     func_roi.inputs.t_size = 1
 
     node, out = strat_pool.get_data(["desc-motion_bold", 
-                                    "desc-preproc_bold",
-                                    "bold"])
+                                     "desc-preproc_bold",
+                                     "bold"])
     wf.connect(node, out, func_roi, 'in_file')
 
     # Apply func initial mask on func ROI volume

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -859,7 +859,6 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
              brain_mask_freesurfer_abcd,
              brain_mask_freesurfer_fsl_tight,
              brain_mask_freesurfer_fsl_loose]
-            #  brain_mask_freesurfer
         ]
         pipeline_blocks += anat_brain_mask_blocks
 

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -2841,7 +2841,7 @@ def coregistration(wf, cfg, strat_pool, pipe_num, opt=None):
         node, out = strat_pool.get_data("fieldmap_mask")
         wf.connect(node, out, func_to_anat, 'inputspec.fieldmapmask')
 
-    if strat_pool.check_rpool('T2w'):
+    if strat_pool.check_rpool('T2w') and cfg.anatomical_preproc['run_t2']:
         outputs = {
             'space-T1w_desc-mean_bold':
                 (func_to_anat, 'outputspec.anat_func_nobbreg'),

--- a/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
@@ -80,6 +80,8 @@ pipeline_setup:
 
 anatomical_preproc: 
 
+  run_t2: On
+
   # Non-local means filtering via ANTs DenoiseImage
   non_local_means_filtering: False
 

--- a/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
@@ -432,7 +432,7 @@ functional_preproc:
 
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based']
     # this is a fork point
-    using: [Anatomical_Refined] #HJ Note: this should be 'Anatomical_Based'
+    using: [Anatomical_Based]
 
 nuisance_corrections: 
 

--- a/CPAC/resources/cpac_templates.csv
+++ b/CPAC/resources/cpac_templates.csv
@@ -7,6 +7,8 @@ EPI-template-deriv,"registration_workflows, functional_registration, func_regist
 EPI-template-for-resample,"registration_workflows, functional_registration, func_registration_to_template, target_template, EPI_template, EPI_template_for_resample",,
 EPI-template-funcreg,"registration_workflows, functional_registration, func_registration_to_template, target_template, EPI_template, EPI_template_funcreg",EPI-based template resampled to the desired preprocessed-functional resolution,"registration_workflows, functional_registration, func_registration_to_template, output_resolution, func_preproc_outputs"
 EPI-template-mask,"registration_workflows, functional_registration, EPI_registration, EPI_template_mask",Binary brain mask of the EPI template,
+FNIRT-T1w-brain-template,"registration_workflows, anatomical_registration, registration, FSL-FNIRT, FNIRT_T1w_brain_template",Additional T1w brain-only template for FSL-FNIRT nonlinear registration (when linear FSL-FLIRT requires a separate template),"registration_workflows, anatomical_registration, registration, FSL-FNIRT, ref_resolution"
+FNIRT-T1w-template,"registration_workflows, anatomical_registration, registration, FSL-FNIRT, FNIRT_T1w_template",Additional T1w whole-head template for FSL-FNIRT nonlinear registration (when linear FSL-FLIRT requires a separate template),"registration_workflows, anatomical_registration, registration, FSL-FNIRT, ref_resolution"
 GM-path,"segmentation, tissue_segmentation, FSL-FAST, use_priors, GM_path",Template-space GM tissue prior,
 lateral-ventricles-mask,"nuisance_corrections, 2-nuisance_regression, lateral_ventricles_mask",,
 T1w-ACPC-template,"anatomical_preproc, acpc_alignment, T1w_ACPC_template",,

--- a/CPAC/resources/cpac_templates.csv
+++ b/CPAC/resources/cpac_templates.csv
@@ -33,3 +33,5 @@ unet-model,"anatomical_preproc, brain_extraction, UNet, unet_model",,
 WM-path,"segmentation, tissue_segmentation, FSL-FAST, use_priors, WM_path",Template-space WM tissue prior,
 template-eye-mask,"PyPEER, eye_mask_path",,"registration_workflows, functional_registration, func_registration_to_template, output_resolution, func_preproc_outputs"
 T1w-brain-template-mask-ccs,"anatomical_preproc, brain_extraction, FreeSurfer-BET, T1w_brain_template_mask_ccs",,
+T2w-ACPC-template,"anatomical_preproc, acpc_alignment, T2w_ACPC_template",Whole-head template for use in ACPC-alignment,
+T2w-brain-ACPC-template,"anatomical_preproc, acpc_alignment, T2w_brain_ACPC_template",Brain-only template for use in ACPC-alignment,

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -855,7 +855,8 @@ def tissue_seg_ants_prior(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": ["tissue_segmentation", "using"],
      "option_val": "ANTs_Prior_Based",
      "inputs": [("desc-brain_T1w",
-                 "space-T1w_desc-brain_mask")],
+                 ["space-T1w_desc-brain_mask",
+                  "space-T1w_desc-acpcbrain_mask"])],
      "outputs": ["label-CSF_mask",
                  "label-GM_mask",
                  "label-WM_mask"]}
@@ -889,7 +890,8 @@ def tissue_seg_ants_prior(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out,
                seg_preproc_ants_prior_based, 'inputspec.anatomical_brain')
 
-    node, out = strat_pool.get_data('space-T1w_desc-brain_mask')
+    node, out = strat_pool.get_data(['space-T1w_desc-brain_mask',
+                                     'space-T1w_desc-acpcbrain_mask'])
     wf.connect(node, out, seg_preproc_ants_prior_based,
                'inputspec.anatomical_brain_mask')
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes T2 data flow and pipeline connections in `develop`

## Description
Recent updates to the NHP pipeline integrate T2 processing, if T2 data is present. Some fixes were necessary based on recent testing.

## Tests
- [x] Need to ensure the NHP pipeline works properly with and without T2 data.
- [x] Need to ensure T2 processing outside of the NHP preconfig works properly.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
