### PR TITLE
🚨 Fix `  # noqa` specificity

### DIFF
--- a/CPAC/cwas/tests/test_cwas.py
+++ b/CPAC/cwas/tests/test_cwas.py
@@ -78,7 +78,7 @@ class RegressionTester(object):
 
         # Read in list of subject functionals
         subjects_list = [
-            l.strip().strip('"') for l in open(sfile).readlines()  # noqa E741
+            l.strip().strip('"') for l in open(sfile).readlines()  # noqa: E741
         ]
 
         # Read in design/regressor file
@@ -93,7 +93,7 @@ class RegressionTester(object):
         c.inputs.inputspec.f_samples = nperms
         c.inputs.inputspec.parallel_nodes = 4
         # c.base_dir = op.join(obase, 'results_fs%i_pn%i' % \
-        #                (c.inputs.inputspec.f_samples, c.inputs.inputspec.parallel_nodes))  # noqa E501
+        #                (c.inputs.inputspec.f_samples, c.inputs.inputspec.parallel_nodes))  # noqa: E501
         c.base_dir = op.join(self.base, "results_%s.py" % self.name)
 
         # export MKL_NUM_THREADS=X # in command line

--- a/CPAC/cwas/tests/test_cwas.py
+++ b/CPAC/cwas/tests/test_cwas.py
@@ -78,7 +78,8 @@ class RegressionTester(object):
 
         # Read in list of subject functionals
         subjects_list = [
-            l.strip().strip('"') for l in open(sfile).readlines()  # noqa: E741
+            l.strip().strip('"') for  # noqa: E741
+            l in open(sfile).readlines()  # pylint: disable=consider-using-with
         ]
 
         # Read in design/regressor file
@@ -93,7 +94,7 @@ class RegressionTester(object):
         c.inputs.inputspec.f_samples = nperms
         c.inputs.inputspec.parallel_nodes = 4
         # c.base_dir = op.join(obase, 'results_fs%i_pn%i' % \
-        #                (c.inputs.inputspec.f_samples, c.inputs.inputspec.parallel_nodes))  # noqa: E501
+        #                (c.inputs.inputspec.f_samples, c.inputs.inputspec.parallel_nodes))  # noqa: E501  # pylint: disable=line-too-long
         c.base_dir = op.join(self.base, "results_%s.py" % self.name)
 
         # export MKL_NUM_THREADS=X # in command line

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -350,7 +350,7 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
     Setting ANTS/ITK thread usage to {ants_threads}
     Maximum potential number of cores that might be used during this run: {max_cores}
 {random_seed}
-"""  # noqa E501
+"""  # noqa: E501
 
     execution_info = """
 
@@ -365,7 +365,7 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
         System time of start:      {run_start}
         System time of completion: {run_finish}
 
-"""  # noqa E501
+"""  # noqa: E501
 
     logger.info('%s', information.format(
         run_command=' '.join(['run', *sys.argv[1:]]),

--- a/CPAC/pipeline/nipype_pipeline_engine/__init__.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/__init__.py
@@ -2,10 +2,10 @@
 See https://fcp-indi.github.io/docs/developer/nodes
 for C-PAC-specific documentation.
 See https://nipype.readthedocs.io/en/latest/api/generated/nipype.pipeline.engine.html
-for Nipype's documentation.'''  # noqa E501
+for Nipype's documentation.'''  # noqa: E501
 from nipype.pipeline import engine as pe
 # import everything in nipype.pipeline.engine.__all__
-from nipype.pipeline.engine import *  # noqa F401
+from nipype.pipeline.engine import *  # noqa: F401,F403
 # import our DEFAULT_MEM_GB and override Node, MapNode
 from .engine import DEFAULT_MEM_GB, get_data_size, Node, MapNode, \
                     UNDEFINED_SIZE, Workflow

--- a/CPAC/pipeline/nipype_pipeline_engine/engine.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/engine.py
@@ -3,7 +3,7 @@ See https://fcp-indi.github.io/docs/developer/nodes
 for C-PAC-specific documentation.
 See https://nipype.readthedocs.io/en/latest/api/generated/nipype.pipeline.engine.html
 for Nipype's documentation.
-'''  # noqa E501
+'''  # noqa: E501
 import os
 import re
 import warnings
@@ -140,7 +140,7 @@ class Node(pe.Node):
             ``mode`` can be any one of
             * 'xyzt' (spatial * temporal) (default if not specified)
             * 'xyz' (spatial)
-            * 't' (temporal)''']))  # noqa E501
+            * 't' (temporal)''']))  # noqa: E501
 
     def _add_flags(self, flags):
         r'''
@@ -415,7 +415,7 @@ class Workflow(pe.Workflow):
                 self._local_func_scans)  # pylint: disable=no-member
         else:
             # TODO: handle S3 files
-            node._apply_mem_x(UNDEFINED_SIZE)  # noqa W0212
+            node._apply_mem_x(UNDEFINED_SIZE)  # noqa: W0212
 
 
 def get_data_size(filepath, mode='xyzt'):

--- a/CPAC/pipeline/nipype_pipeline_engine/plugins/__init__.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/plugins/__init__.py
@@ -1,6 +1,6 @@
 """Import Nipype's pipeline plugins and selectively override"""
-from nipype.pipeline.plugins import *  # noqa F401,F403
+from nipype.pipeline.plugins import *  # noqa: F401,F403
 # Override LegacyMultiProc
-from .legacymultiproc import LegacyMultiProcPlugin  # noqa F401
+from .legacymultiproc import LegacyMultiProcPlugin  # noqa: F401
 # Override MultiProc
-from .multiproc import MultiProcPlugin  # noqa F401
+from .multiproc import MultiProcPlugin  # noqa: F401

--- a/CPAC/pipeline/nipype_pipeline_engine/plugins/cpac_nipype_custom.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/plugins/cpac_nipype_custom.py
@@ -130,7 +130,7 @@ class CpacNipypeCustomPluginMixin():
         Sends jobs to workers when system resources are available.
         Customized from https://github.com/nipy/nipype/commit/79e2fdfc38759bc0853e4051b99ba4c37587d65f
         to catch overhead deadlocks
-        """  # noqa E501  # pylint: disable=line-too-long
+        """  # noqa: E501  # pylint: disable=line-too-long
         # pylint: disable=too-many-branches, too-many-statements
         # Check to see if a job is available (jobs with all dependencies run)
         # See https://github.com/nipy/nipype/pull/2200#discussion_r141605722

--- a/CPAC/pipeline/random_state/seed.py
+++ b/CPAC/pipeline/random_state/seed.py
@@ -162,7 +162,7 @@ def set_up_random_state(seed):
     ValueError: Valid random seeds are positive integers up to 2147483647, "random", or None, not 0
     >>> set_up_random_state(None)
 
-    '''  # noqa E501  # pylint: disable=line-too-long
+    '''  # noqa: E501  # pylint: disable=line-too-long
     if seed is not None:
         if seed == 'random':
             seed = random_random_seed()

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -173,7 +173,7 @@ def permutation_message(key, options):
 
     Returns
     -------
-    msg: str'''  # noqa E501
+    msg: str'''  # noqa: E501
     return f'''
 
 \'{key}\' takes a dictionary with paths to region-of-interest (ROI)

--- a/CPAC/qc/xcp.py
+++ b/CPAC/qc/xcp.py
@@ -49,7 +49,7 @@ normCrossCorr : float
     "Normalization of T1w/Functional to Template:[…] cross correlation" :cite:`cite-Ciri19` :cite:`cite-Penn19`
 normCoverage : float
     "Normalization of T1w/Functional to Template:[…] Coverage index" :cite:`cite-Ciri19` :cite:`cite-Penn19`
-"""  # noqa E501  # pylint: disable=line-too-long
+"""  # noqa: E501  # pylint: disable=line-too-long
 import os
 import re
 from io import BufferedReader
@@ -103,7 +103,7 @@ def calculate_overlap(image_pair):
     (1.0, 1.0, 0.9999999999999998, 1.0)
     >>> tuple(calculate_overlap((a2, a2)).values())
     (1.0, 1.0, 0.9999999999999998, 1.0)
-    '''  # noqa E501  # pylint: disable=line-too-long
+    '''  # noqa: E501  # pylint: disable=line-too-long
     if len(image_pair) != 2:
         raise IndexError('`calculate_overlap` requires 2 images, but '
                          f'{len(image_pair)} were provided')

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -136,7 +136,7 @@ def process_segment_map(wf_name, use_priors, use_custom_threshold, reg_tool):
         :width: 1100
         :height: 480
 
-    """  # noqa
+    """  # noqa:
     import nipype.interfaces.utility as util
 
     preproc = pe.Workflow(name=wf_name)
@@ -457,7 +457,7 @@ def create_seg_preproc_freesurfer(config=None,
 
         outputspec.wm_mask : string (nifti file)
             outputs White Matter mask
-    """  # noqa
+    """  # noqa:
     preproc = pe.Workflow(name=wf_name)
 
     inputnode = pe.Node(util.IdentityInterface(fields=['subject_dir']),

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -136,7 +136,8 @@ def process_segment_map(wf_name, use_priors, use_custom_threshold, reg_tool):
         :width: 1100
         :height: 480
 
-    """  # noqa:
+    """
+    # pylint: disable=import-outside-toplevel,redefined-outer-name,reimported
     import nipype.interfaces.utility as util
 
     preproc = pe.Workflow(name=wf_name)
@@ -457,7 +458,7 @@ def create_seg_preproc_freesurfer(config=None,
 
         outputspec.wm_mask : string (nifti file)
             outputs White Matter mask
-    """  # noqa:
+    """
     preproc = pe.Workflow(name=wf_name)
 
     inputnode = pe.Node(util.IdentityInterface(fields=['subject_dir']),

--- a/CPAC/seg_preproc/utils.py
+++ b/CPAC/seg_preproc/utils.py
@@ -46,7 +46,7 @@ def pick_wm_prob_0(probability_maps):
 
     file : string
         Path to segment_prob_0.nii.gz is returned
-    """  # noqa
+    """  # noqa:
     if isinstance(probability_maps, list):
         if len(probability_maps) == 1:
             probability_maps = probability_maps[0]
@@ -70,7 +70,7 @@ def pick_wm_prob_1(probability_maps):
 
     file : string
         Path to segment_prob_1.nii.gz is returned
-    """  # noqa
+    """  # noqa:
     if isinstance(probability_maps, list):
         if len(probability_maps) == 1:
             probability_maps = probability_maps[0]
@@ -94,7 +94,7 @@ def pick_wm_prob_2(probability_maps):
 
     file : string
         Path to segment_prob_2.nii.gz is returned
-    """  # noqa
+    """  # noqa:
     if isinstance(probability_maps, list):
         if len(probability_maps) == 1:
             probability_maps = probability_maps[0]
@@ -118,7 +118,7 @@ def pick_wm_class_0(tissue_class_files):
 
     file : string
         Path to segment_seg_0.nii.gz is returned
-    """  # noqa
+    """  # noqa:
     if isinstance(tissue_class_files, list):
         if len(tissue_class_files) == 1:
             tissue_class_files = tissue_class_files[0]
@@ -142,7 +142,7 @@ def pick_wm_class_1(tissue_class_files):
 
     file : string
         Path to segment_seg_1.nii.gz is returned
-    """  # noqa
+    """  # noqa:
     if isinstance(tissue_class_files, list):
         if len(tissue_class_files) == 1:
             tissue_class_files = tissue_class_files[0]
@@ -166,7 +166,7 @@ def pick_wm_class_2(tissue_class_files):
 
     file : string
         Path to segment_seg_2.nii.gz is returned
-    """  # noqa
+    """  # noqa:
     if isinstance(tissue_class_files, list):
         if len(tissue_class_files) == 1:
             tissue_class_files = tissue_class_files[0]
@@ -363,7 +363,7 @@ def hardcoded_antsJointLabelFusion(anatomical_brain, anatomical_brain_mask,
     bash_cmd = str.join(cmd)
 
     try:
-        retcode = subprocess.check_output(bash_cmd, shell=True)  # noqa F841
+        retcode = subprocess.check_output(bash_cmd, shell=True)  # noqa: F841
     except Exception as e:
         raise Exception('[!] antsJointLabel segmentation method did not '
                         'complete successfully.\n\nError '
@@ -414,7 +414,7 @@ def pick_tissue_from_labels_file(multiatlas_Labels, csf_label=[4,14,15,24,43],
     gm_mask : string (nifti file)
 
     wm_mask : string (nifti file)
-    """  # noqa
+    """  # noqa:
     import os
     import nibabel as nb
     import numpy as np

--- a/CPAC/seg_preproc/utils.py
+++ b/CPAC/seg_preproc/utils.py
@@ -46,7 +46,7 @@ def pick_wm_prob_0(probability_maps):
 
     file : string
         Path to segment_prob_0.nii.gz is returned
-    """  # noqa:
+    """
     if isinstance(probability_maps, list):
         if len(probability_maps) == 1:
             probability_maps = probability_maps[0]
@@ -70,7 +70,7 @@ def pick_wm_prob_1(probability_maps):
 
     file : string
         Path to segment_prob_1.nii.gz is returned
-    """  # noqa:
+    """
     if isinstance(probability_maps, list):
         if len(probability_maps) == 1:
             probability_maps = probability_maps[0]
@@ -94,7 +94,7 @@ def pick_wm_prob_2(probability_maps):
 
     file : string
         Path to segment_prob_2.nii.gz is returned
-    """  # noqa:
+    """
     if isinstance(probability_maps, list):
         if len(probability_maps) == 1:
             probability_maps = probability_maps[0]
@@ -118,7 +118,7 @@ def pick_wm_class_0(tissue_class_files):
 
     file : string
         Path to segment_seg_0.nii.gz is returned
-    """  # noqa:
+    """
     if isinstance(tissue_class_files, list):
         if len(tissue_class_files) == 1:
             tissue_class_files = tissue_class_files[0]
@@ -142,7 +142,7 @@ def pick_wm_class_1(tissue_class_files):
 
     file : string
         Path to segment_seg_1.nii.gz is returned
-    """  # noqa:
+    """
     if isinstance(tissue_class_files, list):
         if len(tissue_class_files) == 1:
             tissue_class_files = tissue_class_files[0]
@@ -166,7 +166,7 @@ def pick_wm_class_2(tissue_class_files):
 
     file : string
         Path to segment_seg_2.nii.gz is returned
-    """  # noqa:
+    """
     if isinstance(tissue_class_files, list):
         if len(tissue_class_files) == 1:
             tissue_class_files = tissue_class_files[0]
@@ -363,11 +363,15 @@ def hardcoded_antsJointLabelFusion(anatomical_brain, anatomical_brain_mask,
     bash_cmd = str.join(cmd)
 
     try:
-        retcode = subprocess.check_output(bash_cmd, shell=True)  # noqa: F841
-    except Exception as e:
+        retcode = subprocess.check_output(bash_cmd, shell=True) \
+            # noqa: F841  # pylint: disable=unused-variable
+    except Exception as e:  # pylint: disable=broad-except,invalid-name
+        # pylint: disable=raise-missing-from
         raise Exception('[!] antsJointLabel segmentation method did not '
                         'complete successfully.\n\nError '
-                        'details:\n{0}\n{1}\n'.format(e, e.output))
+                        'details:\n{0}\n{1}\n'.format(
+                            e,
+                            getattr(e, 'output', '')))
 
     multiatlas_Intensity = None
     multiatlas_Labels = None
@@ -414,7 +418,8 @@ def pick_tissue_from_labels_file(multiatlas_Labels, csf_label=[4,14,15,24,43],
     gm_mask : string (nifti file)
 
     wm_mask : string (nifti file)
-    """  # noqa:
+    """
+    # pylint: disable=import-outside-toplevel,redefined-outer-name,reimported
     import os
     import nibabel as nb
     import numpy as np

--- a/CPAC/utils/interfaces/netcorr.py
+++ b/CPAC/utils/interfaces/netcorr.py
@@ -189,7 +189,7 @@ class NetCorr(AFNICommand):
     '3dNetCorr -prefix sub0.tp1.ncorr -fish_z -inset functional.nii -in_rois maps.nii -mask mask.nii -ts_wb_Z -ts_wb_corr'
     >>> res = ncorr.run()  # doctest: +SKIP
 
-    """  # noqa E501  # pylint: disable=line-too-long
+    """  # noqa: E501  # pylint: disable=line-too-long
     _cmd = "3dNetCorr"
     input_spec = NetCorrInputSpec
     output_spec = NetCorrOutputSpec

--- a/CPAC/utils/monitoring/__init__.py
+++ b/CPAC/utils/monitoring/__init__.py
@@ -1,7 +1,7 @@
 '''Module to customize Nipype's process monitoring for use in C-PAC
 
 See https://fcp-indi.github.io/docs/developer/nodes for C-PAC-specific documentation.
-See https://nipype.readthedocs.io/en/latest/api/generated/nipype.utils.profiler.html for Nipype's documentation.'''  # noqa E501
+See https://nipype.readthedocs.io/en/latest/api/generated/nipype.utils.profiler.html for Nipype's documentation.'''  # noqa: E501
 from .custom_logging import set_up_logger
 from .monitoring import LoggingHTTPServer, LoggingRequestHandler, \
                         log_nodes_cb, log_nodes_initial, monitor_server, \

--- a/CPAC/utils/monitoring/__init__.py
+++ b/CPAC/utils/monitoring/__init__.py
@@ -1,7 +1,7 @@
 '''Module to customize Nipype's process monitoring for use in C-PAC
 
 See https://fcp-indi.github.io/docs/developer/nodes for C-PAC-specific documentation.
-See https://nipype.readthedocs.io/en/latest/api/generated/nipype.utils.profiler.html for Nipype's documentation.'''  # noqa: E501
+See https://nipype.readthedocs.io/en/latest/api/generated/nipype.utils.profiler.html for Nipype's documentation.'''  # noqa: E501  # pylint: disable=line-too-long
 from .custom_logging import set_up_logger
 from .monitoring import LoggingHTTPServer, LoggingRequestHandler, \
                         log_nodes_cb, log_nodes_initial, monitor_server, \

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -251,7 +251,7 @@ def get_zscore(map_node=False, wf_name='z_score'):
     >>> wf.inputs.inputspec.input_file = '/home/data/graph_working_dir/calculate_centrality/degree_centrality_binarize.nii.gz'
     >>> wf.inputs.inputspec.mask_file = '/home/data/graphs/GraphGeneration/new_mask_3m.nii.gz'
     >>> wf.run()  # doctest: +SKIP
-    """  # noqa
+    """  # noqa:
 
     from CPAC.pipeline import nipype_pipeline_engine as pe
     import nipype.interfaces.utility as util
@@ -1666,7 +1666,7 @@ def dct_diff(dct1, dct2):
     ...     'pipeline_config_fmriprep-options.yml')
     >>> dct_diff(pipeline, pipeline2)['pipeline_setup']['pipeline_name']
     ('cpac-default-pipeline', 'cpac_fmriprep-options')
-    '''  # noqa
+    '''  # noqa:
     diff = {}
     for key in dct1:
         if isinstance(dct1[key], dict):
@@ -1697,7 +1697,7 @@ def dct_diff(dct1, dct2):
     return {}
 
 
-def list_item_replace(l, old, new):  # noqa E741
+def list_item_replace(l, old, new):  # noqa: E741
     '''Function to replace an item in a list
 
     Parameters
@@ -1725,7 +1725,7 @@ def list_item_replace(l, old, new):  # noqa E741
     if isinstance(l, list) and old in l:
         l[l.index(old)] = new
     elif isinstance(l, str):
-        l = l.replace(old, new)  # noqa E741
+        l = l.replace(old, new)  # noqa: E741
     return l
 
 
@@ -1924,7 +1924,7 @@ def update_config_dict(old_dict):
     {'2': None}
     >>> c
     {'pipeline_setup': {'pipeline_name': 'example-pipeline'}, '2': None}
-    ''' # noqa
+    ''' # noqa:
     def _append_to_list(current_value, new_value):
         '''Helper function to add new_value to the current_value list
         or create a list if one does not exist. Skips falsy elements
@@ -2288,7 +2288,7 @@ def update_nested_dict(d_base, d_update, fully_specified=False):
     ...     '/cpac_templates/aal_mask_pad.nii.gz': 'Voxel'
     ... }, 'realignment': 'ROI_to_func'}})
     True
-    """  # noqa
+    """  # noqa:
 
     # short-circuit if d_update has `*_roi_paths` and
     # `roi_paths_fully_specified` children
@@ -2330,7 +2330,7 @@ def update_pipeline_values_1_8(d_old):
     >>> update_pipeline_values_1_8({'segmentation': {'tissue_segmentation': {
     ...     'using': ['FSL-FAST Thresholding']}}})
     {'segmentation': {'tissue_segmentation': {'using': ['FSL-FAST'], 'FSL-FAST': {'thresholding': {'use': 'Auto'}}}}}
-    '''  # noqa
+    '''  # noqa:
     from CPAC.pipeline.schema import valid_options
 
     d = replace_in_strings(d_old.copy())

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -251,8 +251,8 @@ def get_zscore(map_node=False, wf_name='z_score'):
     >>> wf.inputs.inputspec.input_file = '/home/data/graph_working_dir/calculate_centrality/degree_centrality_binarize.nii.gz'
     >>> wf.inputs.inputspec.mask_file = '/home/data/graphs/GraphGeneration/new_mask_3m.nii.gz'
     >>> wf.run()  # doctest: +SKIP
-    """  # noqa:
-
+    """  # noqa: E501  # pylint: disable=line-too-long
+    # pylint: disable=import-outside-toplevel,redefined-outer-name,reimported
     from CPAC.pipeline import nipype_pipeline_engine as pe
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl as fsl
@@ -1666,7 +1666,7 @@ def dct_diff(dct1, dct2):
     ...     'pipeline_config_fmriprep-options.yml')
     >>> dct_diff(pipeline, pipeline2)['pipeline_setup']['pipeline_name']
     ('cpac-default-pipeline', 'cpac_fmriprep-options')
-    '''  # noqa:
+    '''
     diff = {}
     for key in dct1:
         if isinstance(dct1[key], dict):
@@ -1697,7 +1697,8 @@ def dct_diff(dct1, dct2):
     return {}
 
 
-def list_item_replace(l, old, new):  # noqa: E741
+def list_item_replace(l,  # noqa: E741  # pylint: disable=invalid-name
+                      old, new):
     '''Function to replace an item in a list
 
     Parameters
@@ -1917,14 +1918,15 @@ def update_config_dict(old_dict):
 
     Examples
     --------
-    >>> a, b, c = update_config_dict({'pipelineName': 'example-pipeline', '2': None})
+    >>> a, b, c = update_config_dict({
+    ...     'pipelineName': 'example-pipeline', '2': None})
     >>> a
     {'pipeline_setup': {'pipeline_name': 'example-pipeline'}}
     >>> b
     {'2': None}
     >>> c
     {'pipeline_setup': {'pipeline_name': 'example-pipeline'}, '2': None}
-    ''' # noqa:
+    '''
     def _append_to_list(current_value, new_value):
         '''Helper function to add new_value to the current_value list
         or create a list if one does not exist. Skips falsy elements
@@ -2288,7 +2290,7 @@ def update_nested_dict(d_base, d_update, fully_specified=False):
     ...     '/cpac_templates/aal_mask_pad.nii.gz': 'Voxel'
     ... }, 'realignment': 'ROI_to_func'}})
     True
-    """  # noqa:
+    """  # noqa: E501  # pylint: disable=line-too-long
 
     # short-circuit if d_update has `*_roi_paths` and
     # `roi_paths_fully_specified` children
@@ -2330,8 +2332,9 @@ def update_pipeline_values_1_8(d_old):
     >>> update_pipeline_values_1_8({'segmentation': {'tissue_segmentation': {
     ...     'using': ['FSL-FAST Thresholding']}}})
     {'segmentation': {'tissue_segmentation': {'using': ['FSL-FAST'], 'FSL-FAST': {'thresholding': {'use': 'Auto'}}}}}
-    '''  # noqa:
-    from CPAC.pipeline.schema import valid_options
+    '''  # noqa: E501  # pylint: disable=line-too-long
+    from CPAC.pipeline.schema import valid_options \
+        # pylint: disable=import-outside-toplevel
 
     d = replace_in_strings(d_old.copy())
 

--- a/CPAC/utils/yaml_template.py
+++ b/CPAC/utils/yaml_template.py
@@ -76,7 +76,7 @@ def create_yaml_from_template(
         ...         'run': ([True], False),
         ...         'using': (['3dSkullStrip'], ['niworkflows-ants'])}}}})
         {'anatomical_preproc': {'brain_extraction': {'extraction': {'run': False, 'using': ['niworkflows-ants']}}}}
-        '''  # noqa
+        '''  # noqa:
         if isinstance(diff, tuple) and len(diff) == 2:
             return diff[1]
         if isinstance(diff, dict):
@@ -112,7 +112,7 @@ def create_yaml_from_template(
         '''
         return f'\n{" " * level * 2}{key}: '
 
-    def _format_list_items(l, line_level):  # noqa E741
+    def _format_list_items(l, line_level):  # noqa: E741
         '''Helper method to handle lists in the YAML
 
         Parameters
@@ -131,7 +131,7 @@ def create_yaml_from_template(
         '  - 1\n  - 2\n  - nested: 3'
         >>> _format_list_items([1, 2, {'nested': [3, {'deep': [4]}]}], 1)
         '    - 1\n    - 2\n    - nested:\n      - 3\n      - deep:\n        - 4'
-        '''  # noqa
+        '''  # noqa:
         # keep short, simple lists in square brackets
         if all([any([isinstance(item, item_type) for item_type in {
             str, bool, int, float

--- a/CPAC/utils/yaml_template.py
+++ b/CPAC/utils/yaml_template.py
@@ -76,7 +76,7 @@ def create_yaml_from_template(
         ...         'run': ([True], False),
         ...         'using': (['3dSkullStrip'], ['niworkflows-ants'])}}}})
         {'anatomical_preproc': {'brain_extraction': {'extraction': {'run': False, 'using': ['niworkflows-ants']}}}}
-        '''  # noqa:
+        '''  # noqa: E501  # pylint: disable=line-too-long
         if isinstance(diff, tuple) and len(diff) == 2:
             return diff[1]
         if isinstance(diff, dict):
@@ -112,7 +112,8 @@ def create_yaml_from_template(
         '''
         return f'\n{" " * level * 2}{key}: '
 
-    def _format_list_items(l, line_level):  # noqa: E741
+    def _format_list_items(l,  # noqa: E741  # pylint:disable=invalid-name
+                           line_level):
         '''Helper method to handle lists in the YAML
 
         Parameters
@@ -131,11 +132,11 @@ def create_yaml_from_template(
         '  - 1\n  - 2\n  - nested: 3'
         >>> _format_list_items([1, 2, {'nested': [3, {'deep': [4]}]}], 1)
         '    - 1\n    - 2\n    - nested:\n      - 3\n      - deep:\n        - 4'
-        '''  # noqa:
+        '''  # noqa: E501  # pylint: disable=line-too-long
         # keep short, simple lists in square brackets
-        if all([any([isinstance(item, item_type) for item_type in {
+        if all(any(isinstance(item, item_type) for item_type in {
             str, bool, int, float
-        }]) for item in l]):
+        }) for item in l):
             if len(str(l)) < 50:
                 return str(l).replace("'", '').replace('"', '')
         # list long or complex lists on lines with indented '-' lead-ins

--- a/dev/circleci_data/test_external_utils.py
+++ b/dev/circleci_data/test_external_utils.py
@@ -7,7 +7,8 @@ CPAC_DIR = str(Path(__file__).parent.parent.parent)
 sys.path.append(CPAC_DIR)
 DATA_DIR = os.path.join(CPAC_DIR, 'dev', 'circleci_data')
 
-from CPAC.__main__ import utils as CPAC_main_utils  # noqa: E402
+from CPAC.__main__ import utils as CPAC_main_utils \
+    # noqa: E402  # pylint: disable=wrong-import-position
 
 
 def test_build_data_config(cli_runner):
@@ -103,8 +104,8 @@ def _delete_test_yaml(test_yaml):
 
 
 def _test_repickle(pickle_path, gzipped=False):
+    # pylint: disable=import-outside-toplevel,unused-import
     backup = _Backup(pickle_path)
     if gzipped:
         import gzip  # noqa: F401
-
     backup.restore()

--- a/dev/circleci_data/test_external_utils.py
+++ b/dev/circleci_data/test_external_utils.py
@@ -7,7 +7,7 @@ CPAC_DIR = str(Path(__file__).parent.parent.parent)
 sys.path.append(CPAC_DIR)
 DATA_DIR = os.path.join(CPAC_DIR, 'dev', 'circleci_data')
 
-from CPAC.__main__ import utils as CPAC_main_utils  # noqa E402
+from CPAC.__main__ import utils as CPAC_main_utils  # noqa: E402
 
 
 def test_build_data_config(cli_runner):
@@ -105,6 +105,6 @@ def _delete_test_yaml(test_yaml):
 def _test_repickle(pickle_path, gzipped=False):
     backup = _Backup(pickle_path)
     if gzipped:
-        import gzip  # noqa F401
+        import gzip  # noqa: F401
 
     backup.restore()


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes

> :flushed: And I've apparently been doing the [specific-violation for flake8](https://flake8.pycqa.org/en/latest/user/violations.html#in-line-ignoring-errors) wrong:
> without the colon the part after `# noqa` would be ignored

― [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.png?width=12&height=12) DM](https://cmi-cnl.slack.com/archives/D02F35ESMGR/p1643388726771659) @shnizzedy

Related to https://github.com/FCP-INDI/C-PAC/pull/1639#pullrequestreview-865304168 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
* Adds colons to `# noqa` where no colon was present but a specific code was provided
* Removes `# noqa` where no code was provided
* Adds `# pylint: disable` to lines that had `# noqa` but no `# pylint: disable` and Pylint complained about style

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
