### PR TITLE
🐛 Import engine logger with built-in logging library

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -6,11 +6,13 @@ import shutil
 import pickle
 import copy
 import faulthandler
-import yaml
 
+from logging import getLogger
 from time import strftime
 
 import nipype
+import yaml
+
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.pipeline.nipype_pipeline_engine.plugins import \
     LegacyMultiProcPlugin, MultiProcPlugin
@@ -1048,7 +1050,7 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
                 f"to workflow '{wf}' " + previous_nb_str + e.args[0],
             )
             if cfg.pipeline_setup['Debugging']['verbose']:
-                verbose_logger = logging.getLogger('engine')
+                verbose_logger = getLogger('engine')
                 verbose_logger.debug(e.args[0])
                 verbose_logger.debug(rpool)
             raise


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1645 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Depending on one's pipeline configuration between #1645 and this PR, `verbose_logger` would be set to `None` here https://github.com/FCP-INDI/C-PAC/blob/ffac4a02cc7fc0175f7207bf8620d5fcba8d6c6f/CPAC/pipeline/cpac_pipeline.py#L1051 which would raise an `AttributeError` here https://github.com/FCP-INDI/C-PAC/blob/ffac4a02cc7fc0175f7207bf8620d5fcba8d6c6f/CPAC/pipeline/cpac_pipeline.py#L1052

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Nipype's [`getLogger`](https://github.com/nipy/nipype/blob/6c060304f380c46b2f05c5afdc7171dbbdfadc58/nipype/utils/logger.py#L90-L98) relies on [`nipype.utils.logger.Logging`'s `loggers` attribute](https://github.com/nipy/nipype/blob/6c060304f380c46b2f05c5afdc7171dbbdfadc58/nipype/utils/logger.py#L40-L45), which does not include `'engine'`.

Built-in `logging.getLogger` does not have this reliance.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
