### PR TITLE
🔊 Add lens of `strat_list_list` and `rp_dct` to engine.log

### DIFF
--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -404,7 +404,8 @@ class ResourcePool(object):
                 len_inputs -= 1
                 continue
             sub_pool = []
-
+            if debug:
+                verbose_logger.debug('len(rp_dct): %s\n', len(rp_dct))
             for strat in rp_dct.keys():
                 json_info = self.get_json(fetched_resource, strat)
                 cpac_prov = json_info['CpacProvenance']
@@ -447,6 +448,9 @@ class ResourcePool(object):
                     strat_str_list.append(strat_str)
                     strat_list_list.append(strat_list)
 
+            if debug:
+                verbose_logger.debug('len(strat_list_list): %s\n',
+                                     len(strat_list_list))
             for strat_list in strat_list_list:
 
                 json_dct = {}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to setup taking forever with this pipeline config

```YAML
FROM: abcd-options
pipeline_setup:
  pipeline_name: ABCD-blip
  output_directory:
    quality_control:
      generate_xcpqc_files: On
functional_preproc:
  distortion_correction:
    using:
      - PhaseDiff
      - Blip
```

## Description
<!-- Concisely describe what the pull request does. -->
Adds lengths of `strat_list_list` and `rp_dct` to engine.log

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
> I found a couple really good spots where we can add reports for verbose logging/debugging, to help quickly figure out these forking issues in the future. Check the length of strat_list_list right before this loop: https://github.com/FCP-INDI/C-PAC/blob/a33dfe892ce3cd31d346f3c1ab032e7e91e4ba0f/CPAC/pipeline/engine.py#L436, and you get something like this:
>
> ```
> 220203-07:26:12,186 nipype.workflow INFO:
>         Connecting n4_bias_correction...
> 220203-07:26:12,187 nipype.workflow INFO:
>         Connecting acpc_alignment_head_with_mask...
> 1
> 220203-07:26:12,197 nipype.workflow INFO:
>         Connecting freesurfer_abcd_preproc...
> 1
> 220203-07:26:12,214 nipype.workflow INFO:
>         Connecting brain_mask_freesurfer_abcd...
> 2
> 220203-07:26:12,224 nipype.workflow INFO:
>         Connecting brain_extraction...
> 3
> 220203-07:26:12,230 nipype.workflow INFO:
>         Connecting register_ANTs_anat_to_template...
> 9
> 220203-07:26:12,712 nipype.workflow INFO:
>         Connecting overwrite_transform_anat_to_template...
> ```
> so you see that brain_mask_freesurfer_abcd suddenly has two forks, and it starts multiplying out unnecessarily after that- and blows up to 9 right before moving onto the first node block that takes forever (overwrite_transform_anat_to_template) - if you let that progress I'm sure you'll see some crazy number way higher than 9.
> but that wasn't good enough to find out what the problem was (at first I assumed wmparc and T1w had to be linked but that didn't do it) - so I started dropping the amount of strats for each specific resource pulled into a node block - if you report the resource, and the `len(rp_dct)` of each resource [here](https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/pipeline/engine.py#L396), you quickly see that `freesurfer-subject-dir` is the only one with multiple strats/forks in freesurfer_abcd_preproc, and tracing that resource's provenance led me to see that there were two versions of it, one from regular `freesurfer_preproc` and the other from `freesurfer_abcd_preproc`

― @sgiavasis on Slack

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
