### PR TITLE
🐛 Don't run `recon-all` twice

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -3188,7 +3188,7 @@ def correct_restore_brain_intensity_abcd(wf, cfg, strat_pool, pipe_num, opt=None
     wf.connect(node, out, merge_t1_acpc_to_list, 'in3')
 
     merge_t1_acpc = pe.Node(interface=fslMerge(),
-                            name='merge_t1_acpc')
+                            name=f'merge_t1_acpc_{pipe_num}')
 
     merge_t1_acpc.inputs.dimension = 't'
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -857,7 +857,12 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
         pipeline_blocks += anat_blocks
 
         if not rpool.check_rpool('freesurfer-subject-dir'):
-            pipeline_blocks += [freesurfer_abcd_preproc]
+            if freesurfer_preproc in pipeline_blocks:
+                pipeline_blocks[
+                    pipeline_blocks.index(freesurfer_preproc)
+                ] = freesurfer_abcd_preproc
+            else:
+                pipeline_blocks += [freesurfer_abcd_preproc]
 
     # Anatomical T1 brain masking
     if not rpool.check_rpool('space-T1w_desc-brain_mask') or \

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -857,12 +857,7 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
         pipeline_blocks += anat_blocks
 
         if not rpool.check_rpool('freesurfer-subject-dir'):
-            if freesurfer_preproc in pipeline_blocks:
-                pipeline_blocks[
-                    pipeline_blocks.index(freesurfer_preproc)
-                ] = freesurfer_abcd_preproc
-            else:
-                pipeline_blocks += [freesurfer_abcd_preproc]
+            pipeline_blocks += [freesurfer_abcd_preproc]
 
     # Anatomical T1 brain masking
     if not rpool.check_rpool('space-T1w_desc-brain_mask') or \

--- a/CPAC/surface/tests/test_config.py
+++ b/CPAC/surface/tests/test_config.py
@@ -1,15 +1,26 @@
 """
 Tests for surface configuration
-
-FROM: abcd-options
-pipeline_setup:
-  pipeline_name: ABCD-blip
-  output_directory:
-    quality_control:
-      generate_xcpqc_files: On
-functional_preproc:
-  distortion_correction:
-    using:
-      - PhaseDiff
-      - Blip
 """
+import os
+import pkg_resources as p
+import pytest
+import yaml
+
+from CPAC.pipeline.cpac_pipeline import run_workflow
+from CPAC.utils.configuration import Configuration
+
+
+@pytest.mark.timeout(60)
+def test_duplicate_freesurfer():
+    """The pipeline should build fast if freesurfer is not self-duplicating"""
+    c = Configuration(yaml.safe_load('FROM: abcd-options'))
+    sub_dict = yaml.safe_load(open(p.resource_filename(
+        "CPAC",
+        os.path.join(
+            "resources",
+            "configs",
+            "data_config_S3-BIDS-ABIDE.yml"
+        )
+    ), 'r'))[0]
+
+    run_workflow(sub_dict, c, False, test_config=True)

--- a/CPAC/surface/tests/test_config.py
+++ b/CPAC/surface/tests/test_config.py
@@ -1,0 +1,15 @@
+"""
+Tests for surface configuration
+
+FROM: abcd-options
+pipeline_setup:
+  pipeline_name: ABCD-blip
+  output_directory:
+    quality_control:
+      generate_xcpqc_files: On
+functional_preproc:
+  distortion_correction:
+    using:
+      - PhaseDiff
+      - Blip
+"""

--- a/CPAC/utils/configuration.py
+++ b/CPAC/utils/configuration.py
@@ -117,6 +117,15 @@ class Configuration(object):
                     regressor['Name'] = f'Regressor-{str(i + 1)}'
                 # replace spaces with hyphens in Regressor 'Name's
                 regressor['Name'] = regressor['Name'].replace(' ', '-')
+
+        # Don't double-run FreeSurfer
+        try:
+            if 'FreeSurfer-ABCD' in config_map['anatomical_preproc'][
+                    'brain_extraction']['using']:
+                config_map['surface_analysis']['freesurfer']['run'] = False
+        except TypeError:
+            pass
+
         config_map = schema(config_map)
 
         # remove 'FROM' before setting attributes now that it's imported

--- a/dev/circleci_data/requirements.txt
+++ b/dev/circleci_data/requirements.txt
@@ -4,5 +4,6 @@ spython >= 0.0.81
 pytest
 pytest_bdd
 pytest_click
+pytest-timeout
 pyyaml
 yamlordereddictloader

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -170,6 +170,7 @@ surface_analysis:
   # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
   freesurfer: 
 
+    # If anatomical_preproc['brain_extraction']['using'] includes FreeSurfer-ABCD and this switch is On, C-PAC will automatically turn this switch Off to avoid running FreeSurfer twice unnecessarily
     run: Off
 
     # Add extra arguments to recon-all command


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #1653 by @shnizzedy & @sgiavasis 

## Description
<!-- Concisely describe what the pull request does. -->
If `anatomical_preproc.['brain_extraction']['using']` includes `'FreeSurfer-ABCD'`, force `surface_analysis['freesurfer']['run']` to be off.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
> in the ABCD preconfig both freesurfer_preproc is enabled and
> freesurfer_abcd_preproc is enabled and it's causing two strats for
> freesurfer-subject-dir which causes the FS-ABCD brain mask node block
> to fork unnecessarily, which then starts multiplying uncontrollably. I
> turned this off and the pipeline runs immediately for PNC data.
> recon-all still gets a chance to run in freesurfer abcd preproc.

― Steve on Slack

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Passes if pipeline builds in less than a minute:
https://github.com/FCP-INDI/C-PAC/blob/ee734cab1e6f7e2fe11762aeebab126afb058aea/CPAC/surface/tests/test_config.py#L13-L26

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [ ] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
