### PR TITLE
✅ Skip test if `nilearn.datasets.fetch_atlas_craddock_2012()` fails

### DIFF
--- a/CPAC/cwas/tests/test_pipeline_cwas.py
+++ b/CPAC/cwas/tests/test_pipeline_cwas.py
@@ -1,8 +1,10 @@
 import os
+from urllib.error import URLError
+
+import nibabel as nb
+import nilearn.datasets
 import numpy as np
 import pandas as pd
-import nilearn.datasets
-import nibabel as nb
 
 from CPAC.cwas.pipeline import create_cwas
 
@@ -28,10 +30,14 @@ def test_pipeline():
         FID in images[i]
         for i, FID in enumerate(pheno.FILE_ID)
     )
-
-    cc = nilearn.datasets.fetch_atlas_craddock_2012()
+    try:
+        # pylint: disable=invalid-name
+        cc = nilearn.datasets.fetch_atlas_craddock_2012()
+    except URLError:
+        print('Could not fetch atlas, skipping test')
+        return
     img = nb.load(cc['scorr_mean'])
-    img_data = np.copy(img.get_data()[:,:,:,10])
+    img_data = np.copy(img.get_data()[:, :, :, 10])
     img_data[img_data != 2] = 0.0
     img = nb.Nifti1Image(img_data, img.affine)
     nb.save(img, '/tmp/cwas/roi.nii.gz')

--- a/CPAC/cwas/tests/test_pipeline_cwas.py
+++ b/CPAC/cwas/tests/test_pipeline_cwas.py
@@ -9,7 +9,12 @@ import pandas as pd
 from CPAC.cwas.pipeline import create_cwas
 
 def test_pipeline():
-
+    try:
+        # pylint: disable=invalid-name
+        cc = nilearn.datasets.fetch_atlas_craddock_2012()
+    except URLError:
+        print('Could not fetch atlas, skipping test')
+        return
     try:
         os.mkdir('/tmp/cwas')
     except:
@@ -30,12 +35,6 @@ def test_pipeline():
         FID in images[i]
         for i, FID in enumerate(pheno.FILE_ID)
     )
-    try:
-        # pylint: disable=invalid-name
-        cc = nilearn.datasets.fetch_atlas_craddock_2012()
-    except URLError:
-        print('Could not fetch atlas, skipping test')
-        return
     img = nb.load(cc['scorr_mean'])
     img_data = np.copy(img.get_data()[:, :, :, 10])
     img_data[img_data != 2] = 0.0


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes https://github.com/FCP-INDI/C-PAC/pull/1691#issuecomment-1054707819 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
If https://github.com/FCP-INDI/C-PAC/blob/c95f25626e0e506a8eb386c39140ef41336b34c2/CPAC/cwas/tests/test_pipeline_cwas.py#L14 fails, skips this whole test: https://github.com/FCP-INDI/C-PAC/blob/c95f25626e0e506a8eb386c39140ef41336b34c2/CPAC/cwas/tests/test_pipeline_cwas.py#L11-L66

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
By skipping the whole test, we do lose out on this assertion https://github.com/FCP-INDI/C-PAC/blob/c95f25626e0e506a8eb386c39140ef41336b34c2/CPAC/cwas/tests/test_pipeline_cwas.py#L33-L37 that could run without this atlas, but https://github.com/FCP-INDI/C-PAC/blob/c95f25626e0e506a8eb386c39140ef41336b34c2/CPAC/cwas/tests/test_pipeline_cwas.py#L38-L66 seems to be the real test here, with the part we're maybe-unnecessarily skipping just a sanity check

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
