### PR TITLE
✨ Add `--runtime_usage` flag

### DIFF
--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -198,6 +198,15 @@ def run_main():
                              'flag also takes precedence over '
                              'maximum_memory_per_participant in the pipeline '
                              'configuration file.')
+    parser.add_argument('--runtime_usage', type=str,
+                        help='Path to a callback.log from a prior run of the '
+                             'same pipeline configuration. This log will be '
+                             'used to override per-node memory estimates with '
+                             'observed values plus a buffer.')
+    parser.add_argument('--runtime_buffer', type=float, default=10,
+                        help='Buffer to add to per-node memory estimates if '
+                             '--runtime_usage is specified. This number is a '
+                             'percentage of the observed memory usage.')
     parser.add_argument('--num_ants_threads', type=int, default=0,
                         help='The number of cores to allocate to ANTS-'
                              'based anatomical registration per '
@@ -730,6 +739,10 @@ def run_main():
                     'maximum_memory_per_participant']),
                 'status_callback': log_nodes_cb
             }
+            if args.runtime_usage is not None:
+                plugin_args['runtime'] = {
+                    'usage': args.runtime_usage,
+                    'buffer': args.runtime_buffer}
 
             print("Starting participant level processing")
             CPAC.pipeline.cpac_runner.run(


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1688 by @gkiar 

## Description
<!-- Concisely describe what the pull request does. -->
Adds flags `--runtime_usage` and `--runtime_buffer` https://github.com/FCP-INDI/C-PAC/blob/085d26ee9a978a11695b73ccbae2259d97870c0f/dev/docker_data/run.py#L201-L209

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
If `--runtime_usage` is set, the `callback.log` file specified is parsed for node names, the subject-session BIDS tag is stripped from the node name, and each node with an observed `'runtime_memory_gb'` has its `_mem_x` removed (if any is set) and its `mem_gb` set to the observed number + 1 * `runtime_buffer` / 100.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
