### PR TITLE
Rodent template fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed merge error preventing QC files and surface derivatives copying to output directory and renaming connectome → connectivity matrix files
 - Fixed a bug where subsequent subjects' logs were being appended to prior subjects' logs
+- Fixed templates used for rodent pipeline
 
 ## [1.8.3] - 2022-02-11
 

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -64,6 +64,8 @@ registration_workflows:
     
       run: On
 
+      EPI_template: /template/study_based_functional_template_sk.nii.gz
+
       ANTs: 
 
         # EPI registration configuration - synonymous with T1_registration

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -61,10 +61,9 @@ registration_workflows:
       run: Off
 
     EPI_registration:
-    
       run: On
 
-      EPI_template: /template/study_based_functional_template_sk.nii.gz
+      EPI_template: /cpac_templates/chd8_functional_template_sk.nii
 
       ANTs: 
 
@@ -143,7 +142,7 @@ registration_workflows:
 
           # EPI template for direct functional-to-template registration
           # (bypassing coregistration and the anatomical-to-template transforms)
-          EPI_template_funcreg: /template/study_based_functional_template_sk.nii.gz
+          EPI_template_funcreg: /cpac_templates/chd8_functional_template_sk.nii
           
           # EPI template mask.
           EPI_template_mask_funcreg: None
@@ -232,7 +231,7 @@ nuisance_corrections:
 
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions
-    lateral_ventricles_mask: /cpac_templates/chd8_functional_template_noise_mask_ag.nii.gz
+    lateral_ventricles_mask: /cpac_templates/chd8_functional_template_noise_mask_ag.nii
 
 # OUTPUTS AND DERIVATIVES
 # -----------------------


### PR DESCRIPTION
## Fixes
Uses the correct templates for the rodent pipeline. Pipelines were provided by Marco Pagani. 
Fixes #1675 by @shnizzedy 

## Description
Templates `chd8_functional_template_sk.nii` and `chd8_functional_template_noise_mask_ag.nii` were added into this repo for the rodent pipeline. `chd8_functional_template_sk.nii.gz` is the brain template that you use for registration, `chd8_functional_template_noise_mask_ag.nii.gz` is the ventricle mask of the brain template that you use to extract signal for denoising

## Technical details
Template chd8_functional_template_sk.nii was used in:
```
registration_workflows:
  fuctional_registration:
    EPI_registration:
      EPI_template: chd8_functional_template_sk.nii

registration_workflows:
  functional_registration:
    func_registration_to_template:
      target_template:
        EPI_template:
          EPI_template_funcreg: chd8_functional_template_sk.nii
```
Template chd8_functional_template_noise_mask_ag.nii was used in:
```
nuisance_corrections:
  2-nuisance_regression:
    lateral_ventricles_mask: chd8_functional_template_noise_mask_ag.nii
```
Although `chd8_functional_template_noise_mask_ag.nii.gz` is already a template in this repo, whenever it would get used, it gave an error `FileNotFoundError: File /cpac_templates/chd8_functional_template_noise_mask_ag.nii.gz does not exist!`. When I checked the info of that file, it showed that it was not a valid NIFTI file.

`fslinfo /home/agutierrez/Documents/C-PAC_templates/atlases/label/Mouse/chd8_functional_template_noise_mask_ag.nii.gz
Error: file does not appear to be a valid NIFTI image`

These changes were also made in the rodent pipeline `/CPAC/resources/configs/pipeline_config_rodent.yml`

## Tests
Run rodent pipeline with new rodent pipeline where EPI_template: /cpac_templates/chd8_functional_template_sk.nii, EPI_template_funcreg: /cpac_templates/chd8_functional_template_sk.nii, and lateral_ventricles_mask: /cpac_templates/chd8_functional_template_noise_mask_ag.nii in the pipeline. No errors or crashes should arise.

## Screenshots
This is a screenshot from our run with updated templates overlayed over Marco's run from sub-ag150519a. 
<img width="449" alt="Screen Shot 2022-04-19 at 1 19 01 PM" src="https://user-images.githubusercontent.com/58920810/164060251-99626725-1a36-47d7-8ecc-c84100775c70.png">

CPAC run: `/data3/cnl/agutierrez/issue_runs/rodent-template-fix/templates_mapped`
Marco's run to compare against: `/data3/cnl/rodent/Marco_rodent_code/Marco_output/Marco_pipe_run_allsub_1207/part1`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
