### PR TITLE
Rodent template fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed merge error preventing QC files and surface derivatives copying to output directory and renaming connectome → connectivity matrix files
 - Fixed a bug where subsequent subjects' logs were being appended to prior subjects' logs
-- Fixed templates used for rodent pipeline
+- Fixed templates used for rodent pipeline and added outputs that were missing
 
 ## [1.8.3] - 2022-02-11
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1270,10 +1270,14 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
         pipeline_blocks += [warp_bold_mask_to_T1template,
                             warp_deriv_mask_to_T1template]
 
-    apply_func_warp['EPI'] = (
-        _r_w_f_r['coregistration']['run'] and
-        _r_w_f_r['func_registration_to_template']['run_EPI'])
+    template = cfg.registration_workflows['functional_registration']['func_registration_to_template']['target_template']['using']
+
+    if 'T1_template' in template: 
+	    apply_func_warp['EPI'] = (_r_w_f_r['coregistration']['run'] and _r_w_f_r['func_registration_to_template']['run_EPI'])
+    
+    apply_func_warp['EPI'] = (_r_w_f_r['func_registration_to_template']['run_EPI'])
     del _r_w_f_r
+
     template_funcs = [
         'space-EPItemplate_desc-cleaned_bold',
         'space-EPItemplate_desc-brain_bold',

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1272,10 +1272,10 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
 
     template = cfg.registration_workflows['functional_registration']['func_registration_to_template']['target_template']['using']
 
-    if 'T1_template' in template: 
+    if 'T1_template' in template:
 	    apply_func_warp['EPI'] = (_r_w_f_r['coregistration']['run'] and _r_w_f_r['func_registration_to_template']['run_EPI'])
-    
-    apply_func_warp['EPI'] = (_r_w_f_r['func_registration_to_template']['run_EPI'])
+    else:
+        apply_func_warp['EPI'] = (_r_w_f_r['func_registration_to_template']['run_EPI'])
     del _r_w_f_r
 
     template_funcs = [

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -57,6 +57,7 @@ registration_workflows:
     run: Off
 
   functional_registration: 
+
     coregistration:
       run: Off
 
@@ -98,6 +99,8 @@ registration_workflows:
                 updateFieldVarianceInVoxelSpace: 5
 
     func_registration_to_template: 
+
+      run_EPI: On
 
       output_resolution: 
 


### PR DESCRIPTION
## Fixes
Fixes rodent template issues. Adds the correct templates for the rodent pipeline. Templates were provided by Marco.
Fixes rodent-pipeline so that [warp_ts_to EPItemplate](https://github.com/FCP-INDI/C-PAC/blob/80424468c7f4e59c102f446b05d4154ec1cd4b2d/CPAC/registration/registration.py#L3981) nodeblock runs even when coregistration is off.
Fixes #1675  by @shnizzedy 

## Description
Templates `chd8_functional_template_sk.nii` and `chd8_functional_template_noise_mask_ag.nii` were added into this repo for the rodent pipeline. `chd8_functional_template_sk.nii` is the brain template that you use for registration, `chd8_functional_template_noise_mask_ag.nii` is the ventricle mask of the brain template that you use to extract signal for denoising

[warp_ts_to EPItemplate](https://github.com/FCP-INDI/C-PAC/blob/80424468c7f4e59c102f446b05d4154ec1cd4b2d/CPAC/registration/registration.py#L3981) was not running because `run_EPI: ` was `Off` and because coregistration needed to be turned on. 

## Technical details
Template chd8_functional_template_sk.nii was used in:
```
registration_workflows:
  fuctional_registration:
    EPI_registration:
      EPI_template: chd8_functional_template_sk.nii

registration_workflows:
  functional_registration:
    func_registration_to_template:
      target_template:
        EPI_template:
          EPI_template_funcreg: chd8_functional_template_sk.nii
```
Template chd8_functional_template_noise_mask_ag.nii was used in:
```
nuisance_corrections:
  2-nuisance_regression:
    lateral_ventricles_mask: chd8_functional_template_noise_mask_ag.nii
```
Although `chd8_functional_template_noise_mask_ag.nii.gz` is already a template in this repo, whenever it would get used, it gave an error 
```
FileNotFoundError: File /cpac_templates/chd8_functional_template_noise_mask_ag.nii.gz does not exist!. When I checked the info of that file, it showed that it was not a valid NIFTI file.
fslinfo /home/agutierrez/Documents/C-PAC_templates/atlases/label/Mouse/chd8_functional_template_noise_mask_ag.nii.gz
Error: file does not appear to be a valid NIFTI image
```
Therefore I have replaced that template with the same template provided by Marco.

In `CPAC/resources/configs/pipeline_config_rodent.yml`, 
```
registration_workflows:
  functional_registration:
    func_registration_to_template:
      run_EPI: On
```
In `CPAC/pipeline/cpac_pipeline.py`, added these conditions so `apply_func_warp` can run when `coregistraion: Off`, and whenever `coregistration: On`, `T1_template` must be the `tartget_template`. 
https://github.com/FCP-INDI/C-PAC/blob/4706db88caec866f9a4a0c269c4a058482fa0aec/CPAC/pipeline/cpac_pipeline.py#L1273-L1294

## Tests
Run rodent pipeline. No errors or crashes should arise.
Example Docker Command:
```
docker run --security-opt=apparmor:unconfined -v /Users/{username}/Documents/C-PAC:/code -v /Users/{username}Rodent/rodent_data_website/all:/Users/{username}/Rodent/rodent_data_website/all -v /Users/{username}/Documents/Data/Rodent:/data -v /Users/{username}/Documents/C-PAC/dev/docker_data/run.py:/code/run.py -v /Users/{username}/Documents/C-PAC/dev/docker_data/run-with-freesurfer.sh:/code/run-with-freesurfer.sh -v /Users/{username}/Documents/C-PAC/dev/docker_data/default_pipeline.yml:/cpac_resources/default_pipeline.yml -v /Users/{username}/Documents/output:/output fcpindi/c-pac:nightly /data /output participant --save_working_dir --skip_bids_validator --n_cpus 1 --mem_gb 15 --participant_label sub-ag150519a --preconfig rodent
```
Make sure rodent_pipeline.yml has the changes explained above. 

Successful run can be found `/data3/cnl/agutierrez/issue_runs/rodent-template-fix/cpac_pipeline-fix`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
