### PR TITLE
Fix/surface dir

### DIFF
--- a/CPAC/surface/surf_preproc.py
+++ b/CPAC/surface/surf_preproc.py
@@ -65,7 +65,7 @@ def run_surface(post_freesurfer_folder,
                             'MNINonLinear/Results/task-rest01/'
                             'task-rest01_Atlas.dtseries.nii')
     aparc = {'desikan_killiany': {
-        164: os.path.join(post_freesurfer_folder, 'MNINonLinear'
+        164: os.path.join(post_freesurfer_folder, 'MNINonLinear',
                           f'{subject}.aparc.164k_fs_LR.dlabel.nii'),
         32: os.path.join(post_freesurfer_folder, 'MNINonLinear',
                          'fsaverage_LR32k',


### PR DESCRIPTION
## Fixes
Creates correct directory for file `sub-1019436_ses-1.aparc.164k_fs_LR.dlabel.nii` in `surface_preproc.py`

## Description
Crash file stated that path was not found
```
traits.trait_errors.TraitError: The 'in_file' trait of a RenameInputSpec instance must be a pathlike object or string representing an existing file, but a value of '/output/working/cpac_sub-1019436_ses-1/post_freesurfer_205/MNINonLinearsub-1019436_ses-1.aparc.164k_fs_LR.dlabel.nii' <class 'str'> was specified.

Error setting node input:
Node: nii_atlas-DesikanKilliany_space-fsLR_den-164k_dlabel_214
input: in_file
results_file: /output/working/cpac_sub-1019436_ses-1/_scan_rest_run-1_acq-1/post_freesurfer_205/result_post_freesurfer_205.pklz
value: /output/working/cpac_sub-1019436_ses-1/post_freesurfer_205/MNINonLinearsub-1019436_ses-1.aparc.164k_fs_LR.dlabel.nii


When creating this crashfile, the results file corresponding
to the node could not be found.
```

## Technical details
Comma was added separating `MNINonLinear` from `sub-1019436_ses-1.aparc.164k_fs_LR.dlabel.nii` to create `/MNINonLinear/sub-1019436_ses-1.aparc.164k_fs_LR.dlabel.nii`

## Tests
Run ABCD pipeline. No errors or crashes of this type should arise. Example docker command: 
```
docker run --security-opt=apparmor:unconfined -v /home/{user}/Documents/C-PAC:/code -v /home/{user}/Documents/C-PAC/dev/docker_data/run.py:/code/run.py -v /home/{user}/Documents/C-PAC/dev/docker_data/run-with-freesurfer.sh:/code/run-with-freesurfer.sh -v /home/{user}/Documents/C-PAC/dev/docker_data/default_pipeline.yml:/cpac_resources/default_pipeline.yml -v /data3/cnl/{user}/output:/output fcpindi/c-pac:nightly s3://fcp-indi/data/Projects/ADHD200/RawDataBIDS/KKI /output participant --save_working_dir --skip_bids_validator --n_cpus 1 --mem_gb 15 --participant_label sub-1019436 --preconfig abcd-options
```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
