### PR TITLE
🐛 Fix: `itk::ERROR: […] Inputs do not occupy the same physical space`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+per-file-ignores =
+  CPAC/func_preproc/func_preproc.py:E402

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed merge error preventing QC files and surface derivatives copying to output directory and renaming connectome → connectivity matrix files
 - Fixed a bug where subsequent subjects' logs were being appended to prior subjects' logs
 - Fixed templates used for rodent pipeline
+- Fixed [bug](https://github.com/FCP-INDI/C-PAC/issues/1556) in which ITK header imprecision was causing N4 bias correction to crash
 
 ## [1.8.3] - 2022-02-11
 

--- a/CPAC/utils/interfaces/ants.py
+++ b/CPAC/utils/interfaces/ants.py
@@ -2,15 +2,52 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-Nipype interfaces for ANTs commands
-"""
+#
+# STATEMENT OF CHANGES:
+# This file is derived from sources licensed under the Apache-2.0 terms,
+# and this file has been changed.
+#
+# CHANGES:
+#   * Made private classes public
+#   * Removed original example code
+#
+# ORIGINAL WORK'S ATTRIBUTION NOTICE:
+#
+#     Copyright 2021 The NiPreps Developers <nipreps@gmail.com>
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""Nipype interfaces for ANTs commands
 
-# Some of this functionality is adapted from poldracklab/niworkflows:
-# https://github.com/poldracklab/niworkflows/blob/master/niworkflows/interfaces/ants.py
-# https://fmriprep.readthedocs.io/
-# https://poldracklab.stanford.edu/
-# We are temporarily maintaining our own copy for more granular control.
+Some of this functionality is adapted from nipreps/niworkflows:
+- https://github.com/nipreps/niworkflows/blob/5a0f4bd3/niworkflows/interfaces/ants.py
+- https://fmriprep.readthedocs.io/
+- https://poldracklab.stanford.edu/
+We are temporarily maintaining our own copy for more granular control.
+
+Adapted from niworkflows:
+  - AIInputSpec
+  - AIOutputSpec
+  - AI
+  - ImageMathInputSpec
+  - ImageMathOuputSpec
+  - ImageMath
+  - ResampleImageBySpacingInputSpec
+  - ResampleImageBySpacingOutputSpec
+  - ResampleImageBySpacing
+  - ThresholdImageInputSpec
+  - ThresholdImageOutputSpec
+  - ThresholdImage
+"""  # noqa: E501  # pylint: disable=line-too-long
 import os
 from nipype.interfaces import base
 from nipype.interfaces.ants.base import ANTSCommandInputSpec, ANTSCommand
@@ -312,13 +349,7 @@ class AIOuputSpec(base.TraitedSpec):
 
 
 class AI(ANTSCommand):
-    """
-    The replacement for ``AffineInitializer``.
-
-    Example:
-    --------
-
-    """
+    """Replaces ``AffineInitializer``."""
 
     _cmd = 'antsAI'
     input_spec = AIInputSpec
@@ -357,5 +388,3 @@ class AI(ANTSCommand):
 
     def _list_outputs(self):
         return getattr(self, '_output')
-
-

--- a/CPAC/utils/interfaces/ants.py
+++ b/CPAC/utils/interfaces/ants.py
@@ -11,79 +11,10 @@ Nipype interfaces for ANTs commands
 # https://fmriprep.readthedocs.io/
 # https://poldracklab.stanford.edu/
 # We are temporarily maintaining our own copy for more granular control.
-
 import os
-from glob import glob
 from nipype.interfaces import base
 from nipype.interfaces.ants.base import ANTSCommandInputSpec, ANTSCommand
 from nipype.interfaces.base import traits, isdefined
-
-
-class CopyImageHeaderInformationInputSpec(ANTSCommandInputSpec):
-    """InputSpec for ``CopyImageHeaderInformation``.
-
-    ``imagetocopyrefimageinfoto`` is also used for ``imageout`` if
-    ``imageout`` is not specified.
-    """
-    def __setattr__(self, name, value):
-        super(ANTSCommandInputSpec, self).__setattr__(name, value)
-        if name == 'imagetocopyrefimageinfoto':
-            self._infer_imageout()
-
-    def _infer_imageout(self):
-        if (self.imageout == base.Undefined):
-            self.trait_set(imageout=self.imagetocopyrefimageinfoto)
-
-    refimage = base.File(position=1, argstr='%s', name_source=['refimage'],
-                         desc='reference image (with header to copy from)',
-                         exists=True, mandatory=True)
-
-    imagetocopyrefimageinfoto = base.File(position=2, argstr='%s',
-                                          name_source=[
-                                              'imagetocopyrefimageinfoto'
-                                          ], desc='image to copy header to',
-                                          exists=True, mandatory=True)
-
-    imageout = base.File(position=3, argstr='%s', name_sources=[
-                            'imagetocopyrefimageinfoto',
-                            'imageout'
-                         ],
-                         desc='output image file', usedefault=True)
-
-    boolcopydirection = traits.Bool(True, argstr='%d', position=4,
-                                    desc='copy direction?', usedefault=True)
-
-    boolcopyorigin = traits.Bool(True, argstr='%d', position=5,
-                                 desc='copy origin?', usedefault=True)
-
-    boolcopyspacing = traits.Bool(True, argstr='%d', position=6,
-                                  desc='copy spacing?', usedefault=True)
-
-
-class CopyImageHeaderInformationOutputSpec(base.TraitedSpec):
-    """OutputSpec for CopyImageHeaderInformation"""
-    imageout = base.File(exists=True, desc='output image file')
-
-
-class CopyImageHeaderInformation(ANTSCommand):
-    """Copy image header information from one file to another,
-    optionally as a copy.
-
-    Examples
-    --------
-    >>> CopyImageHeaderInformation(
-    ...     refimage='/cpac_templates/MacaqueYerkes19_T1w_2mm_brain.nii.gz',
-    ...     imagetocopyrefimageinfoto='/cpac_templates/MacaqueYerkes19_'
-    ...                               'T1w_2mm_brain_mask.nii.gz'
-    ... ).cmdline
-    'CopyImageHeaderInformation /cpac_templates/MacaqueYerkes19_T1w_2mm_brain.nii.gz /cpac_templates/MacaqueYerkes19_T1w_2mm_brain_mask.nii.gz /cpac_templates/MacaqueYerkes19_T1w_2mm_brain_mask.nii.gz 1 1 1'
-    """  # noqa: E501
-    _cmd = 'CopyImageHeaderInformation'
-    input_spec = CopyImageHeaderInformationInputSpec
-    output_spec = CopyImageHeaderInformationOutputSpec
-
-    def _list_outputs(self):
-        return {'imageout': self.inputs.imageout}
 
 
 class ImageMathInputSpec(ANTSCommandInputSpec):
@@ -112,10 +43,47 @@ class ImageMath(ANTSCommand):
     --------
 
     """
-
     _cmd = 'ImageMath'
     input_spec = ImageMathInputSpec
     output_spec = ImageMathOuputSpec
+
+
+class PrintHeaderInputSpec(ANTSCommandInputSpec):
+    """InputSpec for ``PrintHeader``.
+
+    See `PrintHeader: DESCRIPTION <https://manpages.debian.org/testing/ants/PrintHeader.1.en.html#DESCRIPTION>`_ for ``what_information`` values.
+    """  # noqa: E501  # pylint: disable=line-too-long
+    image = base.File(position=2, argstr='%s', name_source=['image'],
+                      desc='image to read header from', exists=True,
+                      mandatory=True)
+
+    what_information = traits.Int(position=3, argstr='%i',
+                                  name='what_information',
+                                  desc='read what from header')
+
+
+class PrintHeaderOutputSpec(base.TraitedSpec):
+    """OutputSpec for ``PrintHeader``."""
+    header = traits.String(name='header')
+
+
+class PrintHeader(ANTSCommand):
+    """Print image header information."""
+    _cmd = 'PrintHeader'
+    # pylint: disable=protected-access
+    _gen_filename = base.StdOutCommandLine._gen_filename
+    input_spec = PrintHeaderInputSpec
+    output_spec = PrintHeaderOutputSpec
+    _terminal_output = 'stream'
+
+    def aggregate_outputs(self, runtime=None, needed_outputs=None):
+        outputs = super().aggregate_outputs(runtime, needed_outputs)
+        outputs.trait_set(header=runtime.stdout)
+        self.output_spec().trait_set(header=runtime.stdout)
+        return outputs
+
+    def _list_outputs(self):
+        return self._outputs().get()
 
 
 class ResampleImageBySpacingInputSpec(ANTSCommandInputSpec):
@@ -187,6 +155,40 @@ class ResampleImageBySpacing(ANTSCommand):
 
         return super(ResampleImageBySpacing, self)._format_arg(
             name, trait_spec, value)
+
+
+class SetDirectionByMatrixInputSpec(ANTSCommandInputSpec):
+    """InputSpec for ``SetDirectionByMatrix``."""
+    infile = base.File(position=2, argstr='%s', name_source=['infile'],
+                       desc='image to copy header to', exists=True,
+                       mandatory=True)
+    outfile = base.File(position=3, argstr='%s',
+                        name_sources=['infile', 'outfile'],
+                        desc='output image file', usedefault=True)
+    direction = traits.String(argstr='%s', position=4,
+                              desc='dimensions, x-delimited')
+
+
+class SetDirectionByMatrixOutputSpec(base.TraitedSpec):
+    """OutputSpec for ``SetDirectionByMatrix``"""
+    outfile = base.File(exists=True, desc='output image file')
+
+
+class SetDirectionByMatrix(ANTSCommand):
+    """Set image header information from a matrix of dimensions."""
+    _cmd = 'SetDirectionByMatrix'
+    # pylint: disable=protected-access
+    _gen_filename = base.StdOutCommandLine._gen_filename
+    input_spec = SetDirectionByMatrixInputSpec
+    output_spec = SetDirectionByMatrixOutputSpec
+
+    def _format_arg(self, name, trait_spec, value):
+        if name == 'direction':
+            return value.replace('x', ' ')
+        return super()._format_arg(name, trait_spec, value)
+
+    def _list_outputs(self):
+        return {'outfile': self.inputs.outfile}
 
 
 class ThresholdImageInputSpec(ANTSCommandInputSpec):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1556 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->

>  If `CopyImageHeaderInformation` does not work, you can use `SetOrigin`, and if necessary `SetDirectionByMatrix`, to set both image headers to a constant reference value.

― [_ANTsX/ANTs Wiki_: Inputs do not occupy the same physical space: Fixing precision errors](https://github.com/ANTsX/ANTs/wiki/Inputs-do-not-occupy-the-same-physical-space#fixing-precision-errors)

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* In #1531, we set up `CopyImageHeaderInformation`, which reduced but did not eliminate occurrences of this error.  Here we use ANTs to grab the dimensions from the mask header and set them on the timeseries file.
* While I was updating [`CPAC/utils/interfaces/ants.py`](https://github.com/FCP-INDI/C-PAC/blob/28f8bc0a53f71cbdce4f553a41c3fd95ca06ad47/CPAC/utils/interfaces/ants.py), add source license per [_NiPreps_: Licensing and Derived Works](https://www.nipreps.org/community/licensing/)

<span id="note" name="note" />

### Note

This patch is applied here
https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/func_preproc/func_preproc.py#L1662-L1679 https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/func_preproc/func_preproc.py#L1721-L1725
but not to any of these places https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/func_preproc/func_preproc.py#L65-L70 https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/anat_preproc/ants.py#L192-L197 https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/anat_preproc/ants.py#L261-L267 https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/anat_preproc/anat_preproc.py#L1531-L1533 https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/anat_preproc/anat_preproc.py#L2250-L2253 https://github.com/FCP-INDI/C-PAC/blob/5947813c9413d4fcecad1970ae969923dccd7d41/CPAC/registration/registration.py#L2686-L2692 because I've only ever seen the error (myself and user-reported) in the node I patched here. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop-1.8.4` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
