### PR TITLE
♻️ Handle timestamps with or without nanoseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed merge error preventing QC files and surface derivatives copying to output directory and renaming connectome → connectivity matrix files
 - Fixed a bug where subsequent subjects' logs were being appended to prior subjects' logs
 - Fixed templates used for rodent pipeline and added outputs that were missing
+- Fixed a bug where a node with zero nanoseconds in timing information causes report generation to fail.
 
 ## [1.8.3] - 2022-02-11
 

--- a/CPAC/utils/monitoring/draw_gantt_chart.py
+++ b/CPAC/utils/monitoring/draw_gantt_chart.py
@@ -584,33 +584,31 @@ def _timing(nodes_list):
     True
     """
     try:
-        return [{k: _timing_timestamp(v) if k in {"start", "finish"} else
-                 v for k, v in node.items()} for node in nodes_list if
+        return [_timing_timestamp(node) for node in nodes_list if
                 "start" in node and "finish" in node]
     except ValueError:
         # Drop any problematic nodes
         new_node_list = []
         for node in nodes_list:
-            try:
-                new_node_list.append(
-                    {k: _timing_timestamp(v) if
-                     k in {"start", "finish"} else v for
-                     k, v in node.items()})
-            except ValueError:
-                pass
+            if "start" in node and "finish" in node:
+                try:
+                    new_node_list.append(_timing_timestamp(node))
+                except ValueError:
+                    pass
         return new_node_list
 
 
-def _timing_timestamp(timestamp):
-    """Convert one node from string to datetime
+def _timing_timestamp(node):
+    """Convert timestamps in a node from string to datetime
 
     Parameters
     ----------
-    timestamp : string
+    node : dict
 
     Returns
     -------
-    datetime.datetime
+    dict
     """
-    return (datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f") if
-            '.' in timestamp else datetime.fromisoformat(timestamp))
+    return {k: (datetime.strptime(v, "%Y-%m-%dT%H:%M:%S.%f") if
+            '.' in v else datetime.fromisoformat(v)) if
+            k in {"start", "finish"} else v for k, v in node.items()}

--- a/CPAC/utils/monitoring/draw_gantt_chart.py
+++ b/CPAC/utils/monitoring/draw_gantt_chart.py
@@ -230,65 +230,6 @@ def draw_nodes(start, nodes_list, cores, minute_scale, space_between_minutes,
     return result
 
 
-def _timing_timestamp(timestamp):
-    """Convert one node from string to datetime
-
-    Parameters
-    ----------
-    timestamp : string
-
-    Returns
-    -------
-    datetime.datetime
-    """
-    return (datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f") if
-            '.' in timestamp else datetime.fromisoformat(timestamp))
-
-
-def _timing(nodes_list):
-    """Covert timestamps from strings to datetimes
-
-    Parameters
-    ----------
-    nodes_list : list of dicts
-
-    Returns
-    -------
-    nodes_list : list of dicts
-
-    Examples
-    --------
-    >>> node_list = [{"start": "2022-04-16T14:43:36.286896",
-    ...               "finish": "2022-04-16T14:43:36"},
-    ...              {"start": "2022-04-16T14:43:38",
-    ...               "finish": "2022-04-16T14:43:38.529389"}]
-    >>> all(isinstance(v, str) for node in node_list for v in node.values())
-    True
-    >>> any(isinstance(v, datetime) for node in node_list for
-    ...     v in node.values())
-    False
-    >>> all(isinstance(v, datetime) for node in _timing(node_list) for
-    ...     v in node.values())
-    True
-    """
-    try:
-        return [{k: _timing_timestamp(v) if k in {"start", "finish"} else
-                 v for k, v in node.items()} for node in nodes_list if
-                "start" in node and "finish" in node]
-    except ValueError:
-        # Drop any problematic nodes
-        new_node_list = []
-        for node in nodes_list:
-            try:
-                new_node_list.append(
-                    {k: _timing_timestamp(v) if
-                     k in {"start", "finish"} else v for
-                     k, v in node.items()})
-            except ValueError:
-                pass
-        return new_node_list
-
-
 def generate_gantt_chart(
     logfile,
     cores,
@@ -614,3 +555,62 @@ def resource_report(callback_log, num_cores, logger=None):
             logger.warning(e_msg, exc_info=1)
         else:
             warn(e_msg, category=ResourceWarning)
+
+
+def _timing(nodes_list):
+    """Covert timestamps from strings to datetimes
+
+    Parameters
+    ----------
+    nodes_list : list of dicts
+
+    Returns
+    -------
+    nodes_list : list of dicts
+
+    Examples
+    --------
+    >>> node_list = [{"start": "2022-04-16T14:43:36.286896",
+    ...               "finish": "2022-04-16T14:43:36"},
+    ...              {"start": "2022-04-16T14:43:38",
+    ...               "finish": "2022-04-16T14:43:38.529389"}]
+    >>> all(isinstance(v, str) for node in node_list for v in node.values())
+    True
+    >>> any(isinstance(v, datetime) for node in node_list for
+    ...     v in node.values())
+    False
+    >>> all(isinstance(v, datetime) for node in _timing(node_list) for
+    ...     v in node.values())
+    True
+    """
+    try:
+        return [{k: _timing_timestamp(v) if k in {"start", "finish"} else
+                 v for k, v in node.items()} for node in nodes_list if
+                "start" in node and "finish" in node]
+    except ValueError:
+        # Drop any problematic nodes
+        new_node_list = []
+        for node in nodes_list:
+            try:
+                new_node_list.append(
+                    {k: _timing_timestamp(v) if
+                     k in {"start", "finish"} else v for
+                     k, v in node.items()})
+            except ValueError:
+                pass
+        return new_node_list
+
+
+def _timing_timestamp(timestamp):
+    """Convert one node from string to datetime
+
+    Parameters
+    ----------
+    timestamp : string
+
+    Returns
+    -------
+    datetime.datetime
+    """
+    return (datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f") if
+            '.' in timestamp else datetime.fromisoformat(timestamp))

--- a/CPAC/utils/monitoring/draw_gantt_chart.py
+++ b/CPAC/utils/monitoring/draw_gantt_chart.py
@@ -3,10 +3,10 @@
 
 See https://nipype.readthedocs.io/en/latest/api/generated/nipype.utils.draw_gantt_chart.html
 '''  # noqa: E501
-import datetime
 import random
 
 from collections import OrderedDict
+from datetime import datetime
 from warnings import warn
 
 from nipype.utils.draw_gantt_chart import draw_lines, draw_resource_bar, \
@@ -162,7 +162,7 @@ def draw_nodes(start, nodes_list, cores, minute_scale, space_between_minutes,
     scale = space_between_minutes / minute_scale
     space_between_minutes = space_between_minutes / scale
     end_times = [
-        datetime.datetime(
+        datetime(
             start.year, start.month, start.day, start.hour, start.minute,
             start.second
         )
@@ -189,7 +189,7 @@ def draw_nodes(start, nodes_list, cores, minute_scale, space_between_minutes,
         for core in range(len(end_times)):
             if end_times[core] < node_start:
                 left += core * 30
-                end_times[core] = datetime.datetime(
+                end_times[core] = datetime(
                     node_finish.year,
                     node_finish.month,
                     node_finish.day,
@@ -228,6 +228,39 @@ def draw_nodes(start, nodes_list, cores, minute_scale, space_between_minutes,
 
     # Return html string for nodes
     return result
+
+
+def _timing(nodes_list):
+    """Covert timestamps from strings to datetimes
+
+    Parameters
+    ----------
+    nodes_list : list of dicts
+
+    Returns
+    -------
+    nodes_list : list of dicts
+
+    Examples
+    --------
+    >>> node_list = [{"start": "2022-04-16T14:43:36.286896",
+    ...               "finish": "2022-04-16T14:43:36"},
+    ...              {"start": "2022-04-16T14:43:38",
+    ...               "finish": "2022-04-16T14:43:38.529389"}]
+    >>> all(isinstance(v, str) for node in node_list for v in node.values())
+    True
+    >>> any(isinstance(v, datetime) for node in node_list for
+    ...     v in node.values())
+    False
+    >>> all(isinstance(v, datetime) for node in _timing(node_list) for
+    ...     v in node.values())
+    True
+    """
+    return [{k: (datetime.strptime(v, "%Y-%m-%dT%H:%M:%S.%f") if
+                 '.' in v else datetime.fromisoformat(v)
+                 ) if k in {"start", "finish"} else v for k, v in
+            node.items()} for node in nodes_list if
+            "start" in node and "finish" in node]
 
 
 def generate_gantt_chart(
@@ -358,16 +391,7 @@ def generate_gantt_chart(
 
     # Only include nodes with timing information, and covert timestamps
     # from strings to datetimes
-    nodes_list = [
-        {
-            k: datetime.datetime.strptime(i[k], "%Y-%m-%dT%H:%M:%S.%f")
-            if k in {"start", "finish"}
-            else i[k]
-            for k in i
-        }
-        for i in nodes_list
-        if "start" in i and "finish" in i
-    ]
+    nodes_list = _timing(nodes_list)
 
     if not nodes_list:
         return


### PR DESCRIPTION
## Fixes
```Python
Traceback (most recent call last):
  File "/code/run.py", line 798, in <module>
    run_main()
  File "/code/run.py", line 779, in run_main
    test_config=(1 if args.analysis_level == "test_config" else 0)
  File "/code/CPAC/pipeline/cpac_runner.py", line 567, in run
    raise e
  File "/code/CPAC/pipeline/cpac_runner.py", line 564, in run
    p_name, plugin, plugin_args, test_config)
  File "/code/CPAC/pipeline/cpac_pipeline.py", line 720, in run_workflow
    num_cores_per_sub, logger)
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 561, in resource_report
    generate_gantt_chart(callback_log, num_cores)
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 368, in generate_gantt_chart
    for i in nodes_list
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 369, in <listcomp>
    if "start" in i and "finish" in i
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 366, in <dictcomp>
    for k in i
  File "/usr/local/miniconda/lib/python3.7/_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/miniconda/lib/python3.7/_strptime.py", line 359, in _strptime
    (data_string, format))
ValueError: time data '2022-04-29T18:24:09' does not match format '%Y-%m-%dT%H:%M:%S.%f'
```

## Description
<!-- Concisely describe what the pull request does. -->
I'd never seen this before, but with no nanoseconds in the timestamp, `strptime` caused a report generation to fail, and that killed the whole run! 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I pulled the string-to-datetime comprehension out into a separate function so I could write a small unit test to test mix-and-match with and without nanoseconds

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
https://github.com/FCP-INDI/C-PAC/blob/6a41cfcdaca91d61ba4ac2a85fff4a26c5030058/CPAC/utils/monitoring/draw_gantt_chart.py#L573-L584

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop-1.8.4` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
