### PR TITLE
🐛 Handle memory estimation when ingressing from existing working directory

### DIFF
--- a/CPAC/pipeline/nipype_pipeline_engine/engine.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/engine.py
@@ -449,14 +449,8 @@ class Workflow(pe.Workflow):
                                     node._apply_mem_x(_load_resultfile(
                                         input_resultfile
                                     ).inputs[field])
-                                except (FileNotFoundError, TypeError):
-                                    self._handle_just_in_time_exception(node)
-                                except KeyError:
-                                    warnings.warn(str(KeyError(
-                                        f'Node {node.name} specifies memory '
-                                        'allocation for input '
-                                        f'{node.mem_x["file"]}, but no such '
-                                        'input is specified for that Node.')))
+                                except (FileNotFoundError, KeyError,
+                                        TypeError):
                                     self._handle_just_in_time_exception(node)
 
     def _handle_just_in_time_exception(self, node):

--- a/CPAC/pipeline/nipype_pipeline_engine/engine.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/engine.py
@@ -449,7 +449,7 @@ class Workflow(pe.Workflow):
                                     node._apply_mem_x(_load_resultfile(
                                         input_resultfile
                                     ).inputs[field])
-                                except FileNotFoundError:
+                                except (FileNotFoundError, TypeError):
                                     self._handle_just_in_time_exception(node)
                                 except KeyError:
                                     warnings.warn(str(KeyError(

--- a/CPAC/utils/monitoring/draw_gantt_chart.py
+++ b/CPAC/utils/monitoring/draw_gantt_chart.py
@@ -539,14 +539,10 @@ def resource_report(callback_log, num_cores, logger=None):
     try:
         txt_report = resource_overusage_report(callback_log)[0]
         if txt_report:
-            if logger is not None:
-                logger.warning(txt_report)
-            else:
-                warn(txt_report, category=ResourceWarning)
-            open(
-                callback_log + ".resource_overusage.txt", "w"
-            ).write(txt_report)
-    except Exception as exception:
+            with open(callback_log + '.resource_overusage.txt',
+                      'w') as resource_overusage_file:
+                resource_overusage_file.write(txt_report)
+    except Exception as exception:  # pylint: disable=broad-except
         e_msg += f'Excessive usage report failed for {callback_log} ' \
                  f'({str(exception)})\n'
     generate_gantt_chart(callback_log, num_cores)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #1729 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
* #1729 occurs with existing working and output directories. With an existing working directory and a new output directory,
   ```Python
   Traceback (most recent call last):
     File "/code/CPAC/pipeline/cpac_pipeline.py", line 519, in run_workflow
       workflow.run(plugin=plugin, plugin_args=plugin_args)
     File "/usr/local/miniconda/lib/python3.7/site-packages/nipype/pipeline/engine/workflows.py", line 629, in run
       self._configure_exec_nodes(execgraph)
     File "/code/CPAC/pipeline/nipype_pipeline_engine/engine.py", line 451, in _configure_exec_nodes
       ).inputs[field])
   TypeError: list indices must be integers or slices, not str
   ```
   was happening. This PR catches `TypeError`s at that point (in memory estimation) and handles them with an existing handler.
* Warnings like
   ```Python
   UserWarning: 'Node write_composite_invlinear_xfm specifies memory allocation for input input_image, but no such input is specified for that Node.'
   ```
   seem less than useful and are removed
* Resource overusage log is removed from the cleanup portion of the live log (this section is often long and only useful for debugging) but the logfile is retained

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I think the cause of this bug is related to differences in how Nipype handles nodes-to-be-run vs. nodes-to-be-skipped.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop-1.8.4` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
