### PR TITLE
🥅 Fix LookupError transclusion

### DIFF
--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -428,10 +428,10 @@ class ResourcePool:
             total_pool.append(sub_pool)
 
         if not total_pool:
-            raise LookupError('\n\n[!] C-PAC says: None of the listed ' \
-                              'resources in the node block being connected ' \
-                              'exist in the resource pool.\n\nResources:\n' \
-                              '{resource_list}\n\n')
+            raise LookupError('\n\n[!] C-PAC says: None of the listed '
+                              'resources in the node block being connected '
+                              'exist in the resource pool.\n\nResources:\n'
+                              '%s\n\n' % resource_list)
 
         # TODO: right now total_pool is:
         # TODO:    [[[T1w:anat_ingress, desc-preproc_T1w:anatomical_init, desc-preproc_T1w:acpc_alignment], [T1w:anat_ingress,desc-preproc_T1w:anatomical_init]],


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
~~Related to #1728 by #shnizzedy~~

Fixes bug in error handling in which error message was including the literal string `{resource_list}` instead of the contents of the variable `resource_list`

## Description
<!-- Concisely describe what the pull request does. -->
~~From a direct message thread on Slack with @gkiar, tweaks the RBCv0 config to work around #1728~~

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
~~Reverts motion correct tool to MCFLIRT.~~

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
~~Rerunning RBC exemplars with the updated config~~

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop-1.8.4` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
