### PR TITLE
Catch any urllib error

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -10,6 +10,7 @@ from CPAC.func_preproc.utils import add_afni_prefix, nullify, chunk_ts, \
                                     split_ts_chunks, oned_text_concat, \
                                     notch_filter_motion
 from CPAC.generate_motion_statistics import motion_power_statistics
+from CPAC.utils.docs import grab_docstring_dct
 from CPAC.utils.interfaces.ants import AI  # niworkflows
 from CPAC.utils.interfaces.ants import PrintHeader, SetDirectionByMatrix
 from CPAC.utils.interfaces.function import Function

--- a/CPAC/utils/docs.py
+++ b/CPAC/utils/docs.py
@@ -1,7 +1,7 @@
 """Utilties for documentation."""
 import ast
 from urllib import request
-from urllib.error import HTTPError
+from urllib.error import ContentTooShortError, HTTPError, URLError
 from CPAC import __version__
 
 
@@ -31,7 +31,7 @@ def _docs_url_prefix():
     try:
         request.urlopen(  # pylint: disable=consider-using-with
                         _url(url_version))
-    except HTTPError:
+    except (ContentTooShortError, HTTPError, URLError):
         if 'dev' in url_version:
             url_version = 'nightly'
         else:


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Running in Docker on a server with apparmor on and without the `--security-opt=apparmor:unconfined` Docker flag crashes with `URLError`.

## Description
<!-- Concisely describe what the pull request does. -->

Catches `ContentTooShortError` & `URLError` and handles them the same as handling `HTTPError`

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
de7666068615154399c15d7948ba141f18bc1bdc is just a fix for a merge error from #1733; I already cherry-picked it into `develop` @ 815779d53888227d688bd505e2bc94995671a6b3

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
