### PR TITLE
Calculate ReHo and ALFF in template space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the ability to downsample to 10K or 2K resolution for freesurfer runs
 - Difference method (``-``) for ``CPAC.utils.configuration.Configuration`` instances
+- Calculate reho and alff when timeseries in template space
 
 ### Changed
 - Added a level of depth to `working` directories to match `log` and `output` directory structure

--- a/CPAC/alff/alff.py
+++ b/CPAC/alff/alff.py
@@ -275,3 +275,40 @@ def alff_falff(wf, cfg, strat_pool, pipe_num, opt=None):
     }
 
     return (wf, outputs)
+
+def alff_falff_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
+    '''
+    {"name": "alff_falff",
+     "config": ["amplitude_low_frequency_fluctuation"],
+     "switch": ["run"],
+     "option_key": "None",
+     "option_val": "None",
+     "inputs": [["space-template_desc-cleaned_bold", "space-template_desc-brain_bold", "space-template_desc-preproc_bold",
+                 "space-template_bold"],
+                "space-bold_desc-brain_mask"],
+     "outputs": ["space-template_alff",
+                 "space-template_falff"]}
+    '''
+
+    alff = create_alff(f'alff_falff_{pipe_num}')
+
+    alff.inputs.hp_input.hp = \
+        cfg.amplitude_low_frequency_fluctuation['highpass_cutoff']
+    alff.inputs.lp_input.lp = \
+        cfg.amplitude_low_frequency_fluctuation['lowpass_cutoff']
+    alff.get_node('hp_input').iterables = ('hp', alff.inputs.hp_input.hp)
+    alff.get_node('lp_input').iterables = ('lp', alff.inputs.lp_input.lp)
+
+    node, out = strat_pool.get_data(["space-template_desc-cleaned_bold", "space-template_desc-brain_bold",
+                                     "space-template_desc-preproc_bold", "space-template_bold"])
+    wf.connect(node, out, alff, 'inputspec.rest_res')
+
+    node, out = strat_pool.get_data('space-bold_desc-brain_mask')
+    wf.connect(node, out, alff, 'inputspec.rest_mask')
+
+    outputs = {
+        'space-template_alff': (alff, 'outputspec.alff_img'),
+        'space-template_falff': (alff, 'outputspec.falff_img')
+    }
+
+    return (wf, outputs)

--- a/CPAC/alff/alff.py
+++ b/CPAC/alff/alff.py
@@ -278,14 +278,13 @@ def alff_falff(wf, cfg, strat_pool, pipe_num, opt=None):
 
 def alff_falff_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
-    {"name": "alff_falff",
+    {"name": "alff_falff_space_template",
      "config": ["amplitude_low_frequency_fluctuation"],
      "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
-     "inputs": [["space-template_desc-cleaned_bold", "space-template_desc-brain_bold", "space-template_desc-preproc_bold",
-                 "space-template_bold"],
-                "space-bold_desc-brain_mask"],
+     "inputs": [["space-template_desc-denoisedNofilt_bold"],
+                "space-template_desc-bold_mask"],
      "outputs": ["space-template_alff",
                  "space-template_falff"]}
     '''
@@ -299,11 +298,10 @@ def alff_falff_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
     alff.get_node('hp_input').iterables = ('hp', alff.inputs.hp_input.hp)
     alff.get_node('lp_input').iterables = ('lp', alff.inputs.lp_input.lp)
 
-    node, out = strat_pool.get_data(["space-template_desc-cleaned_bold", "space-template_desc-brain_bold",
-                                     "space-template_desc-preproc_bold", "space-template_bold"])
+    node, out = strat_pool.get_data(["space-template_desc-denoisedNofilt_bold"])
     wf.connect(node, out, alff, 'inputspec.rest_res')
 
-    node, out = strat_pool.get_data('space-bold_desc-brain_mask')
+    node, out = strat_pool.get_data("space-template_desc-bold_mask")
     wf.connect(node, out, alff, 'inputspec.rest_mask')
 
     outputs = {

--- a/CPAC/alff/alff.py
+++ b/CPAC/alff/alff.py
@@ -262,7 +262,7 @@ def alff_falff(wf, cfg, strat_pool, pipe_num, opt=None):
     alff.get_node('hp_input').iterables = ('hp', alff.inputs.hp_input.hp)
     alff.get_node('lp_input').iterables = ('lp', alff.inputs.lp_input.lp)
 
-    node, out = strat_pool.get_data(["desc-cleanedNofilt_bold", "desc-brain_bold",
+    node, out = strat_pool.get_data(["desc-denoisedNofilt_bold", "desc-brain_bold",
                                      "desc-preproc_bold", "bold"])
     wf.connect(node, out, alff, 'inputspec.rest_res')
 

--- a/CPAC/alff/alff.py
+++ b/CPAC/alff/alff.py
@@ -246,7 +246,7 @@ def alff_falff(wf, cfg, strat_pool, pipe_num, opt=None):
      "switch": ["run"],
      "option_key": "None",
      "option_val": "None",
-     "inputs": [["desc-cleanedNofilt_bold", "desc-brain_bold", 
+     "inputs": [["desc-denoisedNofilt_bold", "desc-brain_bold", 
                  "desc-preproc_bold", "bold"],
                 "space-bold_desc-brain_mask"],
      "outputs": ["alff",

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -2508,7 +2508,6 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space):
             outputs = {
                 desc_keys[0]: (filt, 'outputspec.residual_file_path'),
                 desc_keys[1]: (filt, 'outputspec.residual_file_path'),
-                desc_keys[2]: (nuis, 'outputspec.residual_file_path'),
                 'regressors': (filt, 'outputspec.residual_regressor')
             }
 
@@ -2533,7 +2532,6 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space):
         outputs = {
             desc_keys[0]: (nuis, 'outputspec.residual_file_path'),
             desc_keys[1]: (nuis, 'outputspec.residual_file_path'),
-            desc_keys[2]: (nuis, 'outputspec.residual_file_path')
         }
 
     return (wf, outputs)
@@ -2556,13 +2554,10 @@ def nuisance_regression_native(wf, cfg, strat_pool, pipe_num, opt=None):
                  "dvars"),
                 "TR"],
      "outputs": {"desc-preproc_bold": {
-        "Description": "Preprocessed BOLD image that was nuisance-"
+        "Description": "Preprocessed BOLD image that was nusiance-"
                        "regressed in native space"},
                  "desc-cleaned_bold": {
-        "Description": "Preprocessed BOLD image that was nuisance-"
-                       "regressed in native space"},
-                 "desc-denoisedNofilt_bold": {
-        "Description": "Preprocessed BOLD image that was nuisance-"
+        "Description": "Preprocessed BOLD image that was nusiance-"
                        "regressed in native space"},
                  "regressors": {
         "Description": "Regressors that were applied in native space"}}}
@@ -2588,13 +2583,10 @@ def nuisance_regression_template(wf, cfg, strat_pool, pipe_num, opt=None):
                  "dvars"),
                 "TR"],
      "outputs": {"space-template_desc-preproc_bold": {
-        "Description": "Preprocessed BOLD image that was nuisance-"
+        "Description": "Preprocessed BOLD image that was nusiance-"
                        "regressed in template space"},
                  "space-template_desc-cleaned_bold": {
-        "Description": "Preprocessed BOLD image that was nuisance-"
-                       "regressed in template space"},
-                 "space-template_desc-denoisedNofilt_bold": {
-        "Description": "Preprocessed BOLD image that was nuisance-"
+        "Description": "Preprocessed BOLD image that was nusiance-"
                        "regressed in template space"},
                  "regressors": {
         "Description": "Regressors that were applied in template space"}}}

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -2508,6 +2508,7 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space):
             outputs = {
                 desc_keys[0]: (filt, 'outputspec.residual_file_path'),
                 desc_keys[1]: (filt, 'outputspec.residual_file_path'),
+                desc_keys[2]: (nuis, 'outputspec.residual_file_path'),
                 'regressors': (filt, 'outputspec.residual_regressor')
             }
 
@@ -2554,10 +2555,13 @@ def nuisance_regression_native(wf, cfg, strat_pool, pipe_num, opt=None):
                  "dvars"),
                 "TR"],
      "outputs": {"desc-preproc_bold": {
-        "Description": "Preprocessed BOLD image that was nusiance-"
+        "Description": "Preprocessed BOLD image that was nuisance-"
                        "regressed in native space"},
                  "desc-cleaned_bold": {
-        "Description": "Preprocessed BOLD image that was nusiance-"
+        "Description": "Preprocessed BOLD image that was nuisance-"
+                       "regressed in native space"},
+                 "desc-denoisedNofilt_bold": {
+        "Description": "Preprocessed BOLD image that was nuisance-"
                        "regressed in native space"},
                  "regressors": {
         "Description": "Regressors that were applied in native space"}}}

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -183,7 +183,7 @@ from CPAC.sca.sca import (
     multiple_regression
 )
 
-from CPAC.alff.alff import alff_falff
+from CPAC.alff.alff import alff_falff, alff_falff_space_template
 from CPAC.reho.reho import reho, reho_space_template
 
 from CPAC.vmhc.vmhc import (
@@ -1297,12 +1297,6 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     else:
         apply_func_warp['EPI'] = (_r_w_f_r['func_registration_to_template']['run_EPI'])
     del _r_w_f_r
-    
-    #target_space = cfg.regional_homogeneity['target_space']
-
-    #if 'Template' in target_space:
-        #if not rpool.check_rpool('reho'):
-            #pipeline_blocks += [reho_space_template]
 
     template_funcs = [
         'space-EPItemplate_desc-cleaned_bold',
@@ -1337,7 +1331,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     tse_atlases, sca_atlases = gather_extraction_maps(cfg)
     cfg.timeseries_extraction['tse_atlases'] = tse_atlases
     cfg.seed_based_correlation_analysis['sca_atlases'] = sca_atlases
-    target_space = cfg.regional_homogeneity['target_space']
+    target_space_reho = cfg.regional_homogeneity['target_space']
+    target_space_alff = cfg.amplitude_low_frequency_fluctuation['target_space']
 
     if not rpool.check_rpool('desc-Mean_timeseries') and \
                     'Avg' in tse_atlases:
@@ -1363,14 +1358,19 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                     'MultReg' in sca_atlases:
         pipeline_blocks += [multiple_regression]
 
-    if not rpool.check_rpool('alff'):
-        pipeline_blocks += [alff_falff]
+    if 'Native' in target_space_alff:
+        if not rpool.check_rpool('alff'):
+            pipeline_blocks += [alff_falff]
 
-    if 'Native' in target_space:
+    if 'Template' in target_space_alff:
+        if not rpool.check_rpool('space-template_alff'):
+            pipeline_blocks += [alff_falff_space_template]
+
+    if 'Native' in target_space_reho:
         if not rpool.check_rpool('reho'):
             pipeline_blocks += [reho]
             
-    if 'Template' in target_space:
+    if 'Template' in target_space_reho:
         if not rpool.check_rpool('space-template_reho'):
             pipeline_blocks += [reho_space_template]
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1292,7 +1292,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                             warp_deriv_mask_to_T1template]
         
     target_space_alff = cfg.amplitude_low_frequency_fluctuation['target_space']
-    if 'Template' in target_space_alff:
+    if 'Template' in target_space_alff and not rpool.check_rpool('space-template_desc-denoisedNofilt_bold'):
         pipeline_blocks += [warp_denoiseNofilt_to_T1template]
 
     template = cfg.registration_workflows['functional_registration']['func_registration_to_template']['target_template']['using']

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -184,7 +184,7 @@ from CPAC.sca.sca import (
 )
 
 from CPAC.alff.alff import alff_falff
-from CPAC.reho.reho import reho
+from CPAC.reho.reho import reho, reho_space_template
 
 from CPAC.vmhc.vmhc import (
     smooth_func_vmhc,
@@ -1297,6 +1297,12 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     else:
         apply_func_warp['EPI'] = (_r_w_f_r['func_registration_to_template']['run_EPI'])
     del _r_w_f_r
+    
+    #target_space = cfg.regional_homogeneity['target_space']
+
+    #if 'Template' in target_space:
+        #if not rpool.check_rpool('reho'):
+            #pipeline_blocks += [reho_space_template]
 
     template_funcs = [
         'space-EPItemplate_desc-cleaned_bold',
@@ -1331,6 +1337,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     tse_atlases, sca_atlases = gather_extraction_maps(cfg)
     cfg.timeseries_extraction['tse_atlases'] = tse_atlases
     cfg.seed_based_correlation_analysis['sca_atlases'] = sca_atlases
+    target_space = cfg.regional_homogeneity['target_space']
 
     if not rpool.check_rpool('desc-Mean_timeseries') and \
                     'Avg' in tse_atlases:
@@ -1359,8 +1366,13 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     if not rpool.check_rpool('alff'):
         pipeline_blocks += [alff_falff]
 
-    if not rpool.check_rpool('reho'):
-        pipeline_blocks += [reho]
+    if 'Native' in target_space:
+        if not rpool.check_rpool('reho'):
+            pipeline_blocks += [reho]
+            
+    if 'Template' in target_space:
+        if not rpool.check_rpool('space-template_reho'):
+            pipeline_blocks += [reho_space_template]
 
     if not rpool.check_rpool('vmhc'):
         pipeline_blocks += [smooth_func_vmhc,

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -102,6 +102,7 @@ from CPAC.registration.registration import (
     warp_bold_mean_to_T1template,
     warp_bold_mask_to_T1template,
     warp_deriv_mask_to_T1template,
+    warp_denoiseNofilt_to_T1template,
     warp_timeseries_to_EPItemplate,
     warp_bold_mean_to_EPItemplate,
     warp_bold_mask_to_EPItemplate,
@@ -1289,6 +1290,10 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     if not rpool.check_rpool('space-template_desc-bold_mask'):
         pipeline_blocks += [warp_bold_mask_to_T1template,
                             warp_deriv_mask_to_T1template]
+        
+    target_space_alff = cfg.amplitude_low_frequency_fluctuation['target_space']
+    if 'Template' in target_space_alff:
+        pipeline_blocks += [warp_denoiseNofilt_to_T1template]
 
     template = cfg.registration_workflows['functional_registration']['func_registration_to_template']['target_template']['using']
 
@@ -1332,7 +1337,6 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     cfg.timeseries_extraction['tse_atlases'] = tse_atlases
     cfg.seed_based_correlation_analysis['sca_atlases'] = sca_atlases
     target_space_reho = cfg.regional_homogeneity['target_space']
-    target_space_alff = cfg.amplitude_low_frequency_fluctuation['target_space']
 
     if not rpool.check_rpool('desc-Mean_timeseries') and \
                     'Avg' in tse_atlases:

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -738,7 +738,7 @@ class ResourcePool:
                                   pipe_idx, f'spatial_smoothing_{smooth_opt}',
                                   fork=True)
 
-        if self.run_zscoring:            
+        if self.zscoring_bool:            
             for label_con_tpl in post_labels:
                 label = label_con_tpl[0]
                 connection = (label_con_tpl[1], label_con_tpl[2])

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -101,7 +101,7 @@ class ResourcePool:
                     'falff', 'desc-sm_falff', 'desc-zstd_falff',
                     'desc-sm-zstd_falff',
                     'reho', 'desc-sm_reho', 'desc-zstd_reho',
-                    'desc-sm-zstd_reho']
+                    'desc-sm-zstd_reho', 'space-template_reho']
 
     def append_name(self, name):
         self.name.append(name)

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -101,7 +101,7 @@ class ResourcePool:
                     'falff', 'desc-sm_falff', 'desc-zstd_falff',
                     'desc-sm-zstd_falff',
                     'reho', 'desc-sm_reho', 'desc-zstd_reho',
-                    'desc-sm-zstd_reho', 'space-template_reho']
+                    'desc-sm-zstd_reho']
 
     def append_name(self, name):
         self.name.append(name)

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -88,8 +88,10 @@ class ResourcePool:
 
             self.run_smoothing = 'smoothed' in cfg.post_processing[
                 'spatial_smoothing']['output']
+            self.smoothing_bool = cfg.post_processing['spatial_smoothing']['run']
             self.run_zscoring = 'z-scored' in cfg.post_processing[
                 'z-scoring']['output']
+            self.zscoring_bool = cfg.post_processing['z-scoring']['run']
             self.fwhm = cfg.post_processing['spatial_smoothing']['fwhm']
             self.smooth_opts = cfg.post_processing['spatial_smoothing'][
                 'smoothing_method']
@@ -697,7 +699,7 @@ class ResourcePool:
                     mask_idx = self.generate_prov_string(mask_prov)[1]
                     break
 
-        if self.run_smoothing:
+        if self.smoothing_bool:
             if label in Outputs.to_smooth:
                 for smooth_opt in self.smooth_opts:
 

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1002,6 +1002,7 @@ latest_schema = Schema({
     'regional_homogeneity': {
         'run': bool,
         'cluster_size': In({7, 19, 27}),
+        'target_space': In({'Template', 'Native'}),
     },
     'post_processing': {
         'spatial_smoothing': {

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -99,12 +99,7 @@ valid_options = {
             ),
         },
     },
-    'amplitude_low_frequency_fluctuation': {
-        'target_space': ['Native', 'Template']
-    },
-    'regional_homogeneity': {
-        'target_space': ['Native', 'Template']
-    }
+    'target_space': ['Native', 'Template']
 }
 mutex = {  # mutually exclusive booleans
     'FSL-BET': {
@@ -991,8 +986,7 @@ latest_schema = Schema({
     },
     'amplitude_low_frequency_fluctuation': {
         'run': bool,
-        #'target_space': In({'Template', 'Native'}),
-        'target_space': [In(valid_options['amplitude_low_frequency_fluctuation']['target_space'])],
+        'target_space': [In(valid_options['target_space'])],
         'highpass_cutoff': [float],
         'lowpass_cutoff': [float],
     },
@@ -1009,8 +1003,7 @@ latest_schema = Schema({
     },
     'regional_homogeneity': {
         'run': bool,
-        #'target_space': In({'Template', 'Native'}),
-        'target_space': [In(valid_options['regional_homogeneity']['target_space'])],
+        'target_space': [In(valid_options['target_space'])],
         'cluster_size': In({7, 19, 27}),
     },
     'post_processing': {

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -985,6 +985,7 @@ latest_schema = Schema({
     },
     'amplitude_low_frequency_fluctuation': {
         'run': bool,
+        'target_space': In({'Template', 'Native'}),
         'highpass_cutoff': [float],
         'lowpass_cutoff': [float],
     },

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1007,11 +1007,13 @@ latest_schema = Schema({
     },
     'post_processing': {
         'spatial_smoothing': {
+            'run': bool,
             'output': [In({'smoothed', 'nonsmoothed'})],
             'smoothing_method': [In({'FSL', 'AFNI'})],
             'fwhm': [int]
         },
         'z-scoring': {
+            'run': bool,
             'output': [In({'z-scored', 'raw'})],
         },
     },

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1002,8 +1002,8 @@ latest_schema = Schema({
     },
     'regional_homogeneity': {
         'run': bool,
-        'cluster_size': In({7, 19, 27}),
         'target_space': In({'Template', 'Native'}),
+        'cluster_size': In({7, 19, 27}),
     },
     'post_processing': {
         'spatial_smoothing': {

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -98,6 +98,12 @@ valid_options = {
                 str, {'components': int, 'method': str}
             ),
         },
+    },
+    'amplitude_low_frequency_fluctuation': {
+        'target_space': ['Native', 'Template']
+    },
+    'regional_homogeneity': {
+        'target_space': ['Native', 'Template']
     }
 }
 mutex = {  # mutually exclusive booleans
@@ -985,7 +991,8 @@ latest_schema = Schema({
     },
     'amplitude_low_frequency_fluctuation': {
         'run': bool,
-        'target_space': In({'Template', 'Native'}),
+        #'target_space': In({'Template', 'Native'}),
+        'target_space': [In(valid_options['amplitude_low_frequency_fluctuation']['target_space'])],
         'highpass_cutoff': [float],
         'lowpass_cutoff': [float],
     },
@@ -1002,7 +1009,8 @@ latest_schema = Schema({
     },
     'regional_homogeneity': {
         'run': bool,
-        'target_space': In({'Template', 'Native'}),
+        #'target_space': In({'Template', 'Native'}),
+        'target_space': [In(valid_options['regional_homogeneity']['target_space'])],
         'cluster_size': In({7, 19, 27}),
     },
     'post_processing': {

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -3719,7 +3719,7 @@ def warp_denoiseNofilt_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
 
 def single_step_resample_timeseries_to_T1template(wf, cfg, strat_pool,
                                                   pipe_num, opt=None):
-    """
+    '''
     Apply motion correction, coreg, anat-to-template transforms on
     slice-time corrected functional timeseries based on fMRIPrep
     pipeline
@@ -3778,7 +3778,7 @@ def single_step_resample_timeseries_to_T1template(wf, cfg, strat_pool,
      "outputs": ["space-template_desc-preproc_bold",
                  "space-template_desc-brain_bold",
                  "space-template_desc-bold_mask"]}
-    """  # noqa: 501
+    '''  # noqa: 501
     bbr2itk = pe.Node(util.Function(input_names=['reference_file',
                                                  'source_file',
                                                  'transform_file'],

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -3663,6 +3663,59 @@ def warp_timeseries_to_T1template_dcan_nhp(wf, cfg, strat_pool, pipe_num, opt=No
 
     return (wf, outputs)
 
+def warp_denoiseNofilt_to_T1template(wf, cfg, strat_pool, pipe_num, opt=None):
+    '''
+    Node Block:
+    {"name": "transform_denoisedNofilt_to_T1template",
+     "config": ["amplitude_low_frequency_fluctuation"],
+     "switch": ["run"],
+     "option_key": ["target_space"],
+     "option_val": "Template",
+     "inputs": [(["desc-denoisedNofilt_bold"],
+                 "from-bold_to-template_mode-image_xfm"),
+                "T1w-brain-template-funcreg"],
+     "outputs": ["space-template_desc-denoisedNofilt_bold"]}
+    '''
+
+    xfm_prov = strat_pool.get_cpac_provenance(
+        'from-bold_to-template_mode-image_xfm')
+    reg_tool = check_prov_for_regtool(xfm_prov)
+
+    num_cpus = cfg.pipeline_setup['system_config'][
+        'max_cores_per_participant']
+
+    num_ants_cores = cfg.pipeline_setup['system_config']['num_ants_threads']
+
+    apply_xfm = apply_transform(f'warp_denoisedNofilt_to_T1template_{pipe_num}', reg_tool,
+                                time_series=True, num_cpus=num_cpus,
+                                num_ants_cores=num_ants_cores)
+
+    if reg_tool == 'ants':
+        apply_xfm.inputs.inputspec.interpolation = cfg.registration_workflows[
+            'functional_registration']['func_registration_to_template'][
+            'ANTs_pipelines']['interpolation']
+    elif reg_tool == 'fsl':
+        apply_xfm.inputs.inputspec.interpolation = cfg.registration_workflows[
+            'functional_registration']['func_registration_to_template'][
+            'FNIRT_pipelines']['interpolation']
+
+    connect, resource = strat_pool.get_data(["desc-denoisedNofilt_bold"],
+                                            report_fetched=True)
+    node, out = connect
+    wf.connect(node, out, apply_xfm, 'inputspec.input_image')
+
+    node, out = strat_pool.get_data("T1w-brain-template-funcreg")
+    wf.connect(node, out, apply_xfm, 'inputspec.reference')
+
+    node, out = strat_pool.get_data("from-bold_to-template_mode-image_xfm")
+    wf.connect(node, out, apply_xfm, 'inputspec.transform')
+
+    outputs = {
+        f'space-template_{resource}': (apply_xfm, 'outputspec.output_image')
+    }
+
+    return (wf, outputs)
+
 
 def single_step_resample_timeseries_to_T1template(wf, cfg, strat_pool,
                                                   pipe_num, opt=None):

--- a/CPAC/reho/reho.py
+++ b/CPAC/reho/reho.py
@@ -153,7 +153,7 @@ def reho(wf, cfg, strat_pool, pipe_num, opt=None):
 
 def reho_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
-    {"name": "ReHo",
+    {"name": "ReHo_space_template",
      "config": ["regional_homogeneity"],
      "switch": ["run"],
      "option_key": "None",

--- a/CPAC/reho/reho.py
+++ b/CPAC/reho/reho.py
@@ -149,3 +149,43 @@ def reho(wf, cfg, strat_pool, pipe_num, opt=None):
     }
 
     return (wf, outputs)
+
+
+def reho_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
+    '''
+    {"name": "ReHo",
+     "config": ["regional_homogeneity"],
+     "switch": ["run"],
+     "option_key": "None",
+     "option_val": "None",
+     "inputs": [["space-template_desc-cleaned_bold", "space-template_desc-brain_bold",
+                 "space-template_desc-preproc_bold", "space-template_bold"],
+                "space-bold_desc-brain_mask"],
+     "outputs": ["space-template_reho"]}
+    '''
+
+    cluster_size = cfg.regional_homogeneity['cluster_size']
+
+    # Check the cluster size is supported
+    if cluster_size not in [7, 19, 27]:
+        err_msg = 'Cluster size specified: %d, is not ' \
+                  'supported. Change to 7, 19, or 27 and try ' \
+                  'again' % cluster_size
+        raise Exception(err_msg)
+
+    reho = create_reho(f'reho_{pipe_num}')
+    reho.inputs.inputspec.cluster_size = cluster_size
+
+
+    node, out = strat_pool.get_data(["space-template_desc-cleaned_bold", "space-template_desc-brain_bold",
+                                     "space-template_desc-preproc_bold", "space-template_bold"])
+    wf.connect(node, out, reho, 'inputspec.rest_res_filt')
+
+    node, out_file = strat_pool.get_data('space-bold_desc-brain_mask')
+    wf.connect(node, out_file, reho, 'inputspec.rest_mask')
+
+    outputs = {
+        'space-template_reho': (reho, 'outputspec.raw_reho_map')
+    }
+
+    return (wf, outputs)

--- a/CPAC/reho/reho.py
+++ b/CPAC/reho/reho.py
@@ -160,7 +160,7 @@ def reho_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": [["space-template_desc-cleaned_bold", "space-template_desc-brain_bold",
                  "space-template_desc-preproc_bold", "space-template_bold"],
-                "space-bold_desc-brain_mask"],
+                "space-template_desc-bold_mask"],
      "outputs": ["space-template_reho"]}
     '''
 
@@ -181,7 +181,7 @@ def reho_space_template(wf, cfg, strat_pool, pipe_num, opt=None):
                                      "space-template_desc-preproc_bold", "space-template_bold"])
     wf.connect(node, out, reho, 'inputspec.rest_res_filt')
 
-    node, out_file = strat_pool.get_data('space-bold_desc-brain_mask')
+    node, out_file = strat_pool.get_data('space-template_desc-bold_mask')
     wf.connect(node, out_file, reho, 'inputspec.rest_mask')
 
     outputs = {

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1611,6 +1611,8 @@ regional_homogeneity:
   # 19 (Faces + Edges)
   # 27 (Faces + Edges + Corners)
   cluster_size: 27
+  # space: Template or Native
+  target_space: Native
 
 
 voxel_mirrored_homotopic_connectivity:

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1598,7 +1598,7 @@ amplitude_low_frequency_fluctuation:
   run: On
 
   # space: Template or Native
-  target_space: Native
+  target_space: ['Native']
 
   # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
   highpass_cutoff: [0.01]
@@ -1614,7 +1614,7 @@ regional_homogeneity:
   run: On
 
   # space: Template or Native
-  target_space: Native
+  target_space: ['Native']
 
   # Number of neighboring voxels used when calculating ReHo
   # 7 (Faces)

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1593,6 +1593,9 @@ amplitude_low_frequency_fluctuation:
   # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF (f/ALFF) for all voxels.
   run: On
 
+  # space: Template or Native
+  target_space: Native
+
   # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
   highpass_cutoff: [0.01]
 
@@ -1606,13 +1609,14 @@ regional_homogeneity:
   # Calculate Regional Homogeneity (ReHo) for all voxels.
   run: On
 
+  # space: Template or Native
+  target_space: Native
+
   # Number of neighboring voxels used when calculating ReHo
   # 7 (Faces)
   # 19 (Faces + Edges)
   # 27 (Faces + Edges + Corners)
   cluster_size: 27
-  # space: Template or Native
-  target_space: Native
 
 
 voxel_mirrored_homotopic_connectivity:

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1472,6 +1472,8 @@ post_processing:
 
   spatial_smoothing:
 
+    run: On
+
     # Smooth the derivative outputs.
     # Set as ['nonsmoothed'] to disable smoothing. Set as ['smoothed', 'nonsmoothed'] to get both.
     #
@@ -1490,6 +1492,8 @@ post_processing:
     fwhm: [4]
 
   z-scoring:
+
+    run: On
 
     # z-score standardize the derivatives. This may be needed for group-level analysis.
     # Set as ['raw'] to disable z-scoring. Set as ['z-scored', 'raw'] to get both.


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
Allow ReHo and ALFF to be calculated after timeseries warps to template space.

## Description
Adding node blocks to `reho.py` and `alff.py` that allows `space-template_*` inputs so that these derivatives can be calculated in template space. 

## Technical details
Default pipeline was changed to choose whether to run these derivatives in `Template` or `Native` space. The default is in 'Native` space.
```
amplitude_low_frequency_fluctuation:

  # ALFF & f/ALFF
  # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF (f/ALFF) for all voxels.
  run: On

  # space: Template or Native
  target_space: Native

  # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
  highpass_cutoff: [0.01]

  # Frequency cutoff (in Hz) for the low-pass filter used when calculating f/ALFF
  lowpass_cutoff: [0.1]


regional_homogeneity:

  # ReHo
  # Calculate Regional Homogeneity (ReHo) for all voxels.
  run: On

  # space: Template or Native
  target_space: Native

  # Number of neighboring voxels used when calculating ReHo
  # 7 (Faces)
  # 19 (Faces + Edges)
  # 27 (Faces + Edges + Corners)
  cluster_size: 27
```
`cpac_pipeline.py` will check whether the input for these derivatives is `Template` or `Native` and then will run the respective node block. 
```
    if 'Native' in target_space_alff:
        if not rpool.check_rpool('alff'):
            pipeline_blocks += [alff_falff]

    if 'Template' in target_space_alff:
        if not rpool.check_rpool('space-template_alff'):
            pipeline_blocks += [alff_falff_space_template]

    if 'Native' in target_space_reho:
        if not rpool.check_rpool('reho'):
            pipeline_blocks += [reho]
            
    if 'Template' in target_space_reho:
        if not rpool.check_rpool('space-template_reho'):
            pipeline_blocks += [reho_space_template]
```
**ALFF & FALFF**
For ALFF/FALFF, a denoised output from nuisance regression was created and warped, so that it could be the input for `wf.connect(node, out, alff, 'inputspec.rest_res')`. 
 
[nuisance.py](https://github.com/FCP-INDI/C-PAC/blob/6df85e47298a8cb712edc285f50203e0bcb902a6/CPAC/nuisance/nuisance.py#L2375)
<img width="577" alt="image" src="https://user-images.githubusercontent.com/58920810/190438218-17827fe3-fdbe-428c-bd4a-c8e45c99dc09.png">

[registration.py](https://github.com/FCP-INDI/C-PAC/blob/6df85e47298a8cb712edc285f50203e0bcb902a6/CPAC/registration/registration.py#L3659-L3710) 
<img width="573" alt="image" src="https://user-images.githubusercontent.com/58920810/190436217-34a8a669-d110-4d49-85a5-247b064fc602.png">

Node block was created in `alff.py` for when alff/falff are calculated in template space.
[alff.py](https://github.com/FCP-INDI/C-PAC/blob/6df85e47298a8cb712edc285f50203e0bcb902a6/CPAC/alff/alff.py#L279-L312) 
<img width="529" alt="image" src="https://user-images.githubusercontent.com/58920810/190438621-e04a05d7-0605-43ed-b961-df3493ef3af8.png">

**ReHo**
Node block was created in `reho.py` for when reho is calculated in template space.
[reho.py](https://github.com/FCP-INDI/C-PAC/blob/6df85e47298a8cb712edc285f50203e0bcb902a6/CPAC/reho/reho.py#L154-L191)
<img width="637" alt="image" src="https://user-images.githubusercontent.com/58920810/190439211-3c79a77b-2915-475f-810e-0a9dc9a5e8f6.png">

## Tests
To test the derivatives, you can create a pipeline config, calling any preconfig. In this case, preproc preconfig was used.
```
# CPAC Pipeline Configuration YAML file
# Version 1.8.1
#
# http://fcp-indi.github.io for more info.
#
# Tip: This file can be edited manually with a text editor for quick modifications.
FROM: preproc
pipeline_setup: 
  pipeline_name: reho_alff_template
  output_directory: 
    path: /output/output
  working_directory: 
    path: /output/working
    remove_working_dir: Off
  log_directory: 
    path: /output/log

post_processing:

  spatial_smoothing:
    run: On
    output: ['smoothed']
    smoothing_method: ['FSL']
    fwhm: [4]

  z-scoring:
    run: On
    output: ['z-scored']

amplitude_low_frequency_fluctuation:
  run: On
  target_space: Template
  highpass_cutoff: [0.01]
  lowpass_cutoff: [0.1]

regional_homogeneity:
  run: On
  target_space: Template
  cluster_size: 27
```
The expected outputs in regards to these changes should be: 

ReHo and ALFF/FALFF calculated in template space was correlated to ReHo and ALFF/FALFF calculated in native space.

Correlations:
| File | File name | Correlation |
| ------------- | ------------- | ------------- |
| ReHo smoothed and z-scored 1 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-sm-zstd-1_reho.nii.gz | 0.931585 |
| ReHo smoothed and z-scored 2 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-sm-zstd-2_reho.nii.gz | 0.936066 |
| ReHo z-scored 1 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-zstd-1_reho.nii.gz | 0.886784 |
| ReHo z-scored 2 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-zstd-2_reho.nii.gz | 0.893396 |
| ALFF smooth and z-scored 1 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-sm-zstd-1_alff.nii.gz  | 0.95074 |
| ALFF smooth and z-scored 2 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-sm-zstd-2_alff.nii.gz | 0.952036 |
| ALFF z-scored 1 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-zstd-1_alff.nii.gz | 0.922602 |
| ALFF z-scored 2 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-zstd-2_alff.nii.gz | 0.925847 |
| FALFF smooth and z-scored 1 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-sm-zstd-1_falff.nii.gz | 0.72528 |
| FALFF smooth and z-scored 2 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-sm-zstd-2_falff.nii.gz | 0.7328 |
| FALFF z-scored 1 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-zstd-1_falff.nii.gz | 0.591724 |
| FALFF z-scored 2 | sub-NDARAE270LEZ_ses-1_task-rest_run-1_space-template_desc-zstd-2_falff.nii.gz | 0.603659 |

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
