### PR TITLE
/Fix/assign_stopidx_asend

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -574,7 +574,7 @@ def get_idx(in_files, stop_idx=None, start_idx=None):
     else:
         startidx = int(start_idx)
 
-    if (stop_idx == None) or (int(stop_idx) > (nvols - 1)):
+    if (stop_idx in [None, "End"]) or (int(stop_idx) > (nvols - 1)):
         stopidx = nvols - 1
     else:
         stopidx = int(stop_idx)

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -20,7 +20,7 @@ License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.'''
 from itertools import chain, permutations
 
 import numpy as np
-from voluptuous import All, ALLOW_EXTRA, Any, In, Length, Match, Optional, \
+from voluptuous import All, Capitalize, ALLOW_EXTRA, Any, In, Length, Match, Optional, \
                        Range, Required, Schema
 from voluptuous.validators import ExactSequence, Maybe
 
@@ -749,7 +749,7 @@ latest_schema = Schema({
         'run': bool,
         'truncation': {
             'start_tr': int,
-            'stop_tr': Maybe(Any(int, 'End'))
+            'stop_tr': Maybe(Any(int, All(Capitalize, 'End')))
         },
         'scaling': {
             'run': bool,


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1766  by @tergeorge 

## Description
This PR would make it possible for the user to assign "End" or "None" as the stop_idx value for time series extraction. 

## Technical details
Added the following test condition to func_preproc.py
```
   
 if (stop_idx in [None, "End"]) or (int(stop_idx) > (nvols - 1)):
        stopidx = nvols - 1
    else:
        stopidx = int(stop_idx)

    return stopidx, startidx

```
## Tests
To test this PR, do the following:
1. Create a pipeline config file with functional_preproc -> truncation -> stop_tr as End
2. Run CPAC with the pipeline config file updated as instructed in step 1.

The pipeline should run to completion without any errors.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
