### PR TITLE
🚚 Use `f'pipeline_{pipeline_name}'` subdirectories for `log`, `working`, and `output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Added a level of depth to working directories to match log and output directory structure
+- Added a level of depth to `working` directories to match `log` and `output` directory structure
+- Renamed participant-pipeline-level `output` directory prefix to `pipeline_` to match `log` and `working` paths
 
 ## [v1.8.4] - 2022-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Added a level of depth to working directories to match log and output directory structure
+
 ## [v1.8.4] - 2022-06-27
 
 ### Added

--- a/CPAC/info.py
+++ b/CPAC/info.py
@@ -185,6 +185,7 @@ REQUIREMENTS = [
     "nose==1.3.7",
     "numpy==1.16.4",
     "pandas==0.23.4",
+    "pathvalidate==2.5.2",
     "patsy==0.5.0",
     "prov==1.5.2",
     "psutil==5.4.6",

--- a/CPAC/longitudinal_pipeline/longitudinal_workflow.py
+++ b/CPAC/longitudinal_pipeline/longitudinal_workflow.py
@@ -446,7 +446,7 @@ def anat_longitudinal_wf(subject_id, sub_list, config):
 
         workflow.run()
 
-        cpac_dir = os.path.join(out_dir, f'cpac_{orig_pipe_name}',
+        cpac_dir = os.path.join(out_dir, f'pipeline_{orig_pipe_name}',
                                 f'{subject_id}_{unique_id}')
         cpac_dirs.append(os.path.join(cpac_dir, 'anat'))
 

--- a/CPAC/pipeline/check_outputs.py
+++ b/CPAC/pipeline/check_outputs.py
@@ -48,7 +48,7 @@ def check_outputs(output_dir, log_dir, pipe_name, unique_id):
     """
     outputs_logger = getLogger(f'{unique_id}_expectedOutputs')
     missing_outputs = ExpectedOutputs()
-    container = os.path.join(f'cpac_{pipe_name}', unique_id)
+    container = os.path.join(f'pipeline_{pipe_name}', unique_id)
     if (
         isinstance(outputs_logger, (Logger, MockLogger)) and
         len(outputs_logger.handlers)

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -430,8 +430,9 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
                       check_centrality_lfcd=check_centrality_lfcd)
 
     # absolute paths of the dirs
-    c.pipeline_setup['working_directory']['path'] = os.path.abspath(
-        c.pipeline_setup['working_directory']['path'])
+    c.pipeline_setup['working_directory']['path'] = os.path.join(
+        os.path.abspath(c.pipeline_setup['working_directory']['path']),
+        p_name)
     if 's3://' not in c.pipeline_setup['output_directory']['path']:
         c.pipeline_setup['output_directory']['path'] = os.path.abspath(
             c.pipeline_setup['output_directory']['path'])
@@ -449,8 +450,7 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
                     'not run')
     else:
         working_dir = os.path.join(
-            c.pipeline_setup['working_directory']['path'], p_name,
-            workflow.name)
+            c.pipeline_setup['working_directory']['path'], workflow.name)
 
         # if c.write_debugging_outputs:
         #    with open(os.path.join(working_dir, 'resource_pool.pkl'), 'wb') as f:

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -263,10 +263,10 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
         subject_id += "_" + sub_dict['unique_id']
 
     c['subject_id'] = subject_id
-
+    if p_name is None:
+        p_name = f'pipeline_{c.pipeline_setup["pipeline_name"]}'
     log_dir = os.path.join(c.pipeline_setup['log_directory']['path'],
-                           f'pipeline_{c.pipeline_setup["pipeline_name"]}',
-                           subject_id)
+                           p_name, subject_id)
     if not os.path.exists(log_dir):
         os.makedirs(os.path.join(log_dir))
 
@@ -449,7 +449,8 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
                     'not run')
     else:
         working_dir = os.path.join(
-            c.pipeline_setup['working_directory']['path'], workflow.name)
+            c.pipeline_setup['working_directory']['path'], p_name,
+            workflow.name)
 
         # if c.write_debugging_outputs:
         #    with open(os.path.join(working_dir, 'resource_pool.pkl'), 'wb') as f:

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -853,7 +853,7 @@ class ResourcePool:
 
                 out_dir = cfg.pipeline_setup['output_directory']['path']
                 pipe_name = cfg.pipeline_setup['pipeline_name']
-                container = os.path.join(f'cpac_{pipe_name}', unique_id)
+                container = os.path.join(f'pipeline_{pipe_name}', unique_id)
                 filename = f'{unique_id}_{resource}'
 
                 out_path = os.path.join(out_dir, container, subdir, filename)
@@ -1582,9 +1582,9 @@ def ingress_output_dir(cfg, rpool, unique_id, creds_path=None):
             print(f"\nOutput directory {out_dir} does not exist yet, "
                   f"initializing.")
             return rpool
-            
-        cpac_dir = os.path.join(out_dir,
-                                f'cpac_{cfg.pipeline_setup["pipeline_name"]}',
+
+        cpac_dir = os.path.join(out_dir, 'pipeline_'
+                                f'{cfg.pipeline_setup["pipeline_name"]}',
                                 unique_id)
     else:
         if os.path.isdir(out_dir):

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -17,11 +17,12 @@ License for more details.
 You should have received a copy of the GNU Lesser General Public
 License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.'''
 # pylint: disable=too-many-lines
+import re
 from itertools import chain, permutations
-
 import numpy as np
-from voluptuous import All, Capitalize, ALLOW_EXTRA, Any, In, Length, Match, Optional, \
-                       Range, Required, Schema
+from pathvalidate import sanitize_filename
+from voluptuous import All, ALLOW_EXTRA, Any, Capitalize, In, Length, Match, \
+                       Optional, Range, Required, Schema
 from voluptuous.validators import ExactSequence, Maybe
 
 from CPAC import docs_prefix
@@ -363,10 +364,15 @@ def _changes_1_8_0_to_1_8_1(config_dict):
     return config_dict
 
 
+def sanitize(filename):
+    '''Sanitize a filename and replace whitespaces with underscores'''
+    return re.sub(r'\s+', '_', sanitize_filename(filename))
+
+
 latest_schema = Schema({
     'FROM': Maybe(str),
     'pipeline_setup': {
-        'pipeline_name': All(str, Length(min=1)),
+        'pipeline_name': All(str, Length(min=1), sanitize),
         'output_directory': {
             'path': str,
             'source_outputs_dir': Maybe(str),

--- a/CPAC/pipeline/test/test_schema_validation.py
+++ b/CPAC/pipeline/test/test_schema_validation.py
@@ -1,8 +1,7 @@
 '''Tests for schema.py'''
 import pytest
-
-from CPAC.utils.configuration import Configuration
 from voluptuous.error import Invalid
+from CPAC.utils.configuration import Configuration
 
 
 @pytest.mark.parametrize('run_value', [
@@ -26,3 +25,9 @@ def test_motion_estimates_and_correction(run_value):
         assert "func#motion_estimate_filter_valid_options" in str(e.value)
     else:
         Configuration(d)
+
+
+def test_pipeline_name():
+    '''Test that pipeline_name sucessfully sanitizes'''
+    c = Configuration({'pipeline_setup': {'pipeline_name': ':va:lid    name'}})
+    assert c['pipeline_setup', 'pipeline_name'] == 'valid_name'

--- a/dev/docker_data/default_pipeline.yml
+++ b/dev/docker_data/default_pipeline.yml
@@ -10,6 +10,7 @@
 pipeline_setup:
 
   # Name for this pipeline configuration - useful for identification.
+  # This string will be sanitized and used in filepaths
   pipeline_name: cpac-default-pipeline
 
   output_directory:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ nipype==1.5.1
 nose==1.3.7
 numpy==1.21.0
 pandas==0.23.4
+pathvalidate==2.5.2
 patsy==0.5.0
 prov==1.5.2
 psutil==5.6.6


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1774 by @shnizzedy 
Maybe fixes #1308 by @cbin-cnl
Related to #1777 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
When the same subject is run through multiple pipelines with the same top-level output directory, not saving the working directory, the top of the tree looks something like
```tree
.
├── log
│   ├── pipeline_fmriprep-options±topup
│   ├── pipeline_RBCv0
│   └── pipeline_RBCv0-noNuisanceRegression
├── output
│   ├── cpac_fmriprep-options±topup
│   ├── cpac_RBCv0
│   └── cpac_RBCv0-noNuisanceRegression
└── working
    ├── cpac_sub-1_ses-1
    …
```
so for any given subject-session, a race condition exists where whichever finishes first will clean up and erase the working directory that the other pipeline(s) are still using, leading to various missing file errors and ultimately crashes.

I'm also not sure what kind of havoc is possible if there are name collisions within the working directory.

This PR updates that tree to be like
```tree
.
├── log
│   ├── pipeline_fmriprep-options±topup
│   ├── pipeline_RBCv0
│   └── pipeline_RBCv0-noNuisanceRegression
├── output
│   ├── pipeline_fmriprep-options±topup
│   ├── pipeline_RBCv0
│   └── pipeline_RBCv0-noNuisanceRegression
└── working
    ├── pipeline_fmriprep-options±topup
    │   ├── cpac_sub-1_ses-1
    │   …
    ├── pipeline_RBCv0
    │   ├── cpac_sub-1_ses-1
    │   …
    └── pipeline_RBCv0-noNuisanceRegression
        ├── cpac_sub-1_ses-1
        …
```
so there is a consistent structure across the `log`, `output`, and `working` directories and each subject-session+pipeline-config combination has its own non-conflicting working space.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The `pipeline_name` variable is populated from the pipeline config https://github.com/FCP-INDI/C-PAC/blob/9616606b3402292422b15e7f96c0adf90d9ae2f1/dev/docker_data/default_pipeline.yml#L12-L13

This PR also adds a sanitizing step https://github.com/FCP-INDI/C-PAC/blob/8804f6180d5d5c6e69f3422691ab6c034348b23e/CPAC/pipeline/schema.py#L367-L369 to validating `pipeline_name`  https://github.com/FCP-INDI/C-PAC/blob/8804f6180d5d5c6e69f3422691ab6c034348b23e/CPAC/pipeline/schema.py#L375


## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/8804f6180d5d5c6e69f3422691ab6c034348b23e/CPAC/pipeline/test/test_schema_validation.py#L30-L33

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
