### PR TITLE
🐛 Differentiate sametime data and pipeline configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.8.5]
+## [unreleased]
 
 ### Added
 - Added the ability to downsample to 10K or 2K resolution for freesurfer runs
 
 ### Changed
 - Changed the 1mm atlases chosen in the rbc-options preconfig to the 2mm versions
+- Added data-config-specific hash string to C-PAC-generated config files
 
 ### Fixed
 

--- a/CPAC/utils/yaml_template.py
+++ b/CPAC/utils/yaml_template.py
@@ -328,6 +328,15 @@ def hash_data_config(sub_list):
     Returns
     -------
     data_config_hash : str, len(8)
+
+    Examples
+    --------
+    >>> sub_list = [{'site_id': f'site{i}', 'subject_id': f'sub{i}',
+    ...              'unique_id': f'uid{i}'} for i in range(1, 4)]
+    >>> sub_list[0]
+    {'site_id': 'site1', 'subject_id': 'sub1', 'unique_id': 'uid1'}
+    >>> hash_data_config(sub_list)
+    '6f49a278'
     '''
     return sha1('_'.join([','.join([run.get(key, '') for run in sub_list]) for
                 key in ['site_id', 'subject_id',


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1776 by @shnizzedy
Related to #1774 & #1775 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Before this PR, C-PAC would generate run-specific config files like
```BASH
cpac_data_config_{timestamp}.yml
cpac_pipeline_config_{timestamp}.yml
```

With this PR, those filenames include the first 8 characters of the hexadecimal digest of a hash of all `site_id`s, `subject_id`s, and `unique_id`s (like `site1,site2,site3_sub1,sub2,sub3_uid1,uid2,uid3`) in the given data config.

```BASH
cpac_data_config_{data_hash}_{timestamp}.yml
cpac_pipeline_config_{data_hash}_{timestamp}.yml
```

<a name="collision-note"></a>
**NOTE**: #1774 is still relevant if running multiple configs to the same top-level output directory (if the same data config launches multiple pipeline configs in the same second, this behavior will persist after this PR)

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
https://github.com/FCP-INDI/C-PAC/blob/68ac96ab2ccd9e509ad58ccabe5577b569b6b6bc/CPAC/utils/yaml_template.py#L320-L343 https://github.com/FCP-INDI/C-PAC/blob/68ac96ab2ccd9e509ad58ccabe5577b569b6b6bc/dev/docker_data/run.py#L710

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
### Unit test
https://github.com/FCP-INDI/C-PAC/blob/68ac96ab2ccd9e509ad58ccabe5577b569b6b6bc/CPAC/utils/yaml_template.py#L334-L339
### Manual test
Start several runs in parallel (e.g., with SLURM) and see you have the same number of data configs and pipeline configs and runs, and that the `data_hash` values appear once each in a data config filename and once in a pipeline config filename (per pipeline config)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
