### PR TITLE
Address transform mismatch (ANTs/FSL) when applying blip warp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `rbc-options` preconfig to use `fmriprep-options` preprocessing
 - Changed minimized pipeline base from `default` to `blank`
 - Removed deprecated `--disable_file_logging` CLI flag
+- Improved flexibility of some pipeline options regarding the application of distortion correction transforms
 
 ### Fixed
 - Fixed [a bug](https://github.com/FCP-INDI/C-PAC/issues/1779) in which generated pipeline configs were not 100% accurate. The only affected configurable option discovered in testing was seed-based correlation analysis always reverting to the default configuration.
 - Fixed [bug](https://github.com/FCP-INDI/C-PAC/issues/1795) that was causing `cpac run` to fail when passing a manual random seed via `--random_seed`.
 - Replaces ``DwellTime`` with ``EffectiveEchoSpacing`` for FSL usage of the term
 - Fixed an issue that was causing some epi field maps to not be ingressed if the BIDS tags were not in the correct order.
+- Fixed an issue where some phase-difference GRE field map files were not properly being ingressed if the filenames were not expected.
 
 ## [v1.8.4] - 2022-06-27
 

--- a/CPAC/distortion_correction/distortion_correction.py
+++ b/CPAC/distortion_correction/distortion_correction.py
@@ -349,7 +349,7 @@ def distcor_blip_afni_qwarp(wf, cfg, strat_pool, pipe_num, opt=None):
                 "pe-direction"],
      "outputs": ["sbref",
                  "space-bold_desc-brain_mask",
-                 "blip-warp"]}
+                 "ants-blip-warp"]}
     '''
 
     match_epi_imports = ['import json']
@@ -476,7 +476,7 @@ def distcor_blip_afni_qwarp(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(undistort_func_mean, 'output_image', remask, 'in_file')
 
     outputs = {
-        'blip-warp': (convert_afni_warp, 'ants_warp'),
+        'ants-blip-warp': (convert_afni_warp, 'ants_warp'),
         #'inv-blip-warp': None,  # TODO
         'sbref': (undistort_func_mean, 'output_image'),
         'space-bold_desc-brain_mask': (remask, 'out_file')
@@ -510,7 +510,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
                 "epi-2-total-readout"],
      "outputs": ["sbref",
                  "space-bold_desc-brain_mask",
-                 "blip-warp"]}
+                 "fsl-blip-warp"]}
     '''
 
     # TODO: re-integrate gradient distortion coefficient usage at a later date
@@ -850,7 +850,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
     outputs = {
         'sbref': (mul_jac, 'out_file'),
         'space-bold_desc-brain_mask': (bet, 'out_file'),
-        'blip-warp': (convert_warp, 'out_file')
+        'fsl-blip-warp': (convert_warp, 'out_file')
     }
 
     return (wf, outputs)

--- a/CPAC/distortion_correction/distortion_correction.py
+++ b/CPAC/distortion_correction/distortion_correction.py
@@ -849,7 +849,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
 
     outputs = {
         'sbref': (mul_jac, 'out_file'),
-        'space-bold_desc-brain_mask': (bet, 'out_file'),
+        'space-bold_desc-brain_mask': (bet, 'mask_file'),
         'fsl-blip-warp': (convert_warp, 'out_file')
     }
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -98,6 +98,7 @@ from CPAC.registration.registration import (
     coregistration,
     create_func_to_T1template_xfm,
     create_func_to_T1template_symmetric_xfm,
+    apply_blip_to_timeseries_separately,
     warp_timeseries_to_T1template,
     warp_bold_mean_to_T1template,
     warp_bold_mask_to_T1template,
@@ -1265,7 +1266,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
 
     if apply_func_warp['T1']:
 
-        ts_to_T1template_block = [warp_timeseries_to_T1template,
+        ts_to_T1template_block = [apply_blip_to_timeseries_separately,
+                                  warp_timeseries_to_T1template,
                                   warp_timeseries_to_T1template_dcan_nhp]
 
         if cfg.nuisance_corrections['2-nuisance_regression']['create_regressors']:

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -463,8 +463,7 @@ def run_main():
                     '1.7-1.8-nesting-mappings')
 
             logger.warning('\nC-PAC changed its pipeline configuration '
-                           'format in v1.8.0.\nSee %s for details.\n', _url,
-                           category=DeprecationWarning)
+                           'format in v1.8.0.\nSee %s for details.\n', _url)
 
             updated_config = os.path.join(
                 output_dir,
@@ -603,8 +602,7 @@ def run_main():
         else:
             logger.warning('Cannot write working directory to S3 bucket. '
                            'Either change the output directory to something '
-                           'local or turn off the --save_working_dir flag',
-                           category=UserWarning)
+                           'local or turn off the --save_working_dir flag')
 
         if c['pipeline_setup']['output_directory']['quality_control'][
                 'generate_xcpqc_files']:


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #1242 by @sgiavasis 

## Description
Applies the AFNI 3dQwarp or FSL TOPUP distortion correction un-warps (derived from EPI field map data).
Current workflows, 3dQwarp produces an ANTs warp field, and TOPUP produces an FSL warp field. These cannot be converted interchangeably, so when the pipeline is using the opposite tool for registration, these warps need to be applied specifically on their own.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
