### PR TITLE
AFNI 3dDespike in template space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added the ability to downsample to 10K or 2K resolution for freesurfer runs
+- Added the ability to run AFNI 3dDespike on template-space BOLD data.
 - Added the ability to ingress TotalReadoutTime from epi field map meta-data from the JSON sidecars.
 - Added the ability to use TotalReadoutTime of epi field maps in the calculation of FSL topup distortion correction.
 - Difference method (``-``) for ``CPAC.utils.configuration.Configuration`` instances

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1003,8 +1003,8 @@ def func_despike(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "func_despike",
      "config": ["functional_preproc", "despiking"],
      "switch": ["run"],
-     "option_key": "None",
-     "option_val": "None",
+     "option_key": "space",
+     "option_val": "native",
      "inputs": ["desc-preproc_bold"],
      "outputs": {
          "desc-preproc_bold": {
@@ -1025,6 +1025,37 @@ def func_despike(wf, cfg, strat_pool, pipe_num, opt=None):
 
     outputs = {
         'desc-preproc_bold': (despike, 'out_file')
+    }
+
+    return (wf, outputs)
+
+
+def func_despike_template(wf, cfg, strat_pool, pipe_num, opt=None):
+    '''
+    {"name": "func_despike_template",
+     "config": ["functional_preproc", "despiking"],
+     "switch": ["run"],
+     "option_key": "space",
+     "option_val": "template",
+     "inputs": ["space-template_desc-preproc_bold"],
+     "outputs": {
+         "space-template_desc-preproc_bold": {
+             "Description": "De-spiked BOLD time-series via AFNI 3dDespike."
+    }}}
+    '''
+
+    despike = pe.Node(interface=preprocess.Despike(),
+                      name=f'func_despiked_template_{pipe_num}',
+                      mem_gb=0.66,
+                      mem_x=(8251808479088459 / 1208925819614629174706176,
+                             'in_file'))
+    despike.inputs.outputtype = 'NIFTI_GZ'
+
+    node, out = strat_pool.get_data("space-template_desc-preproc_bold")
+    wf.connect(node, out, despike, 'in_file')
+
+    outputs = {
+        'space-template_desc-preproc_bold': (despike, 'out_file')
     }
 
     return (wf, outputs)

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1003,8 +1003,8 @@ def func_despike(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "func_despike",
      "config": ["functional_preproc", "despiking"],
      "switch": ["run"],
-     "option_key": "space",
-     "option_val": "native",
+     "option_key": ["space"],
+     "option_val": ["native"],
      "inputs": ["desc-preproc_bold"],
      "outputs": {
          "desc-preproc_bold": {
@@ -1035,8 +1035,8 @@ def func_despike_template(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "func_despike_template",
      "config": ["functional_preproc", "despiking"],
      "switch": ["run"],
-     "option_key": "space",
-     "option_val": "template",
+     "option_key": ["space"],
+     "option_val": ["template"],
      "inputs": ["space-template_desc-preproc_bold"],
      "outputs": {
          "space-template_desc-preproc_bold": {

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -126,6 +126,7 @@ from CPAC.func_preproc.func_preproc import (
     func_scaling,
     func_truncate,
     func_despike,
+    func_despike_template,
     func_slice_time,
     func_reorient,
     bold_mask_afni,
@@ -1282,7 +1283,9 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     if not rpool.check_rpool('space-template_desc-bold_mask'):
         pipeline_blocks += [warp_bold_mask_to_T1template,
                             warp_deriv_mask_to_T1template]
-        
+
+    pipeline_blocks += [func_despike_template]
+
     target_space_alff = cfg.amplitude_low_frequency_fluctuation['target_space']
     if 'Template' in target_space_alff and not rpool.check_rpool('space-template_desc-denoisedNofilt_bold'):
         pipeline_blocks += [warp_denoiseNofilt_to_T1template]

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -631,6 +631,7 @@ latest_schema = Schema({
         },
         'despiking': {
             'run': forkable
+            'space': In({'native', 'template'})
         },
         'slice_timing_correction': {
             'run': forkable,

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -630,7 +630,7 @@ latest_schema = Schema({
             'scaling_factor': Number
         },
         'despiking': {
-            'run': forkable
+            'run': forkable,
             'space': In({'native', 'template'})
         },
         'slice_timing_correction': {

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1192,6 +1192,8 @@ functional_preproc:
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [Off]
 
+    space: 'native'
+
 nuisance_corrections:
   2-nuisance_regression:
 

--- a/CPAC/resources/configs/pipeline_config_rbc-options.yml
+++ b/CPAC/resources/configs/pipeline_config_rbc-options.yml
@@ -110,6 +110,7 @@ functional_preproc:
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+    space: 'template'
 
 nuisance_corrections:
   2-nuisance_regression:


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1812 by @sgiavasis 

## Description
Users can now select to run AFNI 3dDespike on template-space BOLD data.

## Technical details
The toggle can be found in the pipeline config YAML under the despiking segment.
Space: ['native', 'template']

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
