### PR TITLE
🎨 Standardize naming for atlases used in RBC

### DIFF
--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -1785,12 +1785,12 @@ def ingress_pipeconfig_paths(cfg, rpool, unique_id, creds_path=None):
             val = val.replace('${func_resolution}', cfg.registration_workflows[
                 'functional_registration']['func_registration_to_template'][
                 'output_resolution'][tag])
-            
+
         if desc:
-            template_name = lookup_identifier(val)
+            template_name, _template_desc = lookup_identifier(val)
             if template_name:
                 desc = f"{template_name} - {desc}"
-            json_info['Description'] = f"{desc} - {val}"     
+            json_info['Description'] = f"{desc} - {val}"
         if resolution:
             resolution = cfg.get_nested(cfg, res_keys)
             json_info['Resolution'] = resolution

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -23,7 +23,7 @@ import numpy as np
 from pathvalidate import sanitize_filename
 from voluptuous import All, ALLOW_EXTRA, Any, Capitalize, Coerce, \
                        ExactSequence, ExclusiveInvalid, In, Length, Lower, \
-                       Match, Maybe, Optional, Range, Required, Schema
+                       Match, Maybe, Optional, Range, Required, Schema, Title
 from CPAC import docs_prefix
 from CPAC.utils.datatypes import ListFromItem
 from CPAC.utils.utils import YAML_BOOLS
@@ -204,6 +204,8 @@ ANTs_parameters = [Any(
         },
     }, dict  # TODO: specify other valid ANTs parameters
 )]
+target_space = All(Coerce(ListFromItem),
+                   [All(Title, In(valid_options['target_space']))])
 
 
 def permutation_message(key, options):
@@ -865,7 +867,7 @@ latest_schema = Schema({
     },
     'amplitude_low_frequency_fluctuation': {
         'run': bool1_1,
-        'target_space': [In(valid_options['target_space'])],
+        'target_space': target_space,
         'highpass_cutoff': [float],
         'lowpass_cutoff': [float],
     },
@@ -884,7 +886,7 @@ latest_schema = Schema({
     },
     'regional_homogeneity': {
         'run': bool1_1,
-        'target_space': [In(valid_options['target_space'])],
+        'target_space': target_space,
         'cluster_size': In({7, 19, 27}),
     },
     'post_processing': {

--- a/CPAC/resources/configs/pipeline_config_rbc-options.yml
+++ b/CPAC/resources/configs/pipeline_config_rbc-options.yml
@@ -117,7 +117,7 @@ functional_preproc:
 
 nuisance_corrections:
   2-nuisance_regression:
-
+    run: [On]
     # Select which nuisance signal corrections to apply
     Regressors:
       - Name: 36-parameter
@@ -229,12 +229,14 @@ amplitude_low_frequency_fluctuation:
   # ALFF & f/ALFF
   # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF (f/ALFF) for all voxels.
   run: On
+  target_space: template
 
 regional_homogeneity:
 
   # ReHo
   # Calculate Regional Homogeneity (ReHo) for all voxels.
   run: On
+  target_space: template
 
 network_centrality:
 

--- a/CPAC/resources/configs/pipeline_config_rbc-options.yml
+++ b/CPAC/resources/configs/pipeline_config_rbc-options.yml
@@ -117,7 +117,11 @@ functional_preproc:
 
 nuisance_corrections:
   2-nuisance_regression:
+
+    # this is a fork point
+    #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+
     # Select which nuisance signal corrections to apply
     Regressors:
       - Name: 36-parameter
@@ -229,14 +233,18 @@ amplitude_low_frequency_fluctuation:
   # ALFF & f/ALFF
   # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF (f/ALFF) for all voxels.
   run: On
-  target_space: template
+
+  # space: Template or Native
+  target_space: [Template]
 
 regional_homogeneity:
 
   # ReHo
   # Calculate Regional Homogeneity (ReHo) for all voxels.
   run: On
-  target_space: template
+
+  # space: Template or Native
+  target_space: [Template]
 
 network_centrality:
 

--- a/CPAC/resources/templates/BIDS_identifiers.tsv
+++ b/CPAC/resources/templates/BIDS_identifiers.tsv
@@ -1,13 +1,30 @@
-/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_T1w_reference.nii.gz	MNI152NLin2009cAsym
-/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_desc-brain_T1w.nii.gz	MNI152NLin2009cAsym
-/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_desc-brain_mask.nii.gz	MNI152NLin2009cAsym
-/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_desc-fMRIPrep_boldref.nii.gz	MNI152NLin2009cAsym
-/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_label-brain_probseg.nii.gz	MNI152NLin2009cAsym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*.nii.gz	MNI152NLin6ASym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain.nii.gz	MNI152NLin6ASym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask.nii.gz	MNI152NLin6ASym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask_dil.nii.gz	MNI152NLin6ASym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_symmetric.nii.gz	MNI152NLin6Sym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_symmetric.nii.gz	MNI152NLin6Sym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask_symmetric.nii.gz	MNI152NLin6Sym
-/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask_symmetric_dil.nii.gz	MNI152NLin6Sym
+/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_T1w_reference.nii.gz	MNI152NLin2009cAsym	
+/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_desc-brain_T1w.nii.gz	MNI152NLin2009cAsym	
+/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_desc-brain_mask.nii.gz	MNI152NLin2009cAsym	
+/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_desc-fMRIPrep_boldref.nii.gz	MNI152NLin2009cAsym	
+/code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_label-brain_probseg.nii.gz	MNI152NLin2009cAsym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*.nii.gz	MNI152NLin6ASym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain.nii.gz	MNI152NLin6ASym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask.nii.gz	MNI152NLin6ASym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask_dil.nii.gz	MNI152NLin6ASym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_symmetric.nii.gz	MNI152NLin6Sym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_symmetric.nii.gz	MNI152NLin6Sym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask_symmetric.nii.gz	MNI152NLin6Sym	
+/usr/share/fsl/5.0/data/standard/MNI152_T1_(res-){0,1}[0-9]+(\.[0-9]*){0,1}[a-z]*(x[0-9]+(\.[0-9]*){0,1}[a-z]*)*_brain_mask_symmetric_dil.nii.gz	MNI152NLin6Sym	
+/ndmg_atlases/label/Human/AAL_space-MNI152NLin6_res-2x2x2.nii.gz	AAL	
+/ndmg_atlases/label/Human/Brodmann_space-MNI152NLin6_res-2x2x2.nii.gz	Brodmann	
+/cpac_templates/CC200.nii.gz	CC	200
+/cpac_templates/CC400.nii.gz	CC	400
+/ndmg_atlases/label/Human/Glasser_space-MNI152NLin6_res-2x2x2.nii.gz	Glasser	
+/ndmg_atlases/label/Human/Slab907_space-MNI152NLin6_res-2x2x2.nii.gz	Slab	
+/ndmg_atlases/label/Human/HarvardOxfordcort-maxprob-thr25_space-MNI152NLin6_res-2x2x2.nii.gz	HOCPA	th25
+/ndmg_atlases/label/Human/HarvardOxfordsub-maxprob-thr25_space-MNI152NLin6_res-2x2x2.nii.gz	HOSPA	th25
+/ndmg_atlases/label/Human/Juelich_space-MNI152NLin6_res-2x2x2.nii.gz	Juelich	
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-200Parcels17NetworksOrder.nii.gz	Schaefer2018	200p17n
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-300Parcels17NetworksOrder.nii.gz	Schaefer2018	300p17n
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-400Parcels17NetworksOrder.nii.gz	Schaefer2018	400p17n
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-1000Parcels17NetworksOrder.nii.gz	Schaefer2018	1000p17n
+/ndmg_atlases/label/Human/Yeo-7_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	7
+/ndmg_atlases/label/Human/Yeo-7-liberal_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	7liberal
+/ndmg_atlases/label/Human/Yeo-17_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	17
+/ndmg_atlases/label/Human/Yeo-17-liberal_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	17liberal

--- a/CPAC/resources/templates/__init__.py
+++ b/CPAC/resources/templates/__init__.py
@@ -1,4 +1,4 @@
 '''Template resources for C-PAC'''
-from .lookup_table import lookup_identifier
+from .lookup_table import format_identifier, lookup_identifier
 
-__all__ = ['lookup_identifier']
+__all__ = ['format_identifier', 'lookup_identifier']

--- a/CPAC/resources/templates/lookup_table.py
+++ b/CPAC/resources/templates/lookup_table.py
@@ -1,17 +1,58 @@
-'''Utilities for determining BIDS standard template identifiers
+# Copyright (C) 2022  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""Utilities for determining BIDS standard template identifiers
 (https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#standard-template-identifiers)
-from in-container template paths'''
-import os
-import re
-import numpy as np
+from in-container template paths"""
+from os import path as op
+from re import search
+from typing import Optional, Tuple
+from numpy import loadtxt
 
-LOOKUP_TABLE = {row[0]: row[1] for row in
-                np.loadtxt(os.path.join(os.path.dirname(__file__),
-                                        'BIDS_identifiers.tsv'),
-                dtype='str', delimiter='\t')}
+LOOKUP_TABLE = {row[0]: (row[1], str(row[2]) if row[2] else None) for row in
+                loadtxt(op.join(op.dirname(__file__), 'BIDS_identifiers.tsv'),
+                        dtype='str', delimiter='\t')}
 
 
-def lookup_identifier(template_path: str) -> str:
+def format_identifier(identifier: str, desc: Optional[str] = None) -> str:
+    '''Function to create an identifier string from a name and description
+
+    Parameters
+    ----------
+    identifier : str
+
+    desc : str, optional
+
+    Returns
+    -------
+    str
+
+    Examples
+    --------
+    >>> format_identifier('CC', '200')
+    'CC_desc-200'
+    >>> format_identifier('AAL')
+    'AAL'
+    '''
+    if desc:
+        return f'{identifier}_desc-{desc}'
+    return identifier
+
+
+def lookup_identifier(template_path: str) -> Tuple[str, None]:
     '''Function to return a standard template identifier for a packaged
     template, if known. Otherwise, returns the literal string
     'template'
@@ -24,19 +65,23 @@ def lookup_identifier(template_path: str) -> str:
     -------
     identifier : str
 
+    desc : str or None
+
     Examples
     --------
     >>> lookup_identifier('/usr/share/fsl/5.0/data/standard/'
     ...                   'MNI152_T1_1mm_brain.nii.gz')
-    'MNI152NLin6ASym'
+    ('MNI152NLin6ASym', None)
     >>> lookup_identifier('/code/CPAC/resources/templates/'
     ...                   'tpl-MNI152NLin2009cAsym_res-01_label-brain_'
     ...                   'probseg.nii.gz')
-    'MNI152NLin2009cAsym'
+    ('MNI152NLin2009cAsym', None)
     >>> lookup_identifier('/cpac_templates/chd8_functional_template_sk.nii')
-    'template'
+    ('template', None)
+    >>> lookup_identifier('/cpac_templates/CC200.nii.gz')
+    ('CC', '200')
     '''
     for key, value in LOOKUP_TABLE.items():
-        if re.search(key, template_path) is not None:
+        if search(key, template_path) is not None:
             return value
-    return 'template'
+    return 'template', None

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -182,7 +182,7 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
     """
 
     if atlas_id:
-        if '_' in atlas_id:
+        if not (atlas_id.count('_') == 1 and '_desc-' in atlas_id):
             atlas_id = atlas_id.replace('_', '')
         resource = f'atlas-{atlas_id}_{resource}'
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to https://github.com/FCP-INDI/C-PAC_templates/issues/4, #1641, & #1808 by @shnizzedy 
With #1825, this PR is fully included in #1831, so if all three are approved, we can just merge #1831 and get all three without having to do any merge conflict resolution.

## Description
<!-- Concisely describe what the pull request does. -->
For the atlases used in `rbc-options`,
* adds the atlases to [`CPAC/resources/templates/BIDS_identifiers.tsv`](https://github.com/FCP-INDI/C-PAC/blob/3cf67687c0d24c24f8a4996e7c6d37795170fb34/CPAC/resources/templates/BIDS_identifiers.tsv)
* replaces `f'atlas-{strip_extension(basename(atlas_filename))}'` with `f'atlas-{atlasname}'` or `f'atlas-{atlasname}_desc-{atlasdesc}'` in derivative filenames
  (for example,
  ```
  sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-Schaefer2018space-FSLMNI152res-2mmdesc-1000Parcels17NetworksOrder_desc-Mean-1_timeseries.1D
  ```
  becomes
  ```
  sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-Schaefer2018_desc-1000p17_desc-Mean-1_timeseries.1D`
  ```
  )

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
This still allows duplicate `desc` entities and `-`s in entity values; those will be addressed in separate PRs


## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

![named atlases](https://user-images.githubusercontent.com/5974438/200029956-2554e6a3-1757-4f89-8090-911b7c4952ab.png)

![outputs](https://user-images.githubusercontent.com/5974438/200899710-c781cba3-a4d0-473f-b68b-31c96eff0af8.png)



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
