### PR TITLE
🎨 Change `-`s in BIDS values to camelCase

### DIFF
--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -179,6 +179,12 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
 
     This is used in the file renaming performed during the Datasink
     connections.
+
+    Example
+    -------
+    >>> create_id_string('sub-1_ses-1', 'desc-Mean-1_timeseries',
+    ...                  scan_id='rest', atlas_id='Schaefer2018_desc-1007p17')
+    'sub-1_ses-1_task-rest_atlas-Schaefer2018_desc-1007p17Mean1_timeseries'
     """
 
     if atlas_id:
@@ -225,9 +231,11 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
             if key not in entities:
                 entities[key] = []
             entities[key].append(value)
-    return '_'.join([
-        f'{key}-{" ".join(value).replace("-", " ").title().replace(" ", "")}'
-        for key, value in entities.items()] + suffixes)
+    for key, value in entities.items():
+        entities[key] = value[0] + " ".join(value[1:]).replace("-", " ").title(
+        ).replace(" ", "")
+    return '_'.join([f'{key}-{value}' for key, value in entities.items()
+                     ] + suffixes)
 
 
 def write_output_json(json_data, filename, indent=3, basedir=None):

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -203,8 +203,8 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
         for prefix in ['space-', 'from-', 'to-']:
             for bidstag in out_filename.split('_'):
                 if prefix in bidstag and 'template' in bidstag:
-                    out_filename = out_filename.replace(bidstag,
-                                                        f'{prefix}{template_tag}')
+                    out_filename = out_filename.replace(
+                        bidstag, f'{prefix}{template_tag}')
 
     if fwhm:
         for tag in resource.split('_'):
@@ -215,7 +215,19 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
         else:
             raise Exception('\n[!] FWHM provided but no desc-sm?\n')
 
-    return out_filename
+    entity_list = out_filename.split('_')
+    entities = {}
+    # should just be one suffix, but don't want to lose information
+    suffixes = [entity for entity in entity_list if '-' not in entity]
+    for entity in entity_list:
+        if '-' in entity:
+            key, value = entity.split('-', maxsplit=1)
+            if key not in entities:
+                entities[key] = []
+            entities[key].append(value)
+    return '_'.join([
+        f'{key}-{" ".join(value).replace("-", " ").title().replace(" ", "")}'
+        for key, value in entities.items()] + suffixes)
 
 
 def write_output_json(json_data, filename, indent=3, basedir=None):


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #1808 by @shnizzedy 
With #1823, this PR is fully included in #1831, so if all three are approved, we can just merge #1831 and get all three without having to do any merge conflict resolution.

## Description
<!-- Concisely describe what the pull request does. -->
1. Collects BIDS entities in `out_filename` by key
2. Converts all `-`s in values and duplicate keys to a single camelCase entity
3. Recombines the entities into a single `_`-delimited string

## Tests
https://github.com/FCP-INDI/C-PAC/blob/e1960563981f1149165e7e36814d91a1de4b8b00/CPAC/utils/utils.py#L185-L187

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
