### PR TITLE
🎨 Add template specification to new outputs from #1820

### DIFF
--- a/CPAC/qc/xcp.py
+++ b/CPAC/qc/xcp.py
@@ -392,7 +392,8 @@ def qc_xcp(wf, cfg, strat_pool, pipe_num, opt=None):
                  ['T1w-brain-template-funcreg', 'EPI-brain-template-funcreg'],
                  'movement-parameters', 'dvars',
                  'framewise-displacement-jenkinson')],
-     'outputs': ['space-template_desc-xcp_quality']}
+     'outputs': {'space-template_desc-xcp_quality': {
+                     'Template': 'T1w-brain-template-mask'}}}
     """
     if cfg['nuisance_corrections', '2-nuisance_regression', 'run'
            ] and not strat_pool.check_rpool('regressors'):

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -3210,7 +3210,8 @@ def warp_wholeheadT1_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
      "inputs": [("desc-head_T1w",
                  "from-T1w_to-template_mode-image_xfm"),
                 "T1w-template"],
-     "outputs": ["space-template_desc-head_T1w"]}
+     "outputs": {"space-template_desc-head_T1w": {
+                     "Template": "T1w-template"}}}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(
@@ -3265,7 +3266,8 @@ def warp_T1mask_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
      "inputs": [("space-T1w_desc-brain_mask",
                  "from-T1w_to-template_mode-image_xfm"),
                 "T1w-template"],
-     "outputs": ["space-template_desc-brain_mask"]}
+     "outputs": {"space-template_desc-brain_mask": {
+                     "Template": "T1w-template"}}}
     '''
 
     xfm_prov = strat_pool.get_cpac_provenance(


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Updates XCPQC node block and new node blocks from #1820 by @sgiavasis to specify templates for renaming via functionality added in #1819 by @sgiavasis 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
These upgrades were completed in parallel. This PR addresses a gap in the overlap.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
No unspecified `template`s in ![expectedOutputs](https://user-images.githubusercontent.com/5974438/201148129-2c276c53-ab86-47b0-88d7-366e6b819bda.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
