### PR TITLE
👔 Fork on `motion_estimate_filter.filters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculate reho and alff when timeseries in template space
 - Added new default pipeline that uses FSL-BET for brain extraction. Previous default pipleine is now called default-deprecated.
 - Added ``fail_fast`` configuration setting and CLI flag
+- Added abililty to fork on motion filter
 
 ### Changed
 - Space labels in output filenames now contain specific template labels for MNI templates
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved flexibility of some pipeline options regarding the application of distortion correction transforms
 - Pinned AFNI to AFNI_21.1.00
 - Updated some output filenaming conventions for human-readability and to move closer to BIDS-derivatives compliance
+- Changed motion filter from single dictionary to list of dictionaries
 
 ### Fixed
 - Fixed [a bug](https://github.com/FCP-INDI/C-PAC/issues/1779) in which generated pipeline configs were not 100% accurate. The only affected configurable option discovered in testing was seed-based correlation analysis always reverting to the default configuration.

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1186,7 +1186,7 @@ def func_motion_correct(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "motion_correction",
      "config": "None",
-     "switch": ["functional_preproc", "motion_estimates_and_correction", 
+     "switch": ["functional_preproc", "motion_estimates_and_correction",
                 "run"],
      "option_key": ["functional_preproc", "motion_estimates_and_correction",
                     "motion_correction", "using"],
@@ -1211,7 +1211,7 @@ def func_motion_estimates(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "motion_estimates",
      "config": "None",
-     "switch": ["functional_preproc", "motion_estimates_and_correction", 
+     "switch": ["functional_preproc", "motion_estimates_and_correction",
                 "run"],
      "option_key": ["functional_preproc", "motion_estimates_and_correction",
                     "motion_correction", "using"],
@@ -1274,19 +1274,20 @@ def motion_estimate_filter(wf, cfg, strat_pool, pipe_num, opt=None):
      "config": ["functional_preproc", "motion_estimates_and_correction",
                 "motion_estimate_filter"],
      "switch": ["run"],
-     "option_key": "filter_type",
-     "option_val": ["notch", "lowpass"],
+     "option_key": "filters",
+     "option_val": "USER-DEFINED",
      "inputs": ["movement-parameters",
                 "TR"],
      "outputs": ["movement-parameters",
                  "motion-filter-info",
                  "motion-filter-plot"]}
     '''
-
     notch_imports = ['import os', 'import numpy as np',
-                     'from scipy.signal import iirnotch, lfilter, firwin, freqz',
+                     'from scipy.signal import iirnotch, lfilter, firwin, '
+                     'freqz',
                      'from matplotlib import pyplot as plt',
-                     'from CPAC.func_preproc.utils import degrees_to_mm, mm_to_degrees']
+                     'from CPAC.func_preproc.utils import degrees_to_mm, '
+                     'mm_to_degrees']
     notch = pe.Node(Function(input_names=['motion_params',
                                           'filter_type',
                                           'TR',
@@ -1302,29 +1303,15 @@ def motion_estimate_filter(wf, cfg, strat_pool, pipe_num, opt=None):
                                  'filter_plot'],
                              function=notch_filter_motion,
                              imports=notch_imports),
-                    name=f'filter_motion_params_{pipe_num}')
+                    name=f'filter_motion_params_{opt["Name"]}_{pipe_num}')
 
-    notch.inputs.filter_type = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['filter_type']
-    notch.inputs.fc_RR_min = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['breathing_rate_min']
-    notch.inputs.fc_RR_max = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['breathing_rate_max']
-    notch.inputs.center_freq = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['center_frequency']
-    notch.inputs.freq_bw = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['filter_bandwidth']
-    notch.inputs.lowpass_cutoff = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['lowpass_cutoff']
-    notch.inputs.filter_order = cfg.functional_preproc[
-        "motion_estimates_and_correction"][
-        "motion_estimate_filter"]['filter_order']
+    notch.inputs.filter_type = opt.get('filter_type')
+    notch.inputs.fc_RR_min = opt.get('breathing_rate_min')
+    notch.inputs.fc_RR_max = opt.get('breathing_rate_max')
+    notch.inputs.center_freq = opt.get('center_frequency')
+    notch.inputs.freq_bw = opt.get('filter_bandwidth')
+    notch.inputs.lowpass_cutoff = opt.get('lowpass_cutoff')
+    notch.inputs.filter_order = opt.get('filter_order')
 
     node, out = strat_pool.get_data('movement-parameters')
     wf.connect(node, out, notch, 'motion_params')

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -956,8 +956,6 @@ class ResourcePool:
                                                          filt_value)
                             out_dct['filename'] = insert_entity(
                                 out_dct['filename'], 'filt', filt_value)
-                            resource_idx = insert_entity(resource_idx, 'filt',
-                                                         filt_value)
                             labeled_variant = True
                     if True in cfg['nuisance_corrections',
                                    '2-nuisance_regression', 'run']:

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1,21 +1,20 @@
-'''Validation schema for C-PAC pipeline configurations
+# Copyright (C) 2022  C-PAC Developers
 
-Copyright (C) 2022  C-PAC Developers
+# This file is part of C-PAC.
 
-This file is part of C-PAC.
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
 
-C-PAC is free software: you can redistribute it and/or modify it under
-the terms of the GNU Lesser General Public License as published by the
-Free Software Foundation, either version 3 of the License, or (at your
-option) any later version.
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
 
-C-PAC is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
-License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.'''
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+'''Validation schema for C-PAC pipeline configurations'''
 # pylint: disable=too-many-lines
 import re
 from itertools import chain, permutations

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -264,40 +264,43 @@ def name_motion_filter(mfilter, mfilters=None):
     --------
     >>> name_motion_filter({'filter_type': 'notch', 'filter_order': 2,
     ...     'center_frequency': 0.31, 'filter_bandwidth': 0.12})
-    'notch2c0p31bw0p12'
+    'notch2fc0p31bw0p12'
     >>> name_motion_filter({'filter_type': 'notch', 'filter_order': 4,
     ...     'breathing_rate_min': 0.19, 'breathing_rate_max': 0.43})
-    'notch4from0p19to0p43'
+    'notch4fl0p19fu0p43'
     >>> name_motion_filter({'filter_type': 'lowpass', 'filter_order': 4,
     ...     'lowpass_cutoff': .0032})
-    'lowpass4co0p0032'
+    'lowpass4fc0p0032'
     >>> name_motion_filter({'filter_type': 'lowpass', 'filter_order': 2,
     ...     'breathing_rate_min': 0.19})
-    'lowpass2from0p19'
+    'lowpass2fl0p19'
     >>> name_motion_filter({'filter_type': 'lowpass', 'filter_order': 2,
-    ...     'breathing_rate_min': 0.19}, [{'Name': 'lowpass2from0p19'}])
-    'lowpass2from0p19dup1'
+    ...     'breathing_rate_min': 0.19}, [{'Name': 'lowpass2fl0p19'}])
+    'lowpass2fl0p19dup1'
     >>> name_motion_filter({'filter_type': 'lowpass', 'filter_order': 2,
-    ...     'breathing_rate_min': 0.19}, [{'Name': 'lowpass2from0p19'},
-    ...     {'Name': 'lowpass2from0p19dup1'}])
-    'lowpass2from0p19dup2'
+    ...     'breathing_rate_min': 0.19}, [{'Name': 'lowpass2fl0p19'},
+    ...     {'Name': 'lowpass2fl0p19dup1'}])
+    'lowpass2fl0p19dup2'
     '''
     if mfilters is None:
         mfilters = []
-    if mfilter['filter_type'] == 'notch':
-        if mfilter.get('breathing_rate_min'):
-            range_str = (f'from{mfilter["breathing_rate_min"]}'
-                         f'to{mfilter["breathing_rate_max"]}')
-        else:
-            range_str = (f'c{mfilter["center_frequency"]}'
-                         f'bw{mfilter["filter_bandwidth"]}')
+    if 'Name' in mfilter:
+        name = mfilter['Name']
     else:
-        if mfilter.get('breathing_rate_min'):
-            range_str = f'from{mfilter["breathing_rate_min"]}'
+        if mfilter['filter_type'] == 'notch':
+            if mfilter.get('breathing_rate_min'):
+                range_str = (f'fl{mfilter["breathing_rate_min"]}'
+                             f'fu{mfilter["breathing_rate_max"]}')
+            else:
+                range_str = (f'fc{mfilter["center_frequency"]}'
+                             f'bw{mfilter["filter_bandwidth"]}')
         else:
-            range_str = f'co{mfilter["lowpass_cutoff"]}'
-    range_str = range_str.replace('.', 'p')
-    name = f'{mfilter["filter_type"]}{mfilter["filter_order"]}{range_str}'
+            if mfilter.get('breathing_rate_min'):
+                range_str = f'fl{mfilter["breathing_rate_min"]}'
+            else:
+                range_str = f'fc{mfilter["lowpass_cutoff"]}'
+        range_str = range_str.replace('.', 'p')
+        name = f'{mfilter["filter_type"]}{mfilter["filter_order"]}{range_str}'
     dupes = len([_ for _ in (_.get('Name', '') for _ in mfilters) if
                  _.startswith(name)])
     if dupes:

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1089,14 +1089,17 @@ def schema(config_dict):
                     f'registration: using`` to ``ANTS`` {or_else}')
     except KeyError:
         pass
-    motion_filters = partially_validated['functional_preproc'][
-        'motion_estimates_and_correction']['motion_estimate_filter']
-    if True in motion_filters['run']:
-        for motion_filter in motion_filters['filters']:
-            motion_filter['Name'] = name_motion_filter(
-                motion_filter, motion_filters['filters'])
-    else:
-        motion_filters['filters'] = []
+    try:
+        motion_filters = partially_validated['functional_preproc'][
+            'motion_estimates_and_correction']['motion_estimate_filter']
+        if True in motion_filters['run']:
+            for motion_filter in motion_filters['filters']:
+                motion_filter['Name'] = name_motion_filter(
+                    motion_filter, motion_filters['filters'])
+        else:
+            motion_filters['filters'] = []
+    except KeyError:
+        pass
     return partially_validated
 
 

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -21,8 +21,8 @@ from itertools import chain, permutations
 import numpy as np
 from pathvalidate import sanitize_filename
 from voluptuous import All, ALLOW_EXTRA, Any, Capitalize, Coerce, \
-                       ExactSequence, ExclusiveInvalid, In, Length, Lower, \
-                       Match, Maybe, Optional, Range, Required, Schema, Title
+                       ExclusiveInvalid, In, Length, Lower, Match, Maybe, \
+                       Optional, Range, Required, Schema, Title
 from CPAC import docs_prefix
 from CPAC.utils.datatypes import ListFromItem
 from CPAC.utils.utils import YAML_BOOLS

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -301,10 +301,15 @@ def name_motion_filter(mfilter, mfilters=None):
                 range_str = f'fc{mfilter["lowpass_cutoff"]}'
         range_str = range_str.replace('.', 'p')
         name = f'{mfilter["filter_type"]}{mfilter["filter_order"]}{range_str}'
-    dupes = len([_ for _ in (_.get('Name', '') for _ in mfilters) if
-                 _.startswith(name)])
+    dupes = 'Name' not in mfilter and len([_ for _ in (_.get('Name', '') for
+                                           _ in mfilters) if
+                                           _.startswith(name)])
     if dupes:
-        name = f'{name}dup{dupes}'
+        dup = re.search('(?=[A-Za-z0-9]*)(dup[0-9]*)', name)
+        if dup:  # Don't chain 'dup' suffixes
+            name = name.replace(dup.group(), f'dup{dupes}')
+        else:
+            name = f'{name}dup{dupes}'
     return name
 
 

--- a/CPAC/pipeline/test/test_schema_validation.py
+++ b/CPAC/pipeline/test/test_schema_validation.py
@@ -6,26 +6,40 @@ from CPAC.utils.configuration import Configuration
 
 
 @pytest.mark.parametrize('run_value', [
-    True, False, [True], [False], [True, False], [False, True], None, []])
+    True, False, [True], [False], [True, False], [False, True]])
 def test_motion_estimates_and_correction(run_value):
     '''Test that any truthy forkable option for 'run' throws the custom
     human-readable exception for an invalid motion_estimate_filter.
     '''
-    d = {
-        'FROM': 'default',
-        'functional_preproc': {'motion_estimates_and_correction': {
+    # pylint: disable=invalid-name
+    d = {'FROM': 'default',
+         'functional_preproc': {'motion_estimates_and_correction': {
              'motion_estimate_filter': {'run': run_value,
-                                        'filter_type': 'notch',
-                                        'filter_order': 0,
-                                        'breathing_rate_min': None,
-                                        'breathing_rate_max': 101.5}}}
-    }
+                                        'filters': [{
+                                            'filter_type': 'notch',
+                                            'filter_order': 0,
+                                            'breathing_rate_min': None,
+                                            'breathing_rate_max': 101.5}]}}}}
     if bool(run_value) and run_value not in [[False], []]:
         with pytest.raises(Invalid) as e:
             Configuration(d)
         assert "func#motion_estimate_filter_valid_options" in str(e.value)
     else:
         Configuration(d)
+    d = {'FROM': 'default',
+         'functional_preproc': {'motion_estimates_and_correction': {
+             'motion_estimate_filter': {'run': run_value,
+                                        'filters': [{
+                                            'filter_type': 'notch',
+                                            'filter_order': 4,
+                                            'center_frequency': .31,
+                                            'filter_bandwidth': .12}]}}}}
+    c = Configuration(d)
+    if c['functional_preproc', 'motion_estimates_and_correction',
+         'motion_estimate_filter', 'filters']:
+        assert c['functional_preproc', 'motion_estimates_and_correction',
+                 'motion_estimate_filter', 'filters', 0, 'Name'
+                 ] == 'notch4c0p31bw0p12'
 
 
 @pytest.mark.parametrize('registration_using',

--- a/CPAC/pipeline/test/test_schema_validation.py
+++ b/CPAC/pipeline/test/test_schema_validation.py
@@ -23,7 +23,7 @@ def test_motion_estimates_and_correction(run_value):
     if bool(run_value) and run_value not in [[False], []]:
         with pytest.raises(Invalid) as e:
             Configuration(d)
-        assert "func#motion_estimate_filter_valid_options" in str(e.value)
+        assert "func#motion-estimate-filter-valid-options" in str(e.value)
     else:
         Configuration(d)
     d = {'FROM': 'default',
@@ -39,7 +39,7 @@ def test_motion_estimates_and_correction(run_value):
          'motion_estimate_filter', 'filters']:
         assert c['functional_preproc', 'motion_estimates_and_correction',
                  'motion_estimate_filter', 'filters', 0, 'Name'
-                 ] == 'notch4c0p31bw0p12'
+                 ] == 'notch4fc0p31bw0p12'
 
 
 @pytest.mark.parametrize('registration_using',

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -986,50 +986,7 @@ functional_preproc:
       #   run: [On, Off] - this will run both and fork the pipeline
       run: [Off]
 
-      # options: "notch", "lowpass"
-      filter_type: notch
-
-      # Number of filter coefficients.
-      filter_order: 4
-
-      # Dataset-wide respiratory rate data from breathing belt.
-      # Notch filter requires either:
-      #     "breathing_rate_min" and "breathing_rate_max"
-      # or
-      #     "center_frequency" and "filter_bandwitdh".
-      # Lowpass filter requires either:
-      #     "breathing_rate_min"
-      # or
-      #     "lowpass_cutoff".
-      # If "breathing_rate_min" (for lowpass and notch filter)
-      # and "breathing_rate_max" (for notch filter) are set,
-      # the values set in "lowpass_cutoff" (for lowpass filter),
-      # "center_frequency" and "filter_bandwidth" (for notch filter)
-      # options are ignored.
-      # Lowest Breaths-Per-Minute in dataset.
-      # For both notch and lowpass filters.
-      breathing_rate_min:
-
-      # Highest Breaths-Per-Minute in dataset.
-      # For notch filter.
-      breathing_rate_max:
-
-      # notch filter direct customization parameters
-      # mutually exclusive with breathing_rate options above.
-      # If breathing_rate_min and breathing_rate_max are provided,
-      # the following parameters will be ignored.
-      # the center frequency of the notch filter
-      center_frequency:
-
-      # the width of the notch filter
-      filter_bandwidth:
-
-      # lowpass filter direct customization parameter
-      # mutually exclusive with breathing_rate options above.
-      # If breathing_rate_min is provided, the following
-      # parameter will be ignored.
-      # the frequency cutoff of the filter
-      lowpass_cutoff:
+      filters:
 
   distortion_correction:
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -985,8 +985,7 @@ functional_preproc:
       # this is a fork point
       #   run: [On, Off] - this will run both and fork the pipeline
       run: [Off]
-
-      filters:
+      filters: []
 
   distortion_correction:
 

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1095,55 +1095,81 @@ functional_preproc:
       #   run: [On, Off] - this will run both and fork the pipeline
       run: [Off]
 
-      # options: "notch", "lowpass"
-      filter_type: "notch"
+      filters:
+        - # options: "notch", "lowpass"
+          filter_type: "notch"
 
-      # Number of filter coefficients.
-      filter_order: 4
+          # Number of filter coefficients.
+          filter_order: 4
 
-      # Dataset-wide respiratory rate data from breathing belt.
-      # Notch filter requires either:
-      #     "breathing_rate_min" and "breathing_rate_max"
-      # or
-      #     "center_frequency" and "filter_bandwitdh".
-      # Lowpass filter requires either:
-      #     "breathing_rate_min"
-      # or
-      #     "lowpass_cutoff".
-      # If "breathing_rate_min" (for lowpass and notch filter)
-      # and "breathing_rate_max" (for notch filter) are set,
-      # the values set in "lowpass_cutoff" (for lowpass filter),
-      # "center_frequency" and "filter_bandwidth" (for notch filter)
-      # options are ignored.
+          # Dataset-wide respiratory rate data from breathing belt.
+          # Notch filter requires either:
+          #     "breathing_rate_min" and "breathing_rate_max"
+          # or
+          #     "center_frequency" and "filter_bandwitdh".
+          # Lowpass filter requires either:
+          #     "breathing_rate_min"
+          # or
+          #     "lowpass_cutoff".
+          # If "breathing_rate_min" (for lowpass and notch filter)
+          # and "breathing_rate_max" (for notch filter) are set,
+          # the values set in "lowpass_cutoff" (for lowpass filter),
+          # "center_frequency" and "filter_bandwidth" (for notch filter)
+          # options are ignored.
 
-      # Lowest Breaths-Per-Minute in dataset.
-      # For both notch and lowpass filters.
-      breathing_rate_min:
+          # Lowest Breaths-Per-Minute in dataset.
+          # For both notch and lowpass filters.
+          breathing_rate_min:
 
-      # Highest Breaths-Per-Minute in dataset.
-      # For notch filter.
-      breathing_rate_max:
+          # Highest Breaths-Per-Minute in dataset.
+          # For notch filter.
+          breathing_rate_max:
 
-      # notch filter direct customization parameters
+          # notch filter direct customization parameters
 
-      # mutually exclusive with breathing_rate options above.
-      # If breathing_rate_min and breathing_rate_max are provided,
-      # the following parameters will be ignored.
+          # mutually exclusive with breathing_rate options above.
+          # If breathing_rate_min and breathing_rate_max are provided,
+          # the following parameters will be ignored.
 
-      # the center frequency of the notch filter
-      center_frequency:
+          # the center frequency of the notch filter
+          center_frequency:
 
-      # the width of the notch filter
-      filter_bandwidth:
+          # the width of the notch filter
+          filter_bandwidth:
 
-      # lowpass filter direct customization parameter
+        - # options: "notch", "lowpass"
+          filter_type: "lowpass"
 
-      # mutually exclusive with breathing_rate options above.
-      # If breathing_rate_min is provided, the following
-      # parameter will be ignored.
+          # Number of filter coefficients.
+          filter_order: 4
 
-      # the frequency cutoff of the filter
-      lowpass_cutoff:
+          # Dataset-wide respiratory rate data from breathing belt.
+          # Notch filter requires either:
+          #     "breathing_rate_min" and "breathing_rate_max"
+          # or
+          #     "center_frequency" and "filter_bandwitdh".
+          # Lowpass filter requires either:
+          #     "breathing_rate_min"
+          # or
+          #     "lowpass_cutoff".
+          # If "breathing_rate_min" (for lowpass and notch filter)
+          # and "breathing_rate_max" (for notch filter) are set,
+          # the values set in "lowpass_cutoff" (for lowpass filter),
+          # "center_frequency" and "filter_bandwidth" (for notch filter)
+          # options are ignored.
+
+          # Lowest Breaths-Per-Minute in dataset.
+          # For both notch and lowpass filters.
+          breathing_rate_min:
+
+          # lowpass filter direct customization parameter
+
+          # mutually exclusive with breathing_rate options above.
+          # If breathing_rate_min is provided, the following
+          # parameter will be ignored.
+
+          # the frequency cutoff of the filter
+          lowpass_cutoff:
 
   distortion_correction:
 

--- a/CPAC/utils/bids_utils.py
+++ b/CPAC/utils/bids_utils.py
@@ -835,13 +835,13 @@ def combine_multiple_entity_instances(bids_str: str) -> str:
                      ] + suffixes)
 
 
-def insert_reg_entity(resource, reg_value):
-    """Insert a `reg-` BIDS entity before `desc-` if present or before
-    the suffix otherwise
+def insert_entity(resource, key, value):
+    """Insert a `f'{key}-{value}'` BIDS entity before `desc-` if
+    present or before the suffix otherwise
 
     Parameters
     ----------
-    resource, reg_value : str
+    resource, key, value : str
 
     Returns
     -------
@@ -849,10 +849,14 @@ def insert_reg_entity(resource, reg_value):
 
     Examples
     --------
-    >>> insert_reg_entity('run-1_desc-preproc_bold', 'default')
+    >>> insert_entity('run-1_desc-preproc_bold', 'reg', 'default')
     'run-1_reg-default_desc-preproc_bold'
-    >>> insert_reg_entity('run-1_bold', 'default')
+    >>> insert_entity('run-1_bold', 'reg', 'default')
     'run-1_reg-default_bold'
+    >>> insert_entity('run-1_desc-preproc_bold', 'filt', 'notch4c0p31bw0p12')
+    'run-1_filt-notch4c0p31bw0p12_desc-preproc_bold'
+    >>> insert_entity('run-1_reg-default_bold', 'filt', 'notch4c0p31bw0p12')
+    'run-1_reg-default_filt-notch4c0p31bw0p12_bold'
     """
     entities = resource.split('_')[:-1]
     suff = resource.split('_')[-1]
@@ -862,7 +866,7 @@ def insert_reg_entity(resource, reg_value):
             new_entities[1].append(entity)
         else:
             new_entities[0].append(entity)
-    return '_'.join([*new_entities[0], f'reg-{reg_value}', *new_entities[1],
+    return '_'.join([*new_entities[0], f'{key}-{value}', *new_entities[1],
                      suff])
 
 

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -232,7 +232,6 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
         out_filename = out_filename.replace('_space-T1w_', '_')
     if subdir == 'func':
         out_filename = out_filename.replace('_space-bold_', '_')
-
     return combine_multiple_entity_instances(out_filename)
 
 

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -232,6 +232,7 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
         out_filename = out_filename.replace('_space-T1w_', '_')
     if subdir == 'func':
         out_filename = out_filename.replace('_space-bold_', '_')
+
     return combine_multiple_entity_instances(out_filename)
 
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1711 by @shnizzedy & @pab2163

## Description
<!-- Concisely describe what the pull request does. -->
1. Changes `functional_preproc.motion_estimates_and_correction.motion_estimate_filter` from a single filter to a list of filters
2. Forks on that list and/or `run`: `On` / `Off`

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

* This change will require an update to the GUI to generate filters similar to how [regressors and handled specially](https://github.com/FCP-INDI/C-PAC_GUI/blob/5ad6968d6b024191e6426253ee81e464b0f2ba88/app/containers/pipeline/parts/Regressor.jsx).
* In [a :thread: in ![Slack](https://camo.githubusercontent.com/4a2280bbe1168cbab989535aae3624962d9d03df0907f6cd3012ecc5ebb41b24/68747470733a2f2f63646e2e6272616e64666f6c6465722e696f2f35483434324f33572f61742f706c3534366a2d376c65387a6b2d36677769796f2f536c61636b5f4d61726b2e706e673f77696474683d3132266865696768743d3132)`DANLAB/C-PAC#general`](https://danlabc-pac.slack.com/archives/C01AESSCX8W/p1668445438731809?thread_ts=1668202061.902569&cid=C01AESSCX8W) we've been discussing naming conventions for these regressors, but I think that would be fine to update subsequently if needed.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/e03d95a30f6141a8ed7de7ff81f9e978ad9d699e/CPAC/pipeline/schema.py#L265-L283 https://github.com/FCP-INDI/C-PAC/blob/e03d95a30f6141a8ed7de7ff81f9e978ad9d699e/CPAC/pipeline/test/test_schema_validation.py#L8-L42

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Given a config with
```YAML
func_preproc:
  motion_estimates_and_correction:
    motion_estimate_filter:
      run: [On, Off]
      filters:
        - filter_type: notch
          filter_order: 4
          center_frequency: 0.31
          filter_bandwidth: 0.12
        - filter_type: notch
          filter_order: 4
          center_frequency: 0.28
          filter_bandwidth: 0.12
        - filter_type: notch
          filter_order: 4
          center_frequency: 0.28
          filter_bandwidth: 0.12
nuisance_corrections:
  2-nuisance_regression:
    run: [On, Off]
    Regressors:
      - Name: 36-parameter
      - Name: aCompCor
```

The functional derivatives section of `expectedOutputs` looks like
```YAML
func:
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-maxDisplacement*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-relsDisplacement*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-36Parameter*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-36Parameter*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-36Parameter*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-36Parameter*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_dvars
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_framewiseDisplacementJenkinson
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_framewiseDisplacementPower
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_motionFilterInfo
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_motionFilterPlot
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_motionParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_movementParameters
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-Off*_powerParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-aCompCor*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-aCompCor*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-aCompCor*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-none*_reg-aCompCor*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-36Parameter*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-36Parameter*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-36Parameter*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-36Parameter*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-Off*_dvars
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-Off*_framewiseDisplacementJenkinson
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-Off*_framewiseDisplacementPower
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-Off*_motionParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-Off*_movementParameters
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-Off*_powerParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-aCompCor*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-aCompCor*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-aCompCor*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12*_reg-aCompCor*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-36Parameter*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-36Parameter*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-36Parameter*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-36Parameter*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-Off*_dvars
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-Off*_framewiseDisplacementJenkinson
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-Off*_framewiseDisplacementPower
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-Off*_motionParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-Off*_movementParameters
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-Off*_powerParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-aCompCor*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-aCompCor*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-aCompCor*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p28bw0p12dup1*_reg-aCompCor*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-36Parameter*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-36Parameter*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-36Parameter*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-36Parameter*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-Off*_dvars
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-Off*_framewiseDisplacementJenkinson
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-Off*_framewiseDisplacementPower
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-Off*_motionParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-Off*_movementParameters
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-Off*_powerParams
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-aCompCor*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-aCompCor*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-aCompCor*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_filt-notch4fc0p31bw0p12*_reg-aCompCor*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-none*_reg-36Parameter*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-none*_reg-aCompCor*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-notch4fc0p28bw0p12*_reg-36Parameter*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-notch4fc0p28bw0p12*_reg-aCompCor*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-notch4fc0p28bw0p12dup1*_reg-36Parameter*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-notch4fc0p28bw0p12dup1*_reg-aCompCor*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-notch4fc0p31bw0p12*_reg-36Parameter*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_filt-notch4fc0p31bw0p12*_reg-aCompCor*_desc-xcp*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-T1w*_sbref
```



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (https://github.com/FCP-INDI/fcp-indi.github.io/pull/294).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
