### PR TITLE
✅ Smoke tests: Fix failing

### DIFF
--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -36,21 +36,22 @@ jobs:
           - fx-options
           - ndmg
           - preproc
-          # - rbc-options
-          # - regtest-1
-          # - regtest-2
-          # - regtest-3
-          # - regtest-4
+          - rbc-options
+          - regtest-1
+          - regtest-2
+          - regtest-3
+          - regtest-4
         variant:
           - ''
-          - lite
-          - ABCD-HCP
-          - fMRIPrep-LTS
         participant:
-          - 1019436 2014113 3154996 3699991 3884955  # ADHD200
-          - NDARAA504CRN NDARAA947ZG5 NDARAB348EWR NDARAB458VK9  # HBN with EPI field maps
-          - NDARAD481FXF NDARAV894XWD NDARCA186WGH  # HBN with gradient echo field maps
-          - 0025428 0025429 0025448 0025452 0025453 # CoRR HNU
+          - 1019436 2014113 3154996 3699991 3884955 NDARAA504CRN NDARAA947ZG5 NDARAB348EWR NDARAB458VK9 NDARAD481FXF NDARAV894XWD NDARCA186WGH 0025428 0025429 0025448 0025452 0025453
+        include:
+          - preconfig: default
+            variant: lite
+          - preconfig: abcd-options
+            variant: ABCD-HCP
+          - preconfig: fmriprep-options
+            variant: fMRIPrep-LTS
     steps:
       - name: Get C-PAC
         run: |
@@ -113,25 +114,15 @@ jobs:
       matrix:
         preconfig:
           - monkey
-          # - monkey-ABCD
           - nhp-macaque
         variant:
           - ''
-          - lite
-          - ABCD-HCP
-          - fMRIPrep-LTS
         participant:
-          - 032102 032106 # Newcastle
-          - 032164 032167 # Oxford
-          - 032130 032128 # UC Davis
-          - 2215 2312 # UW Madison
-          - 032191 032195 # UWO
-        exclude:
-          # No T2w
+          - 032102 032106 032164 032167 032130 032128 2215 2312 032191 032195
+        include:
+          # requires T2w
           - preconfig: monkey-ABCD
-            participant: 2215 2312
-          - preconfig: monkey-ABCD
-            participant: 032164 032167
+            participant: 032102 032106 032130 032128 032191 032195
     steps:
       - name: Get C-PAC
         run: |
@@ -193,9 +184,6 @@ jobs:
       matrix:
         variant:
           - ''
-          - lite
-          - ABCD-HCP
-          - fMRIPrep-LTS
     steps:
       - name: Get C-PAC
         run: |

--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -48,10 +48,13 @@ jobs:
         include:
           - preconfig: default
             variant: lite
+            participant: 1019436 2014113 3154996 3699991 3884955 NDARAA504CRN NDARAA947ZG5 NDARAB348EWR NDARAB458VK9 NDARAD481FXF NDARAV894XWD NDARCA186WGH 0025428 0025429 0025448 0025452 0025453
           - preconfig: abcd-options
             variant: ABCD-HCP
+            participant: 1019436 2014113 3154996 3699991 3884955 NDARAA504CRN NDARAA947ZG5 NDARAB348EWR NDARAB458VK9 NDARAD481FXF NDARAV894XWD NDARCA186WGH 0025428 0025429 0025448 0025452 0025453
           - preconfig: fmriprep-options
             variant: fMRIPrep-LTS
+            participant: 1019436 2014113 3154996 3699991 3884955 NDARAA504CRN NDARAA947ZG5 NDARAB348EWR NDARAB458VK9 NDARAD481FXF NDARAV894XWD NDARCA186WGH 0025428 0025429 0025448 0025452 0025453
     steps:
       - name: Get C-PAC
         run: |
@@ -122,6 +125,10 @@ jobs:
         include:
           # requires T2w
           - preconfig: monkey-ABCD
+            variant: ''
+            participant: 032102 032106 032130 032128 032191 032195
+          - preconfig: monkey-ABCD
+            variant: ABCD-HCP
             participant: 032102 032106 032130 032128 032191 032195
     steps:
       - name: Get C-PAC

--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -105,7 +105,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: expectedOutputs human ${{ matrix.preconfig }} ${{ matrix.variant }} ${{ matrix.participant }}
-          path: outputs/log/pipeline_*/sub-*/*_expectedOutputs.yml
+          path: outputs/log/pipeline_*/*/*_expectedOutputs.yml
           if-no-files-found: ignore
   smoke_test_nhp:
     name: Non-human primate ${{ matrix.preconfig }} participant smoke tests
@@ -179,7 +179,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: expectedOutputs nhp ${{ matrix.preconfig }} ${{ matrix.variant }} ${{ matrix.participant }}
-          path: outputs/log/pipeline_*/sub-*/*_expectedOutputs.yml
+          path: outputs/log/pipeline_*/*/*_expectedOutputs.yml
           if-no-files-found: ignore
   smoke_test_rodent:
     name: Rodent participant smoke tests
@@ -239,7 +239,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: expectedOutputs rodent ${{ matrix.variant }}
-          path: outputs/log/pipeline_*/sub-*/*_expectedOutputs.yml
+          path: outputs/log/pipeline_*/*/*_expectedOutputs.yml
           if-no-files-found: ignore
   finish-check:
     name: Finish GitHub check

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1957,7 +1957,7 @@ def brain_extraction_temp(wf, cfg, strat_pool, pipe_num, opt=None):
          "desc-preproc_T1w": {
              "SkullStripped": "True"},
          "desc-tempbrain_T1w": {
-             "SkullStripped": "True"}}
+             "SkullStripped": "True"}}}
     '''
 
     anat_skullstrip_orig_vol = pe.Node(interface=afni.Calc(),

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -2851,7 +2851,7 @@ def coregistration(wf, cfg, strat_pool, pipe_num, opt=None):
                  "T2w",
                  ["label-WM_probseg", "label-WM_mask"],
                  ["label-WM_pveseg", "label-WM_mask"],
-                 "desc-head_T1w")],
+                 "desc-head_T1w", "desc-head_T2w")],
      "outputs": ["space-T1w_sbref",
                  "from-bold_to-T1w_mode-image_desc-linear_xfm",
                  "from-bold_to-T1w_mode-image_desc-linear_warp"]}

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1386,6 +1386,7 @@ amplitude_low_frequency_fluctuation:
   # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF (f/ALFF) for all voxels.
   run: Off
 
+  # space: Template or Native
   target_space: []
 
   # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
@@ -1567,8 +1568,8 @@ post_processing:
     fwhm: [4]
 
   z-scoring:
-
     run: Off
+
     # z-score standardize the derivatives. This may be needed for group-level analysis.
     # Set as ['raw'] to disable z-scoring. Set as ['z-scored', 'raw'] to get both.
     #

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1545,7 +1545,6 @@ longitudinal_template_generation:
 # -----------------------
 post_processing:
   spatial_smoothing:
-
     run: Off
 
     # Smooth the derivative outputs.

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1401,6 +1401,8 @@ regional_homogeneity:
   # Calculate Regional Homogeneity (ReHo) for all voxels.
   run: Off
 
+  target_space: []
+
   # Number of neighboring voxels used when calculating ReHo
   # 7 (Faces)
   # 19 (Faces + Edges)

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1566,6 +1566,7 @@ post_processing:
 
   z-scoring:
 
+    run: Off
     # z-score standardize the derivatives. This may be needed for group-level analysis.
     # Set as ['raw'] to disable z-scoring. Set as ['z-scored', 'raw'] to get both.
     #

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1401,6 +1401,7 @@ regional_homogeneity:
   # Calculate Regional Homogeneity (ReHo) for all voxels.
   run: Off
 
+  # space: Template or Native
   target_space: []
 
   # Number of neighboring voxels used when calculating ReHo

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1386,6 +1386,8 @@ amplitude_low_frequency_fluctuation:
   # Calculate Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF (f/ALFF) for all voxels.
   run: Off
 
+  target_space: []
+
   # Frequency cutoff (in Hz) for the high-pass filter used when calculating f/ALFF.
   highpass_cutoff: [0.01]
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1546,6 +1546,8 @@ longitudinal_template_generation:
 post_processing:
   spatial_smoothing:
 
+    run: Off
+
     # Smooth the derivative outputs.
     # Set as ['nonsmoothed'] to disable smoothing. Set as ['smoothed', 'nonsmoothed'] to get both.
     #

--- a/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
@@ -528,6 +528,7 @@ network_centrality:
 # -----------------------
 post_processing:
   spatial_smoothing:
+    run: On
 
     # Smooth the derivative outputs.
     # Set as ['nonsmoothed'] to disable smoothing. Set as ['smoothed', 'nonsmoothed'] to get both.
@@ -535,7 +536,6 @@ post_processing:
     # Options:
     #     ['smoothed', 'nonsmoothed']
     output: [smoothed, nonsmoothed]
-    run: On
 
   z-scoring:
     run: On

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -428,12 +428,12 @@ network_centrality:
 # -----------------------
 post_processing:
   spatial_smoothing:
+    run: On
 
     # Tool to use for smoothing.
     # 'FSL' for FSL MultiImageMaths for FWHM provided
     # 'AFNI' for AFNI 3dBlurToFWHM for FWHM provided
     smoothing_method: [AFNI]
-    run: On
 
   z-scoring:
     run: On

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -202,6 +202,13 @@ functional_preproc:
     # this is a fork point
     using: [FSL_AFNI]
 
+    FSL_AFNI:
+      bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
+
+      brain_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
+
+      brain_probseg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
+
   generate_func_mean:
 
     # Generate mean functional image

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -194,8 +194,6 @@ functional_preproc:
   func_masking:
     FSL_AFNI:
       bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
-      brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-      brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
 
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based', 'Anatomical_Resampled', 'CCS_Anatomical_Refined']
     # FSL_AFNI: fMRIPrep-style BOLD mask. Ref: https://github.com/nipreps/niworkflows/blob/a221f612/niworkflows/func/util.py#L246-L514

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -192,6 +192,10 @@ functional_preproc:
     run: [On]
 
   func_masking:
+    FSL_AFNI:
+      bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
+      brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
+      brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
 
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based', 'Anatomical_Resampled', 'CCS_Anatomical_Refined']
     # FSL_AFNI: fMRIPrep-style BOLD mask. Ref: https://github.com/nipreps/niworkflows/blob/a221f612/niworkflows/func/util.py#L246-L514
@@ -201,13 +205,6 @@ functional_preproc:
     # CCS_Anatomical_Refined: Generate the BOLD mask by basing it off of the anatomical brain. Adapted from the BOLD mask method from the CCS pipeline.
     # this is a fork point
     using: [FSL_AFNI]
-
-    FSL_AFNI:
-      bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
-
-      brain_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-
-      brain_probseg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
 
   generate_func_mean:
 

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -431,12 +431,12 @@ network_centrality:
 # -----------------------
 post_processing:
   spatial_smoothing:
+    run: On
 
     # Tool to use for smoothing.
     # 'FSL' for FSL MultiImageMaths for FWHM provided
     # 'AFNI' for AFNI 3dBlurToFWHM for FWHM provided
     smoothing_method: [AFNI]
-    run: On
 
   z-scoring:
     run: On

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -142,20 +142,6 @@ registration_workflows:
   anatomical_registration:
     run: On
     registration:
-      FSL-FNIRT:
-
-        # Reference mask with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
-
-        # Template with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
-        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm.nii.gz
-
-        # Reference mask for FSL registration.
-        ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-
-        # Identity matrix used during FSL-based resampling of anatomical-space data throughout the pipeline.
-        # It is not necessary to change this path unless you intend to use a different template.
-        identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
 
       # using: ['ANTS', 'FSL', 'FSL-linear']
       # this is a fork point

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -142,119 +142,25 @@ registration_workflows:
   anatomical_registration:
     run: On
     registration:
+      FSL-FNIRT:
+
+        # Reference mask with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
+        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
+
+        # Template with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm.nii.gz
+
+        # Reference mask for FSL registration.
+        ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
+
+        # Identity matrix used during FSL-based resampling of anatomical-space data throughout the pipeline.
+        # It is not necessary to change this path unless you intend to use a different template.
+        identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
 
       # using: ['ANTS', 'FSL', 'FSL-linear']
       # this is a fork point
       #   selecting both ['ANTS', 'FSL'] will run both and fork the pipeline
       using: [ANTS, FSL]
-
-      # option parameters
-      # option parameters
-      ANTs:
-
-        # If a lesion mask is available for a T1w image, use it to improve the ANTs' registration
-        # ANTS registration only.
-        use_lesion_mask: False
-
-        # ANTs parameters for T1-template-based registration
-        T1_registration:
-
-          - collapse-output-transforms: 0
-          - dimensionality: 3
-          - initial-moving-transform :
-             initializationFeature: 0
-
-          - transforms:
-             - Rigid:
-                 gradientStep : 0.1
-                 metric :
-                   type : MI
-                   metricWeight: 1
-                   numberOfBins : 32
-                   samplingStrategy : Regular
-                   samplingPercentage : 0.25
-                 convergence:
-                   iteration : 1000x500x250x100
-                   convergenceThreshold : 1e-08
-                   convergenceWindowSize : 10
-                 smoothing-sigmas : 3.0x2.0x1.0x0.0
-                 shrink-factors : 8x4x2x1
-                 use-histogram-matching : True
-
-             - Affine:
-                 gradientStep : 0.1
-                 metric :
-                   type : MI
-                   metricWeight: 1
-                   numberOfBins : 32
-                   samplingStrategy : Regular
-                   samplingPercentage : 0.25
-                 convergence:
-                   iteration : 1000x500x250x100
-                   convergenceThreshold : 1e-08
-                   convergenceWindowSize : 10
-                 smoothing-sigmas : 3.0x2.0x1.0x0.0
-                 shrink-factors : 8x4x2x1
-                 use-histogram-matching : True
-
-             - SyN:
-                 gradientStep : 0.1
-                 updateFieldVarianceInVoxelSpace : 3.0
-                 totalFieldVarianceInVoxelSpace : 0.0
-                 metric:
-                   type : CC
-                   metricWeight: 1
-                   radius : 4
-                 convergence:
-                   iteration : 100x100x70x20
-                   convergenceThreshold : 1e-09
-                   convergenceWindowSize : 15
-                 smoothing-sigmas : 3.0x2.0x1.0x0.0
-                 shrink-factors : 6x4x2x1
-                 use-histogram-matching : True
-                 winsorize-image-intensities :
-                   lowerQuantile : 0.01
-                   upperQuantile : 0.99
-
-        # Interpolation method for writing out transformed anatomical images.
-        # Possible values: Linear, BSpline, LanczosWindowedSinc
-        interpolation: LanczosWindowedSinc
-
-      FSL-FNIRT:
-
-        # Configuration file to be used by FSL to set FNIRT parameters.
-        # It is not necessary to change this path unless you intend to use custom FNIRT parameters or a non-standard template.
-        fnirt_config: T1_2_MNI152_2mm
-
-        # The resolution to which anatomical images should be transformed during registration.
-        # This is the resolution at which processed anatomical files will be output. 
-        # specifically for monkey pipeline
-        ref_resolution: 2mm
-
-        # Reference mask for FSL registration.
-        ref_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        
-        # Template to be used during registration.
-        # It is for monkey pipeline specifically. 
-        FNIRT_T1w_brain_template: None
-
-        # Template to be used during registration.
-        # It is for monkey pipeline specifically. 
-        FNIRT_T1w_template: None
-        
-        # Interpolation method for writing out transformed anatomical images.
-        # Possible values: trilinear, sinc, spline
-        interpolation: sinc
-
-        # Identity matrix used during FSL-based resampling of anatomical-space data throughout the pipeline.
-        # It is not necessary to change this path unless you intend to use a different template.
-        identity_matrix: /usr/share/fsl/5.0/etc/flirtsch/ident.mat
-
-        # Reference mask with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
-        ref_mask_res-2: /usr/share/fsl/5.0/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
-
-        # Template with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
-        T1w_template_res-2: /usr/share/fsl/5.0/data/standard/MNI152_T1_2mm.nii.gz
 
     # Register skull-on anatomical image to a template.
     reg_with_skull: Off

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -149,10 +149,112 @@ registration_workflows:
       using: [ANTS, FSL]
 
       # option parameters
+      # option parameters
       ANTs:
+
+        # If a lesion mask is available for a T1w image, use it to improve the ANTs' registration
+        # ANTS registration only.
+        use_lesion_mask: False
 
         # ANTs parameters for T1-template-based registration
         T1_registration:
+
+          - collapse-output-transforms: 0
+          - dimensionality: 3
+          - initial-moving-transform :
+             initializationFeature: 0
+
+          - transforms:
+             - Rigid:
+                 gradientStep : 0.1
+                 metric :
+                   type : MI
+                   metricWeight: 1
+                   numberOfBins : 32
+                   samplingStrategy : Regular
+                   samplingPercentage : 0.25
+                 convergence:
+                   iteration : 1000x500x250x100
+                   convergenceThreshold : 1e-08
+                   convergenceWindowSize : 10
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 8x4x2x1
+                 use-histogram-matching : True
+
+             - Affine:
+                 gradientStep : 0.1
+                 metric :
+                   type : MI
+                   metricWeight: 1
+                   numberOfBins : 32
+                   samplingStrategy : Regular
+                   samplingPercentage : 0.25
+                 convergence:
+                   iteration : 1000x500x250x100
+                   convergenceThreshold : 1e-08
+                   convergenceWindowSize : 10
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 8x4x2x1
+                 use-histogram-matching : True
+
+             - SyN:
+                 gradientStep : 0.1
+                 updateFieldVarianceInVoxelSpace : 3.0
+                 totalFieldVarianceInVoxelSpace : 0.0
+                 metric:
+                   type : CC
+                   metricWeight: 1
+                   radius : 4
+                 convergence:
+                   iteration : 100x100x70x20
+                   convergenceThreshold : 1e-09
+                   convergenceWindowSize : 15
+                 smoothing-sigmas : 3.0x2.0x1.0x0.0
+                 shrink-factors : 6x4x2x1
+                 use-histogram-matching : True
+                 winsorize-image-intensities :
+                   lowerQuantile : 0.01
+                   upperQuantile : 0.99
+
+        # Interpolation method for writing out transformed anatomical images.
+        # Possible values: Linear, BSpline, LanczosWindowedSinc
+        interpolation: LanczosWindowedSinc
+
+      FSL-FNIRT:
+
+        # Configuration file to be used by FSL to set FNIRT parameters.
+        # It is not necessary to change this path unless you intend to use custom FNIRT parameters or a non-standard template.
+        fnirt_config: T1_2_MNI152_2mm
+
+        # The resolution to which anatomical images should be transformed during registration.
+        # This is the resolution at which processed anatomical files will be output. 
+        # specifically for monkey pipeline
+        ref_resolution: 2mm
+
+        # Reference mask for FSL registration.
+        ref_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
+        
+        # Template to be used during registration.
+        # It is for monkey pipeline specifically. 
+        FNIRT_T1w_brain_template: None
+
+        # Template to be used during registration.
+        # It is for monkey pipeline specifically. 
+        FNIRT_T1w_template: None
+        
+        # Interpolation method for writing out transformed anatomical images.
+        # Possible values: trilinear, sinc, spline
+        interpolation: sinc
+
+        # Identity matrix used during FSL-based resampling of anatomical-space data throughout the pipeline.
+        # It is not necessary to change this path unless you intend to use a different template.
+        identity_matrix: /usr/share/fsl/5.0/etc/flirtsch/ident.mat
+
+        # Reference mask with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
+        ref_mask_res-2: /usr/share/fsl/5.0/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
+
+        # Template with 2mm resolution to be used during FNIRT-based brain extraction in ABCD-options pipeline.
+        T1w_template_res-2: /usr/share/fsl/5.0/data/standard/MNI152_T1_2mm.nii.gz
 
     # Register skull-on anatomical image to a template.
     reg_with_skull: Off

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -392,6 +392,7 @@ voxel_mirrored_homotopic_connectivity:
 # -----------------------
 post_processing:
   spatial_smoothing:
+    run: On
 
     # Tool to use for smoothing.
     # 'FSL' for FSL MultiImageMaths for FWHM provided
@@ -402,7 +403,6 @@ post_processing:
     # this is a fork point
     #   i.e. multiple kernels - fwhm: [4,6,8]
     fwhm: [6]
-    run: On
 
   z-scoring:
     run: On


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
<table><tr><th>fixes</th><th>in</th></tr>
<tr><td><code>KeyError: 'run'</code></td><td>ff0172fc1a336947407e0ad7435fd8de5490e088</td></tr>
<tr><td>
#1840 /

```Python
LookupError: When trying to connect node block 'alff_falff_space_template' to workflow 'cpac_0025453_10' after node block 'timeseries_extraction_AVG': 

[!] C-PAC says: None of the listed resources are in the resource pool:

  space-template_res-derivative_desc-bold_mask
```

</td><td>#1841?</td></tr>
<tr><td>

```Python
LookupError: When trying to connect node block 'bold_mask_ccs' to workflow 'cpac_0025453_10' after node block 'motion_correction_only': 

[!] C-PAC says: None of the listed resources are in the resource pool:

  FSL-AFNI-bold-ref
```

</td><td>4f08a322aa2101a94cea1ff8328a5625afa35d49</td></tr>
<tr><td>

```Python
Exception: 

[!] C-PAC says: 
You have selected ANTs as your anatomical registration method.
However, no ANTs parameters were specified.
Please specify ANTs parameters properly and try again.
```

</td><td>3f1d1edde3dc5482d649fe8a6d8b086ded99fb6b</td></tr>
<tr><td>

```Python
    {"name": "brain_extraction_temp",
     "config": "None",
     "switch": "None",
     "option_key": "None",
     "option_val": "None",
     "inputs": [("desc-preproc_T1w",
                 ["space-T1w_desc-brain_mask", "space-T1w_desc-acpcbrain_mask"])],
     "outputs": {
         "desc-preproc_T1w": {
             "SkullStripped": "True"},
         "desc-tempbrain_T1w": {
             "SkullStripped": "True"}}
                                      ^
SyntaxError: unexpected EOF while parsing
```

</td><td>f9ece7341801615b9a19823ef4b229118ae678c2</td></tr>
<tr><td rowspan="2"><code>KeyError: 'target_space'</code></td><td>d384de0297b54ac9ee047351b3c28e4e1b1a81eb</td></tr><tr><td>ae5edbfd7</td></tr>
<tr><td>

```Python
LookupError: When trying to connect node block 'coregistration' to workflow 'cpac_sub-032191_ses-001' after node block 'coregistration_prep_fmriprep': 

[!] C-PAC says: None of the listed resources are in the resource pool:

  desc-head_T2w
```

</td><td>b0a63f2</td></tr>
</table>


## Description
<!-- Concisely describe what the pull request does. -->
* Consolidates the number of smoke tests from 220 to 24 by
   * combining all participants into a single test-run
   * running all preconfigs in default container and only running select pipelines in variant containers
* Turns smoke tests back on for previously-commented-out preconfigs


## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### Before
[![https://github.com/FCP-INDI/C-PAC/actions/runs/3465896254](https://user-images.githubusercontent.com/5974438/202024120-7177a2fc-182a-4b14-9712-ed1d65be5991.png)](https://github.com/FCP-INDI/C-PAC/actions/runs/3465896254)

### After
[![https://github.com/FCP-INDI/C-PAC/actions/runs/3474045359](https://user-images.githubusercontent.com/5974438/202029233-f89fbbed-c6f3-4e1b-a0ec-1bfe88624606.png)](https://github.com/FCP-INDI/C-PAC/actions/runs/3474045359) [![https://github.com/FCP-INDI/C-PAC/actions/runs/3474045359](https://user-images.githubusercontent.com/5974438/202029477-7cca9434-5582-4fd1-9faa-3654cf16d19f.png)](https://github.com/FCP-INDI/C-PAC/actions/runs/3474045359)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
