### PR TITLE
👔 Climb the provenance tree to set template name

### DIFF
--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -968,13 +968,24 @@ class ResourcePool:
                                         json_info in all_jsons if
                                         'CpacVariant' in json_info and
                                         'bold' in json_info['CpacVariant']))
-                # any(not) because all is overloaded as a parameter here
-                if any(not re.match(r'apply_(phasediff|blip)_to_timeseries_'
-                                    r'separately_.*', _bold) for
-                       _bold in all_bolds):
+                # not any(not) because all is overloaded as a parameter here
+                if not any(not re.match(r'apply_(phasediff|blip)_to_'
+                                        r'timeseries_separately_.*', _bold)
+                           for _bold in all_bolds):
                     # this fork point should only result in 0 or 1 forks
                     unlabelled.remove('bold')
                 del all_bolds
+            all_forks = {key: set(
+                chain.from_iterable(json_info['CpacVariant'][key] for
+                                    json_info in all_jsons if
+                                    'CpacVariant' in json_info and
+                                    key in json_info['CpacVariant'])) for
+                key in unlabelled}
+            # del all_jsons
+            for key, forks in all_forks.items():
+                if len(forks) < 2:  # no int suffix needed if only one fork
+                    unlabelled.remove(key)
+            # del all_forks
             for pipe_idx in self.rpool[resource]:
                 pipe_x = self.get_pipe_number(pipe_idx)
                 json_info = self.rpool[resource][pipe_idx]['json']

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -130,11 +130,15 @@ class ResourcePool:
               len(json_info.get('CpacProvenance', [])) > 1):
             try:
                 # check parent resource
-                parent_resource = list(self.get(
-                    json_info['CpacProvenance'][-2][-1].split(':')[0]
-                ).items())[0]
-                if (ast.literal_eval(parent_resource[0])[0].split(':')[0] in
-                    json_info.get('Sources', []) and
+                parent = json_info['CpacProvenance'][-2]
+                while isinstance(parent, list):
+                    parent = parent[-1]
+                parent_resource = list(self.get(parent.split(':')[0]).items()
+                                       )[0]
+                parent = ast.literal_eval(parent_resource[0])
+                while isinstance(parent, list):
+                    parent = parent[0]
+                if (parent[0].split(':')[0] in json_info.get('Sources', []) and
                     'json' in parent_resource[1] and
                         'Description' in parent_resource[1]['json']):
                     id_string.inputs.template_desc = (

--- a/CPAC/pipeline/utils.py
+++ b/CPAC/pipeline/utils.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2021-2022  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""C-PAC pipeline engine utilities"""
+from typing import Union
+
+
+def source_set(sources: Union[str, list, set]) -> set:
+    """Given a CpacProvenance, return a set of {resource}:{source} strings
+  
+    Parameters
+    ----------
+    sources: str, list, or set
+
+    Returns
+    -------
+    set
+
+    Examples
+    --------
+    >>> source_set([[[['bold:func_ingress',
+    ...       'desc-preproc_bold:func_reorient',
+    ...       'desc-preproc_bold:func_truncate'],
+    ...      ['TR:func_metadata_ingress'],
+    ...      ['tpattern:func_metadata_ingress'],
+    ...      'desc-preproc_bold:func_slice_time'],
+    ...     [['bold:func_ingress',
+    ...       'desc-preproc_bold:func_reorient',
+    ...       'desc-preproc_bold:func_truncate'],
+    ...      ['bold:func_ingress', 'desc-reorient_bold:func_reorient'],
+    ...      'motion-basefile:get_motion_ref_fmriprep_reference'],
+    ...     'desc-preproc_bold:motion_correction_only_mcflirt'],
+    ...         [[['bold:func_ingress',
+    ...           'desc-preproc_bold:func_reorient',
+    ...           'desc-preproc_bold:func_truncate'],
+    ...      ['bold:func_ingress', 'desc-reorient_bold:func_reorient'],
+    ...      'motion-basefile:get_motion_ref_fmriprep_reference'],
+    ...     [[['bold:func_ingress',
+    ...        'desc-preproc_bold:func_reorient',
+    ...        'desc-preproc_bold:func_truncate'],
+    ...       ['TR:func_metadata_ingress'],
+    ...       ['tpattern:func_metadata_ingress'],
+    ...       'desc-preproc_bold:func_slice_time'],
+    ...      [['bold:func_ingress',
+    ...        'desc-preproc_bold:func_reorient',
+    ...        'desc-preproc_bold:func_truncate'],
+    ...       ['bold:func_ingress', 'desc-reorient_bold:func_reorient'],
+    ...       'motion-basefile:get_motion_ref_fmriprep_reference'],
+    ...      'desc-preproc_bold:motion_correction_only_mcflirt'],
+    ...     ['FSL-AFNI-bold-ref:template_resample'],
+    ...     ['FSL-AFNI-brain-mask:template_resample'],
+    ...     ['FSL-AFNI-brain-probseg:template_resample'],
+    ...     'space-bold_desc-brain_mask:bold_mask_fsl_afni'],
+    ...     'desc-preproc_bold:bold_masking']) == set({
+    ...     'FSL-AFNI-bold-ref:template_resample',
+    ...     'FSL-AFNI-brain-mask:template_resample',
+    ...     'FSL-AFNI-brain-probseg:template_resample',
+    ...     'TR:func_metadata_ingress',
+    ...     'bold:func_ingress',
+    ...     'desc-preproc_bold:bold_masking',
+    ...     'desc-preproc_bold:func_reorient',
+    ...     'desc-preproc_bold:func_slice_time',
+    ...     'desc-preproc_bold:func_truncate',
+    ...     'desc-preproc_bold:motion_correction_only_mcflirt',
+    ...     'desc-reorient_bold:func_reorient',
+    ...     'motion-basefile:get_motion_ref_fmriprep_reference',
+    ...     'space-bold_desc-brain_mask:bold_mask_fsl_afni',
+    ...     'tpattern:func_metadata_ingress'})
+    True
+    """
+    _set = set()
+    if isinstance(sources, str):
+        _set.add(sources)
+    if isinstance(sources, (set, list)):
+        for item in sources:
+            _set.update(source_set(item))
+    return _set


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes
* > The expectedOutputs after [that merge](https://github.com/FCP-INDI/C-PAC/pull/1841) still have some `space-template` derivatives.
  > ![screenshot of expectedOutputs with `space-template` filenames](https://user-images.githubusercontent.com/5974438/202276034-1c648c6d-9c5b-458a-9575-bbe2e6c5e36d.png)

   by @shnizzedy

* Some unintended behavior where unnamed forks in a forking pipeline were getting collapsed into a single output in a chain like  `desc-1_vmhc` → `desc-1_desc-1_vmhc` → `desc-1_desc-1_desc-1_vmhc` → `desc-111_vmhc`

## Description
<!-- Concisely describe what the pull request does. -->
For `space-template` resources that don't have `Template` specified, climb the `CpacProvenance` recursively until either finding a `Template` (in which case it applies the first one it finds ― the assumption is we're not changing templates along the way) or it reaches the root of the tree (in which case it remains `space-template`)

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![screenshot of expectedOutputs with updated `space-` values](https://user-images.githubusercontent.com/5974438/202276693-da11929a-e62e-40ff-9281-dab782ae6a87.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
