### PR TITLE
easy_thresh: Add missing imports; Fix regex escaping

### DIFF
--- a/CPAC/easy_thresh/easy_thresh.py
+++ b/CPAC/easy_thresh/easy_thresh.py
@@ -1,4 +1,8 @@
+import os
+import re
+import subprocess
 
+import nibabel as nib
 from CPAC.pipeline import nipype_pipeline_engine as pe
 import nipype.interfaces.fsl as fsl
 import nipype.interfaces.utility as util
@@ -351,7 +355,7 @@ def easy_thresh(wf_name):
 
 def call_cluster(in_file, volume, dlh, threshold, pthreshold, parameters):
 
-    out_name = re.match('z(\w)*stat(\d)+', os.path.basename(in_file))
+    out_name = re.match(r'z(\w)*stat(\d)+', os.path.basename(in_file))
 
     filename, ext = os.path.splitext(os.path.basename(in_file))
     ext=  os.path.splitext(filename)[1] + ext
@@ -372,7 +376,7 @@ def call_cluster(in_file, volume, dlh, threshold, pthreshold, parameters):
 
     f = open(localmax_txt_file,'wb')
 
-    cmd = sb.Popen([ cmd_path,
+    cmd = subprocess.Popen([ cmd_path,
                     '--dlh=' + str(dlh),
                     '--in=' + in_file,
                     '--oindex=' + index_file,
@@ -451,7 +455,7 @@ def get_standard_background_img(in_file, file_parameters):
 
     try:
 
-        img = load(in_file)
+        img = nib.load(in_file)
         hdr = img.get_header()
         group_mm = int(hdr.get_zooms()[2])
         FSLDIR, MNI = file_parameters

--- a/CPAC/easy_thresh/easy_thresh.py
+++ b/CPAC/easy_thresh/easy_thresh.py
@@ -236,7 +236,7 @@ def easy_thresh(wf_name):
 #    #defines the cluster cordinates
 #    cluster.inputs.out_localmax_txt_file = True
 
-    cluster_imports = ['import os', 'import re', 'import subprocess as sb']
+    cluster_imports = ['import os', 'import re', 'import subprocess']
     cluster = pe.MapNode(util.Function(input_names=['in_file',
                                                     'volume',
                                                     'dlh',
@@ -283,7 +283,7 @@ def easy_thresh(wf_name):
 
     # function mapnode to get the standard fsl brain image based on parameters
     # as FSLDIR,MNI and voxel size
-    get_bg_imports = ['import os', 'from nibabel import load']
+    get_bg_imports = ['import os', 'import nibabel as nib']
     get_backgroundimage = pe.MapNode(util.Function(input_names=['in_file',
                                                                 'file_parameters'],
                                                    output_names=['out_file'],


### PR DESCRIPTION

## Description
<!-- Concisely describe what the pull request does. -->
Add missing imports to easy_thresh module and make an unescaped regex string literal raw.
I wonder how this was able to run before.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
  - I ran the tests locally in docker


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
