### PR TITLE
🚚 RBC Output directory upgrades Pt. 11

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1893,9 +1893,9 @@ def brain_extraction(wf, cfg, strat_pool, pipe_num, opt=None):
                 ["anatomical_preproc", "run"]],
      "option_key": "None",
      "option_val": "None",
-     "inputs": [("desc-preproc_T1w",
-                 ["space-T1w_desc-brain_mask", "space-T1w_desc-acpcbrain_mask"],
-                 "desc-head_T1w")],
+     "inputs": [("desc-head_T1w", "desc-preproc_T1w",
+                 ["space-T1w_desc-brain_mask", "space-T1w_desc-acpcbrain_mask"]
+                )],
      "outputs": {
          "desc-preproc_T1w": {
              "SkullStripped": "True"},
@@ -1928,7 +1928,7 @@ def brain_extraction(wf, cfg, strat_pool, pipe_num, opt=None):
     anat_skullstrip_orig_vol.inputs.expr = 'a*step(b)'
     anat_skullstrip_orig_vol.inputs.outputtype = 'NIFTI_GZ'
 
-    node_T1w, out_T1w = strat_pool.get_data('desc-preproc_T1w')
+    node_T1w, out_T1w = strat_pool.get_data('desc-head_T1w')
     wf.connect(node_T1w, out_T1w, anat_skullstrip_orig_vol, 'in_file_a')
 
     node, out = strat_pool.get_data(['space-T1w_desc-brain_mask',

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -2234,7 +2234,8 @@ def bold_masking(wf, cfg, strat_pool, pipe_num, opt=None):
     {"name": "bold_masking",
      "config": None,
      "switch": [["functional_preproc", "run"],
-                ["functional_preproc", "func_masking", "apply_func_mask_in_native_space"]],
+                ["functional_preproc", "func_masking",
+                 "apply_func_mask_in_native_space"]],
      "option_key": "None",
      "option_val": "None",
      "inputs": [("desc-preproc_bold",
@@ -2248,7 +2249,6 @@ def bold_masking(wf, cfg, strat_pool, pipe_num, opt=None):
              "SkullStripped": True}}
     }
     '''
-
     func_edge_detect = pe.Node(interface=afni_utils.Calc(),
                                name=f'func_extract_brain_{pipe_num}')
 

--- a/CPAC/network_centrality/pipeline.py
+++ b/CPAC/network_centrality/pipeline.py
@@ -82,17 +82,17 @@ def network_centrality(wf, cfg, strat_pool, pipe_num, opt=None):
      "inputs": [("space-template_desc-preproc_bold",
                  "T1w-brain-template-funcreg"),
                 "template-specification-file"],
-     "outputs": {"space-template_desc-weighted_degree-centrality": {
+     "outputs": {"space-template_dcw": {
                      "Template": "T1w-brain-template-funcreg"},
-                 "space-template_desc-binarized_degree-centrality": {
+                 "space-template_dcb": {
                      "Template": "T1w-brain-template-funcreg"},
-                 "space-template_desc-weighted_eigen-centrality": {
+                 "space-template_ecw": {
                      "Template": "T1w-brain-template-funcreg"},
-                 "space-template_desc-binarized_eigen-centrality": {
+                 "space-template_ecb": {
                      "Template": "T1w-brain-template-funcreg"},
-                 "space-template_desc-weighted_lfcd": {
+                 "space-template_lfcdw": {
                      "Template": "T1w-brain-template-funcreg"},
-                 "space-template_desc-binarized_lfcd": {
+                 "space-template_lfcdb": {
                      "Template": "T1w-brain-template-funcreg"}}}
     '''
 
@@ -140,20 +140,28 @@ def network_centrality(wf, cfg, strat_pool, pipe_num, opt=None):
     for option in valid_options['centrality']['method_options']:
         if cfg.network_centrality[option]['weight_options']:
             for weight in cfg.network_centrality[option]['weight_options']:
-                if 'degree' in option.lower():
-                    if 'weight' in weight.lower():
-                        outputs['space-template_desc-weighted_degree-centrality'] = (merge_node, 'degree_weighted')
-                    elif 'binarize' in weight.lower():
-                        outputs['space-template_desc-binarized_degree-centrality'] = (merge_node, 'degree_binarized')
-                elif 'eigen' in option.lower():
-                    if 'weight' in weight.lower():
-                        outputs['space-template_desc-weighted_eigen-centrality'] = (merge_node, 'eigen_weighted')
-                    elif 'binarize' in weight.lower():
-                        outputs['space-template_desc-binarized_eigen-centrality'] = (merge_node, 'eigen_binarized')
-                elif 'lfcd' in option.lower() or 'local_functional' in option.lower():
-                    if 'weight' in weight.lower():
-                        outputs['space-template_desc-weighted_lfcd'] = (merge_node, 'lfcd_weighted')
-                    elif 'binarize' in weight.lower():
-                        outputs['space-template_desc-binarized_lfcd'] = (merge_node, 'lfcd_binarized')
+                _option = option.lower()
+                _weight = weight.lower()
+                if 'degree' in _option:
+                    if 'weight' in _weight:
+                        outputs['space-template_dcw'] = (merge_node,
+                                                         'degree_weighted')
+                    elif 'binarize' in _weight:
+                        outputs['space-template_dcb'] = (merge_node,
+                                                         'degree_binarized')
+                elif 'eigen' in _option:
+                    if 'weight' in _weight:
+                        outputs['space-template_ecw'] = (merge_node,
+                                                         'eigen_weighted')
+                    elif 'binarize' in _weight:
+                        outputs['space-template_ecb'] = (merge_node,
+                                                         'eigen_binarized')
+                elif 'lfcd' in _option or 'local_functional' in _option:
+                    if 'weight' in _weight:
+                        outputs['space-template_lfcdw'] = (merge_node,
+                                                           'lfcd_weighted')
+                    elif 'binarize' in _weight:
+                        outputs['space-template_lfcdb'] = (merge_node,
+                                                           'lfcd_binarized')
 
     return (wf, outputs)

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -2455,9 +2455,11 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space, res=None):
                                        '2-nuisance_regression',
                                        'bandpass_filtering_order'] == 'Before'
 
-    nuis = create_nuisance_regression_workflow(opt, name='nuisance_regression'
-                                               f'_{space}_{opt["Name"]}'
-                                               f'_{pipe_num}')
+    name_suff = (f'{space}_{opt["Name"]}_{pipe_num}' if res is None else
+                 f'{space}_res-{res}_{opt["Name"]}_{pipe_num}')
+    nuis_name = f'nuisance_regression_{name_suff}'
+
+    nuis = create_nuisance_regression_workflow(opt, name=nuis_name)
     if bandpass_before:
         nofilter_nuis = nuis.clone(name=f'{nuis.name}-noFilter')
 
@@ -2504,8 +2506,7 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space, res=None):
 
     if bandpass:
         filt = filtering_bold_and_regressors(opt, name=f'filtering_bold_and_'
-                                             f'regressors_{opt["Name"]}'
-                                             f'_{pipe_num}')
+                                             f'regressors_{name_suff}')
         filt.inputs.inputspec.nuisance_selectors = opt
 
         node, out = strat_pool.get_data('regressors')
@@ -2623,6 +2624,10 @@ def nuisance_regression_template(wf, cfg, strat_pool, pipe_num, opt=None):
                  "space-template_res-derivative_desc-cleaned_bold": {
         "Description": "Preprocessed BOLD image that was nuisance-"
                        "regressed in template space"},
+                "space-template_desc-denoisedNofilt_bold": {
+        "Description": "Preprocessed BOLD image that was nuisance-"
+                       "regressed in template space, but without "
+                       "frequency filtering."},
                  "space-template_res-derivative_desc-denoisedNofilt_bold": {
         "Description": "Preprocessed BOLD image that was nuisance-"
                        "regressed in template space, but without "

--- a/CPAC/pipeline/cpac_group_runner.py
+++ b/CPAC/pipeline/cpac_group_runner.py
@@ -1742,11 +1742,12 @@ def run_isc_group(pipeline_dir, out_dir, working_dir, crash_dir,
 
     output_df_dct = gather_outputs(
         pipeline_dir,
-        ["space-template_bold", "desc-Mean_timeseries"],
+        ["space-template_bold", "space-template_desc-Mean_timeseries"],
         inclusion_list=None,
         get_motion=False, get_raw_score=False, get_func=True,
-        derivatives=["space-template_bold", "desc-Mean_timeseries"],
-        #exts=['nii', 'nii.gz', 'csv']
+        derivatives=["space-template_bold",
+                     "space-template_desc-Mean_timeseries"],
+        # exts=['nii', 'nii.gz', 'csv']
     )
 
     iteration_ids = []
@@ -1758,10 +1759,11 @@ def run_isc_group(pipeline_dir, out_dir, working_dir, crash_dir,
         if "voxel" not in levels and derivative == "space-template_bold":
             continue
 
-        if "roi" not in levels and derivative == "desc-Mean_timeseries":
+        if ("roi" not in levels and
+                derivative == "space-template_desc-Mean_timeseries"):
             continue
 
-        if derivative == "desc-Mean_timeseries":
+        if derivative == "space-template_desc-Mean_timeseries":
             if roi_inclusion:
                 # backwards because ROI labels embedded as substrings
                 for roi_label in roi_inclusion:

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1294,7 +1294,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
         if rpool.check_rpool(func):
             apply_func_warp['T1'] = False
 
-    target_space_nuis = cfg.nuisance_corrections['2-nuisance_regression']['space']
+    target_space_nuis = cfg.nuisance_corrections['2-nuisance_regression'][
+        'space']
     target_space_alff = cfg.amplitude_low_frequency_fluctuation['target_space']
     target_space_reho = cfg.regional_homogeneity['target_space']
 
@@ -1304,7 +1305,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                                   apply_blip_to_timeseries_separately,
                                   warp_timeseries_to_T1template,
                                   warp_timeseries_to_T1template_dcan_nhp]
-                                  
+
         if 'Template' in target_space_alff or 'Template' in target_space_reho:
             ts_to_T1template_block += [warp_timeseries_to_T1template_deriv]
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1373,7 +1373,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
     cfg.timeseries_extraction['tse_atlases'] = tse_atlases
     cfg.seed_based_correlation_analysis['sca_atlases'] = sca_atlases
 
-    if not rpool.check_rpool('desc-Mean_timeseries') and \
+    if not rpool.check_rpool('space-template_desc-Mean_timeseries') and \
                     'Avg' in tse_atlases:
         pipeline_blocks += [timeseries_extraction_AVG]
 
@@ -1385,15 +1385,15 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                     'SpatialReg' in tse_atlases:
         pipeline_blocks += [spatial_regression]
 
-    if not rpool.check_rpool('desc-MeanSCA_correlations') and \
+    if not rpool.check_rpool('space-template_desc-MeanSCA_correlations') and \
                     'Avg' in sca_atlases:
         pipeline_blocks += [SCA_AVG]
 
-    if not rpool.check_rpool('desc-DualReg_correlations') and \
+    if not rpool.check_rpool('space-template_desc-DualReg_correlations') and \
                     'DualReg' in sca_atlases:
         pipeline_blocks += [dual_regression]
 
-    if not rpool.check_rpool('desc-MultReg_correlations') and \
+    if not rpool.check_rpool('space-template_desc-MultReg_correlations') and \
                     'MultReg' in sca_atlases:
         pipeline_blocks += [multiple_regression]
 

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -15,10 +15,11 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import ast
+import copy
 import logging
 import os
+import re
 import warnings
-import copy
 
 from CPAC.pipeline import \
     nipype_pipeline_engine as pe  # pylint: disable=ungrouped-imports
@@ -798,6 +799,11 @@ class ResourcePool:
                                   json_info, pipe_idx,
                                   'fisher_zscore_standardize',
                                   fork=True)
+
+        if '_res-' in label and 'Resolution' in json_info:
+            # replace resolution text with actual resolution
+            label = re.sub('_res-[A-Za-z0-9]*_',
+                           f'_res-{json_info["Resolution"]}_', label)
 
         return (wf, post_labels)
 

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -691,7 +691,10 @@ class ResourcePool:
 
         post_labels = [(label, connection[0], connection[1])]
 
-        if 'centrality' in label or 'lfcd' in label:
+        if re.match(r'(.*_)?[ed]c[bw]$', label) or re.match(r'(.*_)?lfcd[bw]$',
+                                                            label):
+            # suffix: [eigenvector or degree] centrality [binarized or weighted]
+            # or lfcd [binarized or weighted]
             mask = 'template-specification-file'
         elif 'space-template' in label:
             mask = 'space-template_res-derivative_desc-bold_mask'

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -786,7 +786,7 @@ class ResourcePool:
                     wf.connect(connection[0], connection[1],
                                zstd, 'inputspec.correlation_file')
 
-                    # if the output is 'desc-MeanSCA_correlations', we want
+                    # if the output is 'space-template_desc-MeanSCA_correlations', we want
                     # 'desc-MeanSCA_timeseries'
                     oned = label.replace('correlations', 'timeseries')
 

--- a/CPAC/qc/pipeline.py
+++ b/CPAC/qc/pipeline.py
@@ -43,10 +43,10 @@ def qc_snr_plot(wf, cfg, strat_pool, pipe_num, opt=None):
                 "from-bold_to-T1w_mode-image_desc-linear_xfm",
                 "desc-preproc_T1w",
                 "space-T1w_sbref"],
-     "outputs": ["bold-snr-axial-qc",
-                 "bold-snr-sagittal-qc",
-                 "bold-snr-hist-qc",
-                 "bold-snr-qc"]}
+     "outputs": ["desc-boldSnrAxial_quality",
+                 "desc-boldSnrSagittal_quality",
+                 "desc-boldSnrHist_quality",
+                 "desc-boldSnr_quality"]}
     '''
 
     # make SNR plot
@@ -70,12 +70,13 @@ def qc_snr_plot(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, qc_workflow, 'inputspec.mean_functional_in_anat')
 
     outputs = {
-        'bold-snr-axial-qc': (qc_workflow, 'outputspec.snr_axial_image'),
-        'bold-snr-sagittal-qc':
+        'desc-boldSnrAxial_quality': (qc_workflow,
+                                      'outputspec.snr_axial_image'),
+        'desc-boldSnrSagittal_quality':
             (qc_workflow, 'outputspec.snr_sagittal_image'),
-        'bold-snr-hist-qc': (
+        'desc-boldSnrHist_quality': (
             qc_workflow, 'outputspec.snr_histogram_image'),
-        'bold-snr-qc': (qc_workflow, 'outputspec.snr_mean')
+        'desc-boldSnr_quality': (qc_workflow, 'outputspec.snr_mean')
     }
 
     return (wf, outputs)
@@ -89,8 +90,8 @@ def qc_motion_plot(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": "None",
      "option_val": "None",
      "inputs": ["movement-parameters"],
-     "outputs": ["movement-parameters-trans-qc",
-                 "movement-parameters-rot-qc"]}
+     "outputs": ["desc-movementParametersTrans_quality",
+                 "desc-movementParametersRot_quality"]}
     '''
 
     # make motion parameters plot
@@ -100,9 +101,9 @@ def qc_motion_plot(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, qc_workflow, 'inputspec.motion_parameters')
 
     outputs = {
-        'movement-parameters-trans-qc': (
+        'desc-movementParametersTrans_quality': (
             qc_workflow, 'outputspec.motion_translation_plot'),
-        'movement-parameters-rot-qc': (
+        'desc-movementParametersRot_quality': (
             qc_workflow, 'outputspec.motion_rotation_plot')
     }
 
@@ -117,7 +118,7 @@ def qc_fd_plot(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": "None",
      "option_val": "None",
      "inputs": ["framewise-displacement-jenkinson"],
-     "outputs": ["framewise-displacement-jenkinson-plot-qc"]}
+     "outputs": ["desc-framewiseDisplacementJenkinsonPlot_quality"]}
     '''
 
     qc_workflow = create_qc_fd(f'qc_fd_{pipe_num}')
@@ -126,7 +127,7 @@ def qc_fd_plot(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, qc_workflow, 'inputspec.fd')
 
     outputs = {
-        'framewise-displacement-jenkinson-plot-qc':
+        'desc-framewiseDisplacementJenkinsonPlot_quality':
             (qc_workflow, 'outputspec.fd_histogram_plot')
     }
 
@@ -142,8 +143,8 @@ def qc_brain_extraction(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": ["desc-preproc_T1w",
                 "desc-head_T1w"],
-     "outputs": ["desc-brain_T1w-axial-qc",
-                 "desc-brain_T1w-sagittal-qc"]}
+     "outputs": ["desc-brain_desc-T1wAxial_quality",
+                 "desc-brain_desc-T1wSagittal_quality"]}
     '''
 
     # make QC montages for Skull Stripping Visualization
@@ -158,8 +159,9 @@ def qc_brain_extraction(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, qc_workflow, 'inputspec.anatomical_reorient')
 
     outputs = {
-        'desc-brain_T1w-axial-qc': (qc_workflow, 'outputspec.axial_image'),
-        'desc-brain_T1w-sagittal-qc':
+        'desc-brain_desc-T1wAxial_quality': (qc_workflow,
+                                             'outputspec.axial_image'),
+        'desc-brain_desc-T1wSagittal_quality':
             (qc_workflow, 'outputspec.sagittal_image')
     }
 
@@ -175,8 +177,8 @@ def qc_T1w_standard(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": ["space-template_desc-preproc_T1w",
                 "T1w-brain-template"],
-     "outputs": ["space-template_desc-brain_T1w-axial-qc",
-                 "space-template_desc-brain_T1w-sagittal-qc"]}
+     "outputs": ["space-template_desc-brain_desc-T1wAxial_quality",
+                 "space-template_desc-brain_desc-T1wSagittal_quality"]}
     '''
 
     # make QC montages for mni normalized anatomical image
@@ -200,9 +202,9 @@ def qc_T1w_standard(wf, cfg, strat_pool, pipe_num, opt=None):
                montage_mni_anat, 'inputspec.overlay')
 
     outputs = {
-        'space-template_desc-brain_T1w-axial-qc':
+        'space-template_desc-brain_desc-T1wAxial_quality':
             (montage_mni_anat, 'outputspec.axial_png'),
-        'space-template_desc-brain_T1w-sagittal-qc':
+        'space-template_desc-brain_desc-T1wSagittal_quality':
             (montage_mni_anat, 'outputspec.sagittal_png')
     }
 
@@ -223,8 +225,8 @@ def qc_segmentation(wf, cfg, strat_pool, pipe_num, opt=None):
                   "label-WM_mask"],
                  ["label-GM_desc-preproc_mask",
                   "label-GM_mask"])],
-     "outputs": ["dseg-axial-qc",
-                 "dseg-sagittal-qc"]}
+     "outputs": ["desc-dsegAxial_quality",
+                 "desc-dsegSagittal_quality"]}
     '''
 
     # make QC montages for CSF WM GM
@@ -247,8 +249,9 @@ def qc_segmentation(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, montage_csf_gm_wm, 'inputspec.overlay_gm')
 
     outputs = {
-        'dseg-axial-qc': (montage_csf_gm_wm, 'outputspec.axial_png'),
-        'dseg-sagittal-qc': (montage_csf_gm_wm, 'outputspec.sagittal_png')
+        'desc-dsegAxial_quality': (montage_csf_gm_wm, 'outputspec.axial_png'),
+        'desc-dsegSagittal_quality': (montage_csf_gm_wm,
+                                      'outputspec.sagittal_png')
     }
 
     return (wf, outputs)
@@ -268,8 +271,8 @@ def qc_epi_segmentation(wf, cfg, strat_pool, pipe_num, opt=None):
                   "space-bold_label-WM_mask"],
                  ["space-bold_label-GM_desc-preproc_mask",
                   "space-bold_label-GM_mask"])],
-     "outputs": ["epi-dseg-axial-qc",
-                 "epi-dseg-sagittal-qc"]}
+     "outputs": ["epi-desc-dsegAxial_quality",
+                 "epi-desc-dsegSagittal_quality"]}
     '''
 
     # make QC montages for CSF WM GM
@@ -292,8 +295,10 @@ def qc_epi_segmentation(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, montage_csf_gm_wm, 'inputspec.overlay_gm')
 
     outputs = {
-        'epi-dseg-axial-qc': (montage_csf_gm_wm, 'outputspec.axial_png'),
-        'epi-dseg-sagittal-qc': (montage_csf_gm_wm, 'outputspec.sagittal_png')
+        'epi-desc-dsegAxial_quality': (montage_csf_gm_wm,
+                                       'outputspec.axial_png'),
+        'epi-desc-dsegSagittal_quality': (montage_csf_gm_wm,
+                                          'outputspec.sagittal_png')
     }
 
     return (wf, outputs)
@@ -311,7 +316,7 @@ def qc_carpet_plot(wf, cfg, strat_pool, pipe_num, opt=None):
                 "GM-path",
                 "WM-path",
                 "CSF-path"],
-     "outputs": ["space-template_desc-preproc_bold-carpet-qc"]}
+     "outputs": ["space-template_desc-preprocBoldCarpet_quality"]}
     '''
 
     # make QC Carpet plot
@@ -335,9 +340,8 @@ def qc_carpet_plot(wf, cfg, strat_pool, pipe_num, opt=None):
     node, out = strat_pool.get_data("CSF-path")
     wf.connect(node, out, carpet_seg, 'inputspec.anatomical_csf_mask')
 
-    outputs = {
-        f'{resource}-carpet-qc': (carpet_seg, 'outputspec.carpet_plot'),
-    }
+    outputs = {'space-template_desc-preprocBoldCarpet_quality': (
+        carpet_seg, 'outputspec.carpet_plot')}
 
     return (wf, outputs)
 
@@ -351,8 +355,8 @@ def qc_coregistration(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": [("desc-preproc_T1w",
                  "space-T1w_sbref")],
-     "outputs": ["space-T1w_bold-axial-qc",
-                 "space-T1w_bold-sagittal-qc"]}
+     "outputs": ["space-T1w_desc-boldAxial_quality",
+                 "space-T1w_desc-boldSagittal_quality"]}
     '''
 
     # make QC montage for Mean Functional in T1 with T1 edge
@@ -375,9 +379,9 @@ def qc_coregistration(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, montage_anat, 'inputspec.underlay')
 
     outputs = {
-        'space-T1w_bold-axial-qc':
+        'space-T1w_desc-boldAxial_quality':
             (montage_anat, 'outputspec.axial_png'),
-        'space-T1w_bold-sagittal-qc':
+        'space-T1w_desc-boldSagittal_quality':
             (montage_anat, 'outputspec.sagittal_png')
     }
 
@@ -395,8 +399,8 @@ def qc_bold_registration(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": ["space-template_sbref",
                 "T1w-brain-template-funcreg"],
-     "outputs": ["space-template_bold-axial-qc",
-                 "space-template_bold-sagittal-qc"]}
+     "outputs": ["space-template_desc-boldAxial_quality",
+                 "space-template_desc-boldSagittal_quality"]}
     '''
 
     # make QC montage for Mean Functional in MNI with MNI edge
@@ -420,9 +424,9 @@ def qc_bold_registration(wf, cfg, strat_pool, pipe_num, opt=None):
                montage_mfi, 'inputspec.overlay')
 
     outputs = {
-        'space-template_bold-axial-qc':
+        'space-template_desc-boldAxial_quality':
             (montage_mfi, 'outputspec.axial_png'),
-        'space-template_bold-sagittal-qc':
+        'space-template_desc-boldSagittal_quality':
             (montage_mfi, 'outputspec.sagittal_png')
     }
 
@@ -442,8 +446,8 @@ def qc_bold_EPI_registration(wf, cfg, strat_pool, pipe_num, opt=None):
      "inputs": [("space-template_sbref",
                  "from-bold_to-EPItemplate_mode-image_xfm"),
                 "EPI-template-funcreg"],
-     "outputs": ["space-template_desc-mean_bold-axial-qc",
-                 "space-template_desc-mean_bold-sagittal-qc"]}
+     "outputs": ["space-template_desc-mean_desc-boldAxial_quality",
+                 "space-template_desc-mean_desc-boldSagittal_quality"]}
     '''
 
     # make QC montage for Mean Functional in MNI with MNI edge
@@ -467,9 +471,9 @@ def qc_bold_EPI_registration(wf, cfg, strat_pool, pipe_num, opt=None):
                montage_mfi, 'inputspec.overlay')
 
     outputs = {
-        'space-template_bold-axial-qc':
+        'space-template_desc-boldAxial_quality':
             (montage_mfi, 'outputspec.axial_png'),
-        'space-template_bold-sagittal-qc':
+        'space-template_desc-boldSagittal_quality':
             (montage_mfi, 'outputspec.sagittal_png')
     }
 

--- a/CPAC/resources/cpac_outputs.tsv
+++ b/CPAC/resources/cpac_outputs.tsv
@@ -114,20 +114,20 @@ rels-displacement	motion		func	1D
 label-CSF_probseg	probseg	T1w	anat	NIfTI					
 label-GM_probseg	probseg	T1w	anat	NIfTI					
 label-WM_probseg	probseg	T1w	anat	NIfTI					
-T1w-axial-qc	qc		anat	png					
-T1w-sagittal-qc	qc		anat	png					
-dseg-axial-qc	qc		anat	png					
-desg-sagittal-qc	qc		anat	png					
-bold-axial-qc	qc		func	png					
-bold-sagittal-qc	qc		func	png					
-bold-carpet-qc	qc		func	png					
-framewise-displacement-jenkinson-plot-qc	qc		func	png					
-movement-parameters-trans-qc	qc		func	png					
-movement-parameters-rot-qc	qc		func	png					
-bold-snr-axial-qc	qc		func	png					
-bold-snr-sagittal-qc	qc		func	png					
-bold-snr-hist-qc	qc		func	png					
-bold-snr-qc	qc		func	png					
+desc-T1wAxial_quality	qc		anat	png					
+desc-T1wSagittal_quality	qc		anat	png					
+desc-dsegAxial_quality	qc		anat	png					
+desc-dsegSagittal_quality	qc		anat	png					
+desc-boldAxial_quality	qc		func	png					
+desc-boldSagittal_quality	qc		func	png					
+desc-boldCarpet_quality	qc		func	png					
+desc-framewiseDisplacementJenkinsonPlot_quality	qc		func	png					
+desc-movementParametersTrans_quality	qc		func	png					
+desc-movementParametersRot_quality	qc		func	png					
+desc-boldSnrAxial_quality	qc		func	png					
+desc-boldSnrSagittal_quality	qc		func	png					
+desc-boldSnrHist_quality	qc		func	png					
+desc-boldSnr_quality	qc		func	png					
 space-template_desc-xcp_quality	qc		func	tsv					
 regressors	regressors		func	1D					
 desc-sm_reho	reho	functional	func	NIfTI		Yes			

--- a/CPAC/resources/cpac_outputs.tsv
+++ b/CPAC/resources/cpac_outputs.tsv
@@ -37,19 +37,19 @@ desc-PearsonAfni_correlations	correlation	template	func	tsv
 desc-PartialAfni_correlations	correlation	template	func	tsv					
 desc-PearsonNilearn_correlations	correlation	template	func	tsv					
 desc-PartialNilearn_correlations	correlation	template	func	tsv					
-space-template_desc-binarized_degree-centrality	degree-centrality	template	func	NIfTI	Yes	Yes			
+space-template_dcb	degree-centrality	template	func	NIfTI	Yes	Yes			
 space-template_desc-binarized-sm_degree-centrality	degree-centrality	template	func	NIfTI		Yes			
 space-template_desc-binarized-sm-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
 space-template_desc-binarized-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
-space-template_desc-weighted_degree-centrality	degree-centrality	template	func	NIfTI	Yes	Yes			
+space-template_dcw	degree-centrality	template	func	NIfTI	Yes	Yes			
 space-template_desc-weighted-sm_degree-centrality	degree-centrality	template	func	NIfTI		Yes			
 space-template_desc-weighted-sm-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
 space-template_desc-weighted-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
-space-template_desc-binarized_eigen-centrality	eigen-centrality	template	func	NIfTI	Yes	Yes			
+space-template_ecb	eigen-centrality	template	func	NIfTI	Yes	Yes			
 space-template_desc-binarized-sm_eigen-centrality	eigen-centrality	template	func	NIfTI		Yes			
 space-template_desc-binarized-sm-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
 space-template_desc-binarized-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
-space-template_desc-weighted_eigen-centrality	eigen-centrality	template	func	NIfTI	Yes	Yes			
+space-template_ecw	eigen-centrality	template	func	NIfTI	Yes	Yes			
 space-template_desc-weighted-sm_eigen-centrality	eigen-centrality	template	func	NIfTI		Yes			
 space-template_desc-weighted-sm-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
 space-template_desc-weighted-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
@@ -61,11 +61,11 @@ space-template_desc-sm_falff	falff	template	func	NIfTI		Yes
 space-template_desc-sm-zstd_falff	falff	template	func	NIfTI					
 space-template_desc-zstd_falff	falff	template	func	NIfTI					
 space-template_falff	falff	template	func	NIfTI	Yes	Yes			
-space-template_desc-binarized_lfcd	lfcd	template	func	NIfTI	Yes	Yes			
+space-template_lfcdb	lfcd	template	func	NIfTI	Yes	Yes			
 space-template_desc-binarized-sm_lfcd	lfcd	template	func	NIfTI		Yes			
 space-template_desc-binarized-sm-zstd_lfcd	lfcd	template	func	NIfTI					
 space-template_desc-binarized-zstd_lfcd	lfcd	template	func	NIfTI					
-space-template_desc-weighted_lfcd	lfcd	template	func	NIfTI	Yes	Yes			
+space-template_lfcdw	lfcd	template	func	NIfTI	Yes	Yes			
 space-template_desc-weighted-sm_lfcd	lfcd	template	func	NIfTI		Yes			
 space-template_desc-weighted-sm-zstd_lfcd	lfcd	template	func	NIfTI					
 space-template_desc-weighted-zstd_lfcd	lfcd	template	func	NIfTI					

--- a/CPAC/resources/cpac_outputs.tsv
+++ b/CPAC/resources/cpac_outputs.tsv
@@ -38,21 +38,21 @@ space-template_desc-PartialAfni_correlations	correlation	template	func	tsv
 space-template_desc-PearsonNilearn_correlations	correlation	template	func	tsv					
 space-template_desc-PartialNilearn_correlations	correlation	template	func	tsv					
 space-template_dcb	degree-centrality	template	func	NIfTI	Yes	Yes			
-space-template_desc-binarized-sm_degree-centrality	degree-centrality	template	func	NIfTI		Yes			
-space-template_desc-binarized-sm-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
-space-template_desc-binarized-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
+space-template_desc-sm_dcb	degree-centrality	template	func	NIfTI		Yes			
+space-template_desc-sm-zstd_dcb	degree-centrality	template	func	NIfTI					
+space-template_desc-zstd_dcb	degree-centrality	template	func	NIfTI					
 space-template_dcw	degree-centrality	template	func	NIfTI	Yes	Yes			
-space-template_desc-weighted-sm_degree-centrality	degree-centrality	template	func	NIfTI		Yes			
-space-template_desc-weighted-sm-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
-space-template_desc-weighted-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
+space-template_desc-sm_dcw	degree-centrality	template	func	NIfTI		Yes			
+space-template_desc-sm-zstd_dcw	degree-centrality	template	func	NIfTI					
+space-template_desc-zstd_dcw	degree-centrality	template	func	NIfTI					
 space-template_ecb	eigen-centrality	template	func	NIfTI	Yes	Yes			
-space-template_desc-binarized-sm_eigen-centrality	eigen-centrality	template	func	NIfTI		Yes			
-space-template_desc-binarized-sm-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
-space-template_desc-binarized-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
+space-template_desc-sm_ecb	eigen-centrality	template	func	NIfTI		Yes			
+space-template_desc-sm-zstd_ecb	eigen-centrality	template	func	NIfTI					
+space-template_desc-zstd_ecb	eigen-centrality	template	func	NIfTI					
 space-template_ecw	eigen-centrality	template	func	NIfTI	Yes	Yes			
-space-template_desc-weighted-sm_eigen-centrality	eigen-centrality	template	func	NIfTI		Yes			
-space-template_desc-weighted-sm-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
-space-template_desc-weighted-zstd_eigen-centrality	eigen-centrality	template	func	NIfTI					
+space-template_desc-sm_ecw	eigen-centrality	template	func	NIfTI		Yes			
+space-template_desc-sm-zstd_ecw	eigen-centrality	template	func	NIfTI					
+space-template_desc-zstd_ecw	eigen-centrality	template	func	NIfTI					
 desc-sm_falff	falff	functional	func	NIfTI		Yes			
 desc-sm-zstd_falff	falff	functional	func	NIfTI					
 desc-zstd_falff	falff	functional	func	NIfTI					
@@ -62,13 +62,13 @@ space-template_desc-sm-zstd_falff	falff	template	func	NIfTI
 space-template_desc-zstd_falff	falff	template	func	NIfTI					
 space-template_falff	falff	template	func	NIfTI	Yes	Yes			
 space-template_lfcdb	lfcd	template	func	NIfTI	Yes	Yes			
-space-template_desc-binarized-sm_lfcd	lfcd	template	func	NIfTI		Yes			
-space-template_desc-binarized-sm-zstd_lfcd	lfcd	template	func	NIfTI					
-space-template_desc-binarized-zstd_lfcd	lfcd	template	func	NIfTI					
+space-template_desc-sm_lfcdb	lfcd	template	func	NIfTI		Yes			
+space-template_desc-sm-zstd_lfcdb	lfcd	template	func	NIfTI					
+space-template_desc-zstd_lfcdb	lfcd	template	func	NIfTI					
 space-template_lfcdw	lfcd	template	func	NIfTI	Yes	Yes			
-space-template_desc-weighted-sm_lfcd	lfcd	template	func	NIfTI		Yes			
-space-template_desc-weighted-sm-zstd_lfcd	lfcd	template	func	NIfTI					
-space-template_desc-weighted-zstd_lfcd	lfcd	template	func	NIfTI					
+space-template_desc-sm_lfcdw	lfcd	template	func	NIfTI		Yes			
+space-template_desc-sm-zstd_lfcdw	lfcd	template	func	NIfTI					
+space-template_desc-zstd_lfcdw	lfcd	template	func	NIfTI					
 space-EPItemplate_desc-bold_mask	mask	EPI template	func	NIfTI					
 space-EPItemplate_res-derivative_desc-bold_mask	mask	EPI template	func	NIfTI					
 space-bold_desc-brain_mask	mask	functional	func	NIfTI					

--- a/CPAC/resources/cpac_outputs.tsv
+++ b/CPAC/resources/cpac_outputs.tsv
@@ -29,14 +29,14 @@ space-template_desc-mean_bold	bold	template	func	NIfTI
 space-template_desc-preproc_bold	bold	template	func	NIfTI			Yes		
 space-template_desc-scout_bold	bold	template	func	NIfTI					
 space-template_sbref	bold	template	func	NIfTI					
-desc-DualReg_correlations	correlation	template	func	NIfTI					
-desc-MeanSCA_correlations	correlation	template	func	NIfTI					
-desc-MultReg_correlations	correlation	template	func	NIfTI					
-desc-ndmg_correlations	correlation	template	func	NIfTI					
-desc-PearsonAfni_correlations	correlation	template	func	tsv					
-desc-PartialAfni_correlations	correlation	template	func	tsv					
-desc-PearsonNilearn_correlations	correlation	template	func	tsv					
-desc-PartialNilearn_correlations	correlation	template	func	tsv					
+space-template_desc-DualReg_correlations	correlation	template	func	NIfTI					
+space-template_desc-MeanSCA_correlations	correlation	template	func	NIfTI					
+space-template_desc-MultReg_correlations	correlation	template	func	NIfTI					
+space-template_space-template_desc-ndmg_correlations	correlation	template	func	NIfTI					
+space-template_desc-PearsonAfni_correlations	correlation	template	func	tsv					
+space-template_desc-PartialAfni_correlations	correlation	template	func	tsv					
+space-template_desc-PearsonNilearn_correlations	correlation	template	func	tsv					
+space-template_desc-PartialNilearn_correlations	correlation	template	func	tsv					
 space-template_dcb	degree-centrality	template	func	NIfTI	Yes	Yes			
 space-template_desc-binarized-sm_degree-centrality	degree-centrality	template	func	NIfTI		Yes			
 space-template_desc-binarized-sm-zstd_degree-centrality	degree-centrality	template	func	NIfTI					
@@ -174,7 +174,7 @@ space-template_desc-brain_T1w	T1w	template	anat	NIfTI
 space-template_desc-preproc_T1w	T1w	template	anat	NIfTI					
 space-template_desc-head_T1w	T1w	template	anat	NIfTI					
 space-template_desc-T1w_mask	mask	template	anat	NIfTI					
-desc-Mean_timeseries	timeseries		func	1D					
+space-template_desc-Mean_timeseries	timeseries		func	1D					
 desc-MeanSCA_timeseries	timeseries		func	1D					
 desc-SpatReg_timeseries	timeseries		func	1D					
 desc-Voxel_timeseries	timeseries		func	1D					

--- a/CPAC/resources/templates/BIDS_identifiers.tsv
+++ b/CPAC/resources/templates/BIDS_identifiers.tsv
@@ -20,10 +20,10 @@
 /ndmg_atlases/label/Human/HarvardOxfordcort-maxprob-thr25_space-MNI152NLin6_res-2x2x2.nii.gz	HOCPA	th25
 /ndmg_atlases/label/Human/HarvardOxfordsub-maxprob-thr25_space-MNI152NLin6_res-2x2x2.nii.gz	HOSPA	th25
 /ndmg_atlases/label/Human/Juelich_space-MNI152NLin6_res-2x2x2.nii.gz	Juelich	
-/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-200Parcels17NetworksOrder.nii.gz	Schaefer2018	200p17n
-/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-300Parcels17NetworksOrder.nii.gz	Schaefer2018	300p17n
-/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-400Parcels17NetworksOrder.nii.gz	Schaefer2018	400p17n
-/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-1000Parcels17NetworksOrder.nii.gz	Schaefer2018	1000p17n
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-200Parcels17NetworksOrder.nii.gz	Schaefer2018	p200n17
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-300Parcels17NetworksOrder.nii.gz	Schaefer2018	p300n17
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-400Parcels17NetworksOrder.nii.gz	Schaefer2018	p400n17
+/cpac_templates/Schaefer2018_space-FSLMNI152_res-2mm_desc-1000Parcels17NetworksOrder.nii.gz	Schaefer2018	p1000n17
 /ndmg_atlases/label/Human/Yeo-7_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	7
 /ndmg_atlases/label/Human/Yeo-7-liberal_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	7liberal
 /ndmg_atlases/label/Human/Yeo-17_space-MNI152NLin6_res-2x2x2.nii.gz	Yeo	17

--- a/CPAC/sca/sca.py
+++ b/CPAC/sca/sca.py
@@ -391,7 +391,7 @@ def SCA_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": ["space-template_desc-preproc_bold"],
      "outputs": ["desc-MeanSCA_timeseries",
-                 "desc-MeanSCA_correlations",
+                 "space-template_desc-MeanSCA_correlations",
                  "atlas_name"]}
     '''
 
@@ -453,7 +453,7 @@ def SCA_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
             (roi_timeseries_for_sca, 'outputspec.roi_csv'),
                                     #('outputspec.roi_outputs',
                                     # extract_one_d)),
-        'desc-MeanSCA_correlations':
+        'space-template_desc-MeanSCA_correlations':
             (sca_roi, 'outputspec.correlation_stack'),
         'atlas_name': (roi_dataflow_for_sca, 'outputspec.out_name')
     }
@@ -472,7 +472,7 @@ def dual_regression(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": ["space-template_desc-preproc_bold"],
                 "space-template_desc-bold_mask"],
-     "outputs": ["desc-DualReg_correlations",
+     "outputs": ["space-template_desc-DualReg_correlations",
                  "desc-DualReg_statmap",
                  "atlas_name"]}
     '''
@@ -536,7 +536,7 @@ def dual_regression(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, dr_temp_reg, 'inputspec.subject_mask')
 
     outputs = {
-        'desc-DualReg_correlations':
+        'space-template_desc-DualReg_correlations':
             (dr_temp_reg, 'outputspec.temp_reg_map'),
         'desc-DualReg_statmap':
             (dr_temp_reg, 'outputspec.temp_reg_map_z'),
@@ -558,7 +558,7 @@ def multiple_regression(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_val": "None",
      "inputs": ["space-template_desc-preproc_bold",
                 "space-template_desc-bold_mask"],
-     "outputs": ["desc-MultReg_correlations",
+     "outputs": ["space-template_desc-MultReg_correlations",
                  "desc-MultReg_statmap",
                  "atlas_name"]}
     '''
@@ -634,7 +634,7 @@ def multiple_regression(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, sc_temp_reg, 'inputspec.subject_mask')
 
     outputs = {
-        'desc-MultReg_correlations':
+        'space-template_desc-MultReg_correlations':
             (sc_temp_reg, 'outputspec.temp_reg_map'),
         'desc-MultReg_statmap':
             (sc_temp_reg, 'outputspec.temp_reg_map_z'),

--- a/CPAC/timeseries/timeseries_analysis.py
+++ b/CPAC/timeseries/timeseries_analysis.py
@@ -842,7 +842,7 @@ def timeseries_extraction_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
                     pipe_num=pipe_num
                 )
                 brain_mask_node, brain_mask_out = strat_pool.get_data([
-                    'space-template_desc-brain_bold'])
+                    'space-template_desc-preproc_bold'])
                 wf.connect(brain_mask_node, brain_mask_out,
                            timeseries_correlation, 'inputspec.mask')
 

--- a/CPAC/timeseries/timeseries_analysis.py
+++ b/CPAC/timeseries/timeseries_analysis.py
@@ -767,13 +767,13 @@ def timeseries_extraction_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
      "option_key": "None",
      "option_val": "None",
      "inputs": ["space-template_desc-preproc_bold"],
-     "outputs": ["desc-Mean_timeseries",
-                 "desc-ndmg_correlations",
+     "outputs": ["space-template_desc-Mean_timeseries",
+                 "space-template_space-template_desc-ndmg_correlations",
                  "atlas_name",
-                 "desc-PearsonAfni_correlations",
-                 "desc-PartialAfni_correlations",
-                 "desc-PearsonNilearn_correlations",
-                 "desc-PartialNilearn_correlations"]}
+                 "space-template_desc-PearsonAfni_correlations",
+                 "space-template_desc-PartialAfni_correlations",
+                 "space-template_desc-PearsonNilearn_correlations",
+                 "space-template_desc-PartialNilearn_correlations"]}
     '''
     resample_functional_roi = pe.Node(Function(input_names=['in_func',
                                                             'in_roi',
@@ -856,11 +856,12 @@ def timeseries_extraction_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
 
             output_desc = ''.join(term.lower().capitalize() for term in [
                 cm_measure, cm_tool])
-            matrix_outputs[f'desc-{output_desc}_correlations'] = (
-                timeseries_correlation, 'outputspec.out_file')
+            matrix_outputs[f'space-template_desc-{output_desc}_correlations'
+                           ] = (timeseries_correlation, 'outputspec.out_file')
 
     outputs = {
-        'desc-Mean_timeseries': (roi_timeseries, 'outputspec.roi_csv'),
+        'space-template_desc-Mean_timeseries': (
+            roi_timeseries, 'outputspec.roi_csv'),
         'atlas_name': (roi_dataflow, 'outputspec.out_name'),
         **matrix_outputs
     }
@@ -883,7 +884,8 @@ def timeseries_extraction_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
 
         wf.connect(roi_timeseries, 'outputspec.roi_ts', ndmg_graph, 'ts')
         wf.connect(roi_dataflow, 'outputspec.out_file', ndmg_graph, 'labels')
-        outputs['desc-ndmg_correlations'] = (ndmg_graph, 'out_file')
+        outputs['space-template_space-template_desc-ndmg_correlations'
+                ] = (ndmg_graph, 'out_file')
 
     return (wf, outputs)
 

--- a/CPAC/utils/bids_utils.py
+++ b/CPAC/utils/bids_utils.py
@@ -1035,6 +1035,51 @@ def load_cpac_data_config(data_config_file, participant_labels,
     return sub_list
 
 
+def res_in_filename(cfg, label):
+    """Specify resolution in filename
+
+    Parameters
+    ----------
+    cfg : CPAC.utils.configuration.Configuration
+
+    label : str
+
+    Returns
+    -------
+    label : str
+
+    Examples
+    --------
+    >>> from CPAC.utils.configuration import Configuration
+    >>> res_in_filename(Configuration({
+    ...     'registration_workflows': {
+    ...         'anatomical_registration': {'resolution_for_anat': '2x2x2'}}}),
+    ...     'sub-1_res-anat_bold')
+    'sub-1_res-2x2x2_bold'
+    >>> res_in_filename(Configuration({
+    ...     'registration_workflows': {
+    ...         'anatomical_registration': {'resolution_for_anat': '2x2x2'}}}),
+    ...     'sub-1_res-3mm_bold')
+    'sub-1_res-3mm_bold'
+    """
+    if '_res-' in label:
+        # replace resolution text with actual resolution
+        resolution = label.split('_res-', 1)[1].split('_', 1)[0]
+        resolution = {
+            'anat': cfg['registration_workflows', 'anatomical_registration',
+                        'resolution_for_anat'],
+            'bold': cfg['registration_workflows', 'functional_registration',
+                        'func_registration_to_template', 'output_resolution',
+                        'func_preproc_outputs'],
+            'derivative': cfg['registration_workflows',
+                              'functional_registration',
+                              'func_registration_to_template',
+                              'output_resolution', 'func_derivative_outputs']
+        }.get(resolution, resolution)
+        label = re.sub('_res-[A-Za-z0-9]*_', f'_res-{resolution}_', label)
+    return label
+
+
 def sub_list_filter_by_labels(sub_list, labels):
     """Function to filter a sub_list by provided BIDS labels for
     specified suffixes

--- a/CPAC/utils/bids_utils.py
+++ b/CPAC/utils/bids_utils.py
@@ -847,6 +847,8 @@ def combine_multiple_entity_instances(bids_str: str) -> str:
             entities[key].append(value)
     for key, value in entities.items():
         entities[key] = camelCase('-'.join(value))
+    if 'desc' in entities:  # make 'desc' final entity
+        suffixes.insert(0, f'desc-{entities.pop("desc")}')
     return '_'.join([f'{key}-{value}' for key, value in entities.items()
                      ] + suffixes)
 

--- a/CPAC/utils/configuration/configuration.py
+++ b/CPAC/utils/configuration/configuration.py
@@ -145,7 +145,7 @@ class Configuration:
             # set attribute
             setattr(self, key, set_from_ENV(config_map[key]))
 
-        self.__update_attr()
+        self._update_attr()
 
     def __str__(self):
         return ('C-PAC Configuration '
@@ -158,7 +158,7 @@ class Configuration:
     def __copy__(self):
         newone = type(self)({})
         newone.__dict__.update(self.__dict__)
-        newone.__update_attr()
+        newone._update_attr()
         return newone
 
     def __getitem__(self, key):
@@ -287,7 +287,7 @@ class Configuration:
 
     # method to find any pattern ($) in the configuration
     # and update the attributes with its pattern value
-    def __update_attr(self):
+    def _update_attr(self):
 
         def check_path(key):
             if isinstance(key, str) and '/' in key:

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -22,6 +22,7 @@ import gzip
 import json
 import numbers
 import pickle
+import re
 import numpy as np
 import yaml
 
@@ -199,7 +200,11 @@ def create_id_string(cfg, unique_id, resource, scan_id=None,
 
     if atlas_id:
         if '_desc-' in atlas_id:
-            atlas_id = atlas_id.replace('_desc-', '')
+            atlas, desc = atlas_id.split('_desc-')
+            if not re.match(r'.*[0-9]$', atlas) and re.match(r'[a-z].*', desc):
+                atlas_id = f'{atlas}{desc[0].upper()}{desc[1:]}'
+            else:
+                atlas_id = atlas_id.replace('_desc-', '')
         resource = f'atlas-{atlas_id}_{resource}'
 
     part_id = unique_id.split('_')[0]

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -172,8 +172,9 @@ def read_json(json_file):
     return json_dct
 
 
-def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
-                     atlas_id=None, fwhm=None, subdir=None):
+def create_id_string(cfg, unique_id, resource, scan_id=None,
+                     template_desc=None, atlas_id=None, fwhm=None, subdir=None
+                     ):
     """Create the unique key-value identifier string for BIDS-Derivatives
     compliant file names.
 
@@ -182,11 +183,14 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
 
     Example
     -------
-    >>> create_id_string('sub-1_ses-1', 'desc-Mean-1_timeseries',
+    >>> from CPAC.utils.configuration import Configuration
+    >>> create_id_string(Configuration(), 'sub-1_ses-1',
+    ...                  'res-derivative_desc-Mean-1_timeseries',
     ...                  scan_id='rest', atlas_id='Schaefer2018_desc-1007p17')
-    'sub-1_ses-1_task-rest_atlas-Schaefer2018_desc-1007p17Mean1_timeseries'
+    'sub-1_ses-1_task-rest_atlas-Schaefer2018_res-3mm_desc-1007p17Mean1_timeseries'
     """
-    from CPAC.utils.bids_utils import combine_multiple_entity_instances
+    from CPAC.utils.bids_utils import combine_multiple_entity_instances, \
+                                      res_in_filename
     from CPAC.utils.outputs import Outputs
 
     if resource in Outputs.motion:
@@ -233,7 +237,8 @@ def create_id_string(unique_id, resource, scan_id=None, template_desc=None,
     if subdir == 'func':
         out_filename = out_filename.replace('_space-bold_', '_')
 
-    return combine_multiple_entity_instances(out_filename)
+    return combine_multiple_entity_instances(
+        res_in_filename(cfg, out_filename))
 
 
 def write_output_json(json_data, filename, indent=3, basedir=None):

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -22,7 +22,6 @@ import gzip
 import json
 import numbers
 import pickle
-import re
 import numpy as np
 import yaml
 
@@ -190,6 +189,7 @@ def create_id_string(cfg, unique_id, resource, scan_id=None,
     ...                  scan_id='rest', atlas_id='Yeo_desc-7')
     'sub-1_ses-1_task-rest_atlas-Yeo7_res-3mm_desc-Mean1_timeseries'
     """
+    import re
     from CPAC.utils.bids_utils import combine_multiple_entity_instances, \
                                       res_in_filename
     from CPAC.utils.outputs import Outputs

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -186,8 +186,8 @@ def create_id_string(cfg, unique_id, resource, scan_id=None,
     >>> from CPAC.utils.configuration import Configuration
     >>> create_id_string(Configuration(), 'sub-1_ses-1',
     ...                  'res-derivative_desc-Mean-1_timeseries',
-    ...                  scan_id='rest', atlas_id='Schaefer2018_desc-1007p17')
-    'sub-1_ses-1_task-rest_atlas-Schaefer2018_res-3mm_desc-1007p17Mean1_timeseries'
+    ...                  scan_id='rest', atlas_id='Yeo_desc-7')
+    'sub-1_ses-1_task-rest_atlas-Yeo7_res-3mm_desc-Mean1_timeseries'
     """
     from CPAC.utils.bids_utils import combine_multiple_entity_instances, \
                                       res_in_filename
@@ -198,8 +198,8 @@ def create_id_string(cfg, unique_id, resource, scan_id=None,
             f'desc-{resource.replace("framewise-displacement", "FD")}_motion')
 
     if atlas_id:
-        if not (atlas_id.count('_') == 1 and '_desc-' in atlas_id):
-            atlas_id = atlas_id.replace('_', '')
+        if '_desc-' in atlas_id:
+            atlas_id = atlas_id.replace('_desc-', '')
         resource = f'atlas-{atlas_id}_{resource}'
 
     part_id = unique_id.split('_')[0]


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #1808 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
* [Updates](https://github.com/FCP-INDI/C-PAC/commit/27c383bca94cdd4d19670a56dfe393ea3d5ca53a#diff-e1c8f266fdc8a7a1b635c8807fb98daa856518b7e16fd15905c31a5e5184b3e8) network centrality resource names per [BEP012](https://docs.google.com/document/d/16CvBwVMAs0IMhdoKmlmcm3W8254dQmNARo-7HhE-lJU)
* [Renames](https://github.com/FCP-INDI/C-PAC/commit/fd8bafccd252455baf2a97d15cdef03522debbcd) `res-[A-Za-z0-9]*` output entities to use actual resolution from sidecar
* [Updates](https://github.com/FCP-INDI/C-PAC/commit/1101e3de82b0433e40f585aaaa111028c0498c3e#diff-9b28de95c69080546f6835010600c40eae05103f411a7cd50eb20e188416243f) timeseries analysis to use `desc-preproc_bold` instead of `desc-brain_bold` 
* [Renames](https://github.com/FCP-INDI/C-PAC/commit/56b58c4fea87f198814fda06c565b4a6a011ebaa) `{what-ever}-qc` to `to desc-{whatEver}_quality`
* [Combines](https://github.com/FCP-INDI/C-PAC/commit/cd58f9488c5a53105e85efdda3269ed28bb7d4db) atlas entities like `atlas-name_desc-disambig` into `atlas-nameDisambig` for derivatives
* [Changes](https://github.com/FCP-INDI/C-PAC/commit/a2574dbbaa70b41837bdb562e4ccd7188878ee61) brain extraction source from `preproc` to `head`

## Screenshots

### `benchmark-FNIRT` @ 6fc6607
<details><summary><code>expectedOututs.yml</code></summary>

```YAML
anat:
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-head*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-preproc*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-reorient*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-MNI152NLin6ASym*_to-T1w*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-MNI152NLin6Sym*_to-T1w*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6ASym*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6ASym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6Sym*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6Sym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-CSF*_desc-preproc*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-CSF*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-CSF*_probseg
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-GM*_desc-preproc*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-GM*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-GM*_probseg
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-WM*_desc-preproc*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-WM*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-WM*_probseg
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-brain*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-head*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-preproc*_T1w
func:
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-FDJenkinson*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-FDPower*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-cleaned*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-dvars*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-maxDisplacement*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-mean*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-motion*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-motionParams*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-movementParameters*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-powerParams*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_framewiseDisplacementJenkinsonPlotQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-bold*_to-MNI152NLin6ASym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-bold*_to-MNI152NLin6Sym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-bold*_to-T1w*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_movementParametersRotQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_movementParametersTransQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-1*_boldSnrAxialQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-1*_boldSnrHistQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-1*_boldSnrQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-1*_boldSnrSagittalQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-4*_boldSnrAxialQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-4*_boldSnrHistQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-4*_boldSnrQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-4*_boldSnrSagittalQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-Mean1*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-Mean4*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-PartialNilearn1*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-PartialNilearn4*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-PearsonNilearn1*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-PearsonNilearn4*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-SpatReg1*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-SpatReg4*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-Voxel1*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-Voxel4*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-ndmg1*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-ndmg4*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-preproc1*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-preproc4*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-smZstd1*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-smZstd4*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-zstd1*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-zstd4*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-2*_boldSnrAxialQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-2*_boldSnrHistQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-2*_boldSnrQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-2*_boldSnrSagittalQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-5*_boldSnrAxialQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-5*_boldSnrHistQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-5*_boldSnrQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-5*_boldSnrSagittalQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-Mean2*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-Mean5*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-PartialNilearn2*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-PartialNilearn5*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-PearsonNilearn2*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-PearsonNilearn5*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-SpatReg2*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-SpatReg5*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-Voxel2*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-Voxel5*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-ndmg2*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-ndmg5*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-preproc2*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-preproc5*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-smZstd2*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-smZstd5*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-zstd2*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-zstd5*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-3*_boldSnrAxialQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-3*_boldSnrHistQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-3*_boldSnrQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-3*_boldSnrSagittalQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-6*_boldSnrAxialQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-6*_boldSnrHistQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-6*_boldSnrQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-6*_boldSnrSagittalQc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-Mean3*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-Mean6*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-PartialNilearn3*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-PartialNilearn6*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-PearsonNilearn3*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-PearsonNilearn6*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-SpatReg3*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-SpatReg6*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-Voxel3*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-Voxel6*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-ndmg3*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-ndmg6*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-preproc3*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-preproc6*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-smZstd3*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-smZstd6*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-zstd3*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-zstd6*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-bold*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedSmZstd1*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedSmZstd1*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedSmZstd1*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedSmZstd4*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedSmZstd4*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedSmZstd4*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedZstd1*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedZstd1*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedZstd1*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedZstd4*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedZstd4*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-binarizedZstd4*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-preproc1*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-preproc4*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-smZstd1*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-smZstd4*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedSmZstd1*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedSmZstd1*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedSmZstd1*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedSmZstd4*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedSmZstd4*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedSmZstd4*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedZstd1*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedZstd1*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedZstd1*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedZstd4*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedZstd4*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-weightedZstd4*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-zstd1*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-zstd4*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedSmZstd2*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedSmZstd2*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedSmZstd2*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedSmZstd5*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedSmZstd5*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedSmZstd5*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedZstd2*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedZstd2*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedZstd2*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedZstd5*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedZstd5*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-binarizedZstd5*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-preproc2*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-preproc5*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-smZstd2*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-smZstd5*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedSmZstd2*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedSmZstd2*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedSmZstd2*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedSmZstd5*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedSmZstd5*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedSmZstd5*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedZstd2*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedZstd2*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedZstd2*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedZstd5*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedZstd5*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-weightedZstd5*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-zstd2*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-zstd5*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedSmZstd3*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedSmZstd3*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedSmZstd3*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedSmZstd6*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedSmZstd6*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedSmZstd6*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedZstd3*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedZstd3*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedZstd3*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedZstd6*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedZstd6*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-binarizedZstd6*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-preproc3*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-preproc6*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-smZstd3*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-smZstd6*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedSmZstd3*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedSmZstd3*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedSmZstd3*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedSmZstd6*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedSmZstd6*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedSmZstd6*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedZstd3*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedZstd3*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedZstd3*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedZstd6*_degreeCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedZstd6*_eigenCentrality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-weightedZstd6*_lfcd
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-zstd3*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-zstd6*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_res-derivative*_desc-bold*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6Sym*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-T1w*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_vmhc
```
</details>

<details><summary><code>tree output</code></summary>

```tree
output
└── pipeline_benchmark-FNIRT
    └── sub-NDARYX806FL1
        └── ses-HBNsiteRU
            ├── anat
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-brain_T1w.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-brain_T1w.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-brain_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-brain_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-head_T1w.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-head_T1w.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-preproc_T1w.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-preproc_T1w.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-reorient_T1w.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_desc-reorient_T1w.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-MNI152NLin6ASym_to-T1w_mode-image_desc-linear_xfm.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-MNI152NLin6ASym_to-T1w_mode-image_desc-linear_xfm.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-MNI152NLin6Sym_to-T1w_mode-image_desc-linear_xfm.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-MNI152NLin6Sym_to-T1w_mode-image_desc-linear_xfm.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6ASym_mode-image_desc-linear_xfm.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6ASym_mode-image_desc-linear_xfm.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6ASym_mode-image_xfm.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6ASym_mode-image_xfm.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6Sym_mode-image_desc-linear_xfm.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6Sym_mode-image_desc-linear_xfm.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6Sym_mode-image_xfm.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_from-T1w_to-MNI152NLin6Sym_mode-image_xfm.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-CSF_desc-preproc_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-CSF_desc-preproc_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-CSF_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-CSF_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-CSF_probseg.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-CSF_probseg.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-GM_desc-preproc_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-GM_desc-preproc_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-GM_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-GM_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-GM_probseg.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-GM_probseg.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-WM_desc-preproc_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-WM_desc-preproc_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-WM_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-WM_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-WM_probseg.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_label-WM_probseg.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_space-MNI152NLin6ASym_desc-brain_mask.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_space-MNI152NLin6ASym_desc-brain_mask.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_space-MNI152NLin6ASym_desc-head_T1w.json
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_space-MNI152NLin6ASym_desc-head_T1w.nii.gz
            │   ├── sub-NDARYX806FL1_ses-HBNsiteRU_space-MNI152NLin6ASym_desc-preproc_T1w.json
            │   └── sub-NDARYX806FL1_ses-HBNsiteRU_space-MNI152NLin6ASym_desc-preproc_T1w.nii.gz
            └── func
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Mean1_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Mean1_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Mean4_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Mean4_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PartialNilearn1_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PartialNilearn1_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PartialNilearn4_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PartialNilearn4_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PearsonNilearn1_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PearsonNilearn1_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PearsonNilearn4_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-PearsonNilearn4_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-SpatReg1_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-SpatReg1_timeseries.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-SpatReg4_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-SpatReg4_timeseries.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Voxel1_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Voxel1_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Voxel4_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-Voxel4_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-ndmg1_correlations.csv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-ndmg1_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-ndmg4_correlations.csv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor1_desc-ndmg4_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Mean2_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Mean2_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Mean5_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Mean5_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PartialNilearn2_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PartialNilearn2_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PartialNilearn5_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PartialNilearn5_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PearsonNilearn2_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PearsonNilearn2_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PearsonNilearn5_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-PearsonNilearn5_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-SpatReg2_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-SpatReg2_timeseries.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-SpatReg5_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-SpatReg5_timeseries.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Voxel2_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Voxel2_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Voxel5_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-Voxel5_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-ndmg2_correlations.csv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-ndmg2_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-ndmg5_correlations.csv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor2_desc-ndmg5_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Mean3_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Mean3_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Mean6_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Mean6_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PartialNilearn3_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PartialNilearn3_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PartialNilearn6_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PartialNilearn6_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PearsonNilearn3_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PearsonNilearn3_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PearsonNilearn6_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-PearsonNilearn6_correlations.tsv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-SpatReg3_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-SpatReg3_timeseries.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-SpatReg6_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-SpatReg6_timeseries.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Voxel3_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Voxel3_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Voxel6_timeseries.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-Voxel6_timeseries.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-ndmg3_correlations.csv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-ndmg3_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-ndmg6_correlations.csv
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_atlas-rois2mm_reg-Regressor3_desc-ndmg6_correlations.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-FDJenkinson_motion.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-FDJenkinson_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-FDPower_motion.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-FDPower_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-brain_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-brain_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-brain_mask.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-brain_mask.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-cleaned_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-cleaned_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-dvars_motion.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-dvars_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-maxDisplacement_motion.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-maxDisplacement_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-mean_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-mean_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-motionParams_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-motionParams_motion.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-motion_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-motion_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-movementParameters_motion.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-movementParameters_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-powerParams_motion.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-powerParams_motion.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-sm4_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-sm4_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-smZstd_alff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-smZstd_alff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-smZstd_falff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-smZstd_falff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-zstd_alff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-zstd_alff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-zstd_falff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_desc-zstd_falff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_framewiseDisplacementJenkinsonPlotQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_framewiseDisplacementJenkinsonPlotQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_from-bold_to-MNI152NLin6ASym_mode-image_xfm.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_from-bold_to-MNI152NLin6ASym_mode-image_xfm.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_from-bold_to-MNI152NLin6Sym_mode-image_xfm.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_from-bold_to-MNI152NLin6Sym_mode-image_xfm.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_from-bold_to-T1w_mode-image_desc-linear_xfm.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_from-bold_to-T1w_mode-image_desc-linear_xfm.mat
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_movementParametersRotQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_movementParametersRotQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_movementParametersTransQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_movementParametersTransQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrAxialQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrAxialQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrHistQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrHistQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrQc.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrSagittalQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-1_boldSnrSagittalQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrAxialQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrAxialQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrHistQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrHistQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrQc.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrSagittalQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-4_boldSnrSagittalQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-preproc1_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-preproc1_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-preproc4_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-preproc4_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-smZstd1_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-smZstd1_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-smZstd4_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-smZstd4_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-zstd1_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-zstd1_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-zstd4_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor1_desc-zstd4_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrAxialQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrAxialQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrHistQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrHistQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrQc.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrSagittalQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-2_boldSnrSagittalQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrAxialQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrAxialQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrHistQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrHistQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrQc.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrSagittalQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-5_boldSnrSagittalQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-preproc2_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-preproc2_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-preproc5_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-preproc5_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-smZstd2_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-smZstd2_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-smZstd5_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-smZstd5_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-zstd2_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-zstd2_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-zstd5_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor2_desc-zstd5_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrAxialQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrAxialQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrHistQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrHistQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrQc.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrSagittalQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-3_boldSnrSagittalQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrAxialQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrAxialQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrHistQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrHistQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrQc.txt
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrSagittalQc.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-6_boldSnrSagittalQc.png
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-preproc3_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-preproc3_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-preproc6_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-preproc6_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-smZstd3_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-smZstd3_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-smZstd6_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-smZstd6_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-zstd3_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-zstd3_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-zstd6_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_reg-Regressor3_desc-zstd6_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_regressors.1D
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_regressors.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_sbref.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_sbref.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-bold_mask.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-bold_mask.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-smZstd_alff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-smZstd_alff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-smZstd_falff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-smZstd_falff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-zstd_alff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-zstd_alff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-zstd_falff.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_desc-zstd_falff.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd1_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd1_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd1_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd1_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd1_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd1_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd4_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd4_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd4_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd4_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd4_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedSmZstd4_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd1_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd1_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd1_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd1_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd1_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd1_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd4_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd4_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd4_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd4_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd4_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-binarizedZstd4_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-preproc1_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-preproc1_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-preproc4_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-preproc4_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-smZstd1_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-smZstd1_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-smZstd4_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-smZstd4_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd1_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd1_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd1_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd1_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd1_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd1_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd4_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd4_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd4_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd4_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd4_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedSmZstd4_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd1_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd1_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd1_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd1_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd1_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd1_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd4_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd4_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd4_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd4_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd4_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-weightedZstd4_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-zstd1_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-zstd1_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-zstd4_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor1_desc-zstd4_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd2_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd2_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd2_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd2_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd2_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd2_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd5_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd5_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd5_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd5_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd5_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedSmZstd5_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd2_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd2_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd2_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd2_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd2_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd2_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd5_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd5_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd5_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd5_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd5_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-binarizedZstd5_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-preproc2_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-preproc2_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-preproc5_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-preproc5_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-smZstd2_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-smZstd2_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-smZstd5_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-smZstd5_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd2_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd2_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd2_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd2_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd2_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd2_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd5_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd5_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd5_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd5_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd5_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedSmZstd5_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd2_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd2_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd2_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd2_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd2_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd2_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd5_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd5_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd5_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd5_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd5_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-weightedZstd5_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-zstd2_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-zstd2_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-zstd5_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor2_desc-zstd5_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd3_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd3_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd3_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd3_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd3_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd3_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd6_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd6_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd6_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd6_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd6_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedSmZstd6_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd3_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd3_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd3_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd3_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd3_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd3_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd6_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd6_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd6_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd6_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd6_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-binarizedZstd6_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-preproc3_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-preproc3_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-preproc6_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-preproc6_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-smZstd3_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-smZstd3_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-smZstd6_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-smZstd6_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd3_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd3_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd3_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd3_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd3_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd3_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd6_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd6_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd6_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd6_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd6_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedSmZstd6_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd3_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd3_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd3_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd3_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd3_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd3_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd6_degreeCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd6_degreeCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd6_eigenCentrality.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd6_eigenCentrality.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd6_lfcd.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-weightedZstd6_lfcd.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-zstd3_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-zstd3_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-zstd6_reho.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_reg-Regressor3_desc-zstd6_reho.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_res-derivative_desc-bold_mask.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_res-derivative_desc-bold_mask.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_sbref.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6ASym_sbref.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6Sym_desc-sm_bold.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-MNI152NLin6Sym_desc-sm_bold.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-T1w_sbref.json
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_space-T1w_sbref.nii.gz
                ├── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_vmhc.json
                └── sub-NDARYX806FL1_ses-HBNsiteRU_task-rest_run-1_vmhc.nii.gz

5 directories, 452 files
```
</details>

### `benchmark-FNIRT` @ 56b58c4
<details><summary><code>expectedOututs.yml</code></summary>

```YAML
anat:
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-head*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-preproc*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-reorient*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-MNI152NLin6ASym*_to-T1w*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-MNI152NLin6Sym*_to-T1w*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6ASym*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6ASym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6Sym*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-T1w*_to-MNI152NLin6Sym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-CSF*_desc-preproc*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-CSF*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-CSF*_probseg
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-GM*_desc-preproc*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-GM*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-GM*_probseg
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-WM*_desc-preproc*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-WM*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_label-WM*_probseg
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-brain*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-head*_T1w
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-preproc*_T1w
func:
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-111*_vmhc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-FDJenkinson*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-FDPower*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-brain*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-cleaned11*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-dvars*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-framewiseDisplacementJenkinsonPlot*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-maxDisplacement*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-mean*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-motion*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-motionParams*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-movementParameters*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-movementParametersRot*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-movementParametersTrans*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-powerParams*_motion
- sub-NDARYX806FL1*_ses-HBNsiteRU*_desc-sm11*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-bold*_to-MNI152NLin6ASym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-bold*_to-MNI152NLin6Sym*_mode-image*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_from-bold*_to-T1w*_mode-image*_desc-linear*_xfm
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-SpatReg*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-Voxel*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-boldSnr*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-boldSnrAxial*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-boldSnrHist*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-boldSnrSagittal*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-cleaned*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-preproc*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-smZstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_desc-zstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor1*_vmhc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-SpatReg*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-Voxel*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-boldSnr*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-boldSnrAxial*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-boldSnrHist*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-boldSnrSagittal*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-cleaned*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-preproc*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-smZstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_desc-zstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor2*_vmhc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-SpatReg*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-Voxel*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-boldSnr*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-boldSnrAxial*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-boldSnrHist*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-boldSnrSagittal*_quality
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-cleaned*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-preproc*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-smZstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_desc-zstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_regressors
- sub-NDARYX806FL1*_ses-HBNsiteRU*_reg-Regressor3*_vmhc
- sub-NDARYX806FL1*_ses-HBNsiteRU*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_desc-bold*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-preproc*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-smZstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor1*_desc-zstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-preproc*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-smZstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor2*_desc-zstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-Mean*_timeseries
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-PartialNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-PearsonNilearn*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-preproc*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-smZstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-smZstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-smZstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-zstd*_alff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-zstd*_falff
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_reg-Regressor3*_desc-zstd*_reho
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_res-derivative*_desc-bold*_mask
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASym*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASymMNI152NLin6ASym*_reg-Regressor1*_desc-ndmg*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASymMNI152NLin6ASym*_reg-Regressor2*_desc-ndmg*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-MNI152NLin6ASymMNI152NLin6ASym*_reg-Regressor3*_desc-ndmg*_correlations
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-T1w*_sbref
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-symtemplate*_desc-sm11*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-symtemplate*_reg-Regressor1*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-symtemplate*_reg-Regressor2*_desc-sm*_bold
- sub-NDARYX806FL1*_ses-HBNsiteRU*_space-symtemplate*_reg-Regressor3*_desc-sm*_bold
```
</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors (**in progress**).

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
