### PR TITLE
:necktie: ACPC align head update 'desc-head_T1w'

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1239,9 +1239,11 @@ def acpc_align_head(wf, cfg, strat_pool, pipe_num, opt=None):
                 ["anatomical_preproc", "run"]],
      "option_key": "None",
      "option_val": "None",
-     "inputs": ["desc-preproc_T1w",
+     "inputs": ["desc-head_T1w",
+                "desc-preproc_T1w",
                 "T1w-ACPC-template"],
-     "outputs": ["desc-preproc_T1w",
+     "outputs": ["desc-head_T1w",
+                 "desc-preproc_T1w",
                  "from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm"]}
     '''
 
@@ -1251,16 +1253,18 @@ def acpc_align_head(wf, cfg, strat_pool, pipe_num, opt=None):
                                 mask=False,
                                 wf_name=f'acpc_align_{pipe_num}')
 
-    node, out = strat_pool.get_data('desc-preproc_T1w')
+    node, out = strat_pool.get_data(['desc-head_T1w', 'desc-preproc_T1w'])
     wf.connect(node, out, acpc_align, 'inputspec.anat_leaf')
 
     node, out = strat_pool.get_data('T1w-ACPC-template')
     wf.connect(node, out, acpc_align, 'inputspec.template_head_for_acpc')
 
     outputs = {
+        'desc-head_T1w': (acpc_align, 'outputspec.acpc_aligned_head'),
         'desc-preproc_T1w': (acpc_align, 'outputspec.acpc_aligned_head'),
         'from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm': (
-            acpc_align, 'outputspec.from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm')
+            acpc_align,
+            'outputspec.from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm')
     }
 
     return (wf, outputs)
@@ -1274,11 +1278,12 @@ def acpc_align_head_with_mask(wf, cfg, strat_pool, pipe_num, opt=None):
                 ["anatomical_preproc", "run"]],
      "option_key": "None",
      "option_val": "None",
-     "inputs": [("desc-preproc_T1w",
+     "inputs": [("desc-head_T1w", "desc-preproc_T1w",
                  "space-T1w_desc-brain_mask"),
                 "T1w-ACPC-template",
                 "T1w-brain-ACPC-template"],
-     "outputs": ["desc-preproc_T1w",
+     "outputs": ["desc-head_T1w",
+                 "desc-preproc_T1w",
                  "space-T1w_desc-brain_mask",
                  "from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm"]}
     '''
@@ -1289,7 +1294,7 @@ def acpc_align_head_with_mask(wf, cfg, strat_pool, pipe_num, opt=None):
                                 mask=True,
                                 wf_name=f'acpc_align_{pipe_num}')
 
-    node, out = strat_pool.get_data('desc-preproc_T1w')
+    node, out = strat_pool.get_data(['desc-head_T1w', 'desc-preproc_T1w'])
     wf.connect(node, out, acpc_align, 'inputspec.anat_leaf')
 
     node, out = strat_pool.get_data('T1w-ACPC-template')
@@ -1303,6 +1308,7 @@ def acpc_align_head_with_mask(wf, cfg, strat_pool, pipe_num, opt=None):
         wf.connect(node, out, acpc_align, 'inputspec.template_brain_for_acpc')
 
     outputs = {
+        'desc-head_T1w': (acpc_align, 'outputspec.acpc_aligned_head'),
         'desc-preproc_T1w': (acpc_align, 'outputspec.acpc_aligned_head'),
         'space-T1w_desc-brain_mask': (
             acpc_align, 'outputspec.acpc_brain_mask'),


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
Crash with abcd-options brain_extraction
Fixes #[issue number] by @[original issue author]

## Description
**Crash**
```
RuntimeError: Command:
3dcalc -a /ocean/projects/med220004p/agutierr/reg_test_1.8.5/bugfix_runs/with_data_configs_formatted/abcd-options/working/pipeline_abcd-options-seed/cpac_sub-NDARAD481FXF_1/anat_reorient_0/sub-NDARAD481FXF_T1w_resample.nii.gz -b /ocean/projects/med220004p/agutierr/reg_test_1.8.5/bugfix_runs/with_data_configs_formatted/abcd-options/working/pipeline_abcd-options-seed/cpac_sub-NDARAD481FXF_1/brain_mask_to_t1_restore_104/wmparc_maths_fill_holes_maths_warp.nii.gz -expr "a*step(b)" -prefix sub-NDARAD481FXF_T1w_resample_calc.nii.gz
Standard output:

Standard error:
++ 3dcalc: AFNI version=AFNI_21.1.00 (Nov  3 2022) [64-bit]
++ Authored by: A cast of thousands
++ WARNING: file /jet/home/agutierr/.afni.log is now 119942812 (120 million) bytes long!
 [7m*+ WARNING: [0m Template space of dataset /ocean/projects/med220004p/agutierr/reg_test_1.8.5/bugfix_runs/with_data_configs_formatted/abcd-options/working/pipeline_abcd-options-seed/cpac_sub-NDARAD481FXF_1/brain_mask_to_t1_restore_104/wmparc_maths_fill_holes_maths_warp.nii.gz does not match space of first dataset
Continuing anyway, but be sure the datasets really do match
 [7m** FATAL ERROR: [0m dataset /ocean/projects/med220004p/agutierr/reg_test_1.8.5/bugfix_runs/with_data_configs_formatted/abcd-options/working/pipeline_abcd-options-seed/cpac_sub-NDARAD481FXF_1/brain_mask_to_t1_restore_104/wmparc_maths_fill_holes_maths_warp.nii.gz differs in size [7221032 voxels] from others [11534336]
```
The wrong input files were being added in brain extraction node. This is because the input was `desc-head`, which worked for most pipelines, except for abcd-options. Now with the addition of desc-preproc and desc-head as the input, the correct input for abcd-options brain extraction were met. 
<!-- Concisely describe what the pull request does. -->

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/58920810/206314510-affbd570-42d2-4ff0-bb99-369b7e3faf12.png">


## Tests
ran abcd-options and correct inputs in brain extraction were there. 
Correct files should be: 
```
infile_a: /acpc_align_60/anat_acpc_6_applywarp/sub-NDARUL675RXW_acq-HCP_T1w_resample_noise_corrected_corrected_warp.nii.gz

infile_b: /brain_mask_to_t1_restore_90/wmparc_maths_fill_holes_maths_warp.nii.gz
```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
