### PR TITLE
👔 `3dresample` template-space brain mask with resampled data

### DIFF
--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -2471,15 +2471,31 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space, res=None):
             new_label = f'{new_label}_res-{res}'
         desc_keys = tuple(f'{new_label}_{key}' for key in desc_keys)
 
-    brain_mask = 'FSL-AFNI-brain-mask' if (
-        space == 'template'
-    ) else 'space-bold_desc-brain_mask'
-
-    node, out = strat_pool.get_data(brain_mask)
-    wf.connect(node, out, nuis, 'inputspec.functional_brain_mask_file_path')
-    if bandpass_before:
+    if space == 'template':
+        # sometimes mm dimensions match but the voxel dimensions don't
+        # so here we align the mask to the resampled data before applying
+        match_grid = pe.Node(afni.Resample(),
+                             name='align_template_mask_to_template_data')
+        match_grid.inputs.outputtype = 'NIFTI_GZ'
+        match_grid.inputs.resample_mode = 'Cu'
+        node, out = strat_pool.get_data('FSL-AFNI-brain-mask')
+        wf.connect(node, out, match_grid, 'in_file')
+        node, out = strat_pool.get_data(desc_keys[0])
+        wf.connect(node, out, match_grid, 'master')
+        wf.connect(match_grid, 'out_file',
+                   nuis, 'inputspec.functional_brain_mask_file_path')
+        if bandpass_before:
+            wf.connect(match_grid, 'out_file',
+                       nofilter_nuis,
+                       'inputspec.functional_brain_mask_file_path')
+    else:
+        node, out = strat_pool.get_data('space-bold_desc-brain_mask')
         wf.connect(node, out,
-                   nofilter_nuis, 'inputspec.functional_brain_mask_file_path')
+                   nuis, 'inputspec.functional_brain_mask_file_path')
+        if bandpass_before:
+            wf.connect(node, out,
+                       nofilter_nuis,
+                       'inputspec.functional_brain_mask_file_path')
 
     node, out = strat_pool.get_data('regressors')
     wf.connect(node, out, nuis, 'inputspec.regressor_file')
@@ -2512,9 +2528,13 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space, res=None):
         node, out = strat_pool.get_data('regressors')
         wf.connect(node, out, filt, 'inputspec.regressors_file_path')
 
-        node, out = strat_pool.get_data(brain_mask)
-        wf.connect(node, out,
-                   filt, 'inputspec.functional_brain_mask_file_path')
+        if space == 'template':
+            wf.connect(match_grid, 'out_file',
+                       filt, 'inputspec.functional_brain_mask_file_path')
+        else:
+            node, out = strat_pool.get_data('space-bold_desc-brain_mask')
+            wf.connect(node, out,
+                       filt, 'inputspec.functional_brain_mask_file_path')
 
         node, out = strat_pool.get_data('TR')
         wf.connect(node, out, filt, 'inputspec.tr')


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes [`CRASHES v1.8.5/fx-options`](https://drive.google.com/drive/folders/1ww4nIh1SRRWKhd8OB3frgydFPeGo1a2Q) by @amygutierrez 

## Description
<!-- Concisely describe what the pull request does. -->
When applying nuisance correction in template space, sometimes the template-space brain mask is slightly misaligned with the template-space data (for example, the mask's `3dinfo` would show
```
R-to-L extent:   -94.045 [R] -to-    95.045 [L] -step-     3.438 mm [ 56 voxels]
A-to-P extent:   -94.954 [A] -to-   131.954 [P] -step-     3.438 mm [ 67 voxels]
I-to-S extent:   -77.700 [I] -to-   112.700 [S] -step-     3.400 mm [ 57 voxels]
```
while the timeseries `3dinfo` would show
```
R-to-L extent:   -96.028 [R] -to-    96.500 [L] -step-     3.438 mm [ 57 voxels]
A-to-P extent:   -97.846 [A] -to-   132.500 [P] -step-     3.438 mm [ 68 voxels]
I-to-S extent:   -78.500 [I] -to-   115.300 [S] -step-     3.400 mm [ 58 voxels]
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
