### PR TITLE
Freesurfer directory ingress overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added [`sdcflows`](https://www.nipreps.org/sdcflows/2.0/) to CPAC requirements
 
 ### Changed
+- Freesurfer output directory ingress moved to the data configuration YAML
 - Space labels in output filenames now contain specific template labels for MNI templates
 - Added a level of depth to `working` directories to match `log` and `output` directory structure
 - Renamed participant-pipeline-level `output` directory prefix to `pipeline_` to match `log` and `working` paths

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2589,8 +2589,8 @@ def freesurfer_reconall(wf, cfg, strat_pool, pipe_num, opt=None):
 def freesurfer_postproc(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "freesurfer_postproc",
-     "config": ["surface_analysis", "freesurfer"],
-     "switch": ["run_postproc"],
+     "config": "None",
+     "switch": "None",
      "option_key": "None",
      "option_val": "None",
      "inputs": [("freesurfer-subject-dir",

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2590,7 +2590,7 @@ def freesurfer_postproc(wf, cfg, strat_pool, pipe_num, opt=None):
     '''
     {"name": "freesurfer_postproc",
      "config": ["surface_analysis", "freesurfer"],
-     "switch": ["run"],
+     "switch": ["run_postproc"],
      "option_key": "None",
      "option_val": "None",
      "inputs": [("freesurfer-subject-dir",

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -41,7 +41,8 @@ import CPAC
 from CPAC.pipeline.check_outputs import check_outputs
 from CPAC.pipeline.engine import NodeBlock, initiate_rpool
 from CPAC.anat_preproc.anat_preproc import (
-    freesurfer_preproc,
+    freesurfer_reconall,
+    freesurfer_postproc,
     freesurfer_abcd_preproc,
     anatomical_init,
     acpc_align_head,
@@ -845,7 +846,8 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
         pipeline_blocks += anat_init_blocks
 
     if not rpool.check_rpool('freesurfer-subject-dir'):
-        pipeline_blocks += [freesurfer_preproc]
+        pipeline_blocks += [freesurfer_reconall]
+    pipeline_blocks += [freesurfer_postproc]
 
     if not rpool.check_rpool('desc-preproc_T1w'):
 
@@ -901,8 +903,7 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
 
         pipeline_blocks += anat_blocks
 
-        if not rpool.check_rpool('freesurfer-subject-dir'):
-            pipeline_blocks += [freesurfer_abcd_preproc]
+        pipeline_blocks += [freesurfer_abcd_preproc]
 
     # Anatomical T1 brain masking
     if not rpool.check_rpool('space-T1w_desc-brain_mask') or \

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -847,7 +847,9 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
 
     if not rpool.check_rpool('freesurfer-subject-dir'):
         pipeline_blocks += [freesurfer_reconall]
-    pipeline_blocks += [freesurfer_postproc]
+        pipeline_blocks += [freesurfer_postproc]
+    else:
+	pipeline_blocks += [freesurfer_postproc]
 
     if not rpool.check_rpool('desc-preproc_T1w'):
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -849,7 +849,7 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
         pipeline_blocks += [freesurfer_reconall]
         pipeline_blocks += [freesurfer_postproc]
     else:
-	pipeline_blocks += [freesurfer_postproc]
+        pipeline_blocks += [freesurfer_postproc]
 
     if not rpool.check_rpool('desc-preproc_T1w'):
 
@@ -882,7 +882,7 @@ def build_anat_preproc_stack(rpool, cfg, pipeline_blocks=None):
             'acpc_target'] == 'whole-head':
             if (rpool.check_rpool('space-T1w_desc-brain_mask') and \
                 cfg.anatomical_preproc['acpc_alignment']['align_brain_mask']) or \
-                    cfg.surface_analysis['freesurfer']['run']:
+                    cfg.surface_analysis['freesurfer']['run_reconall']:
                 acpc_blocks = [
                     acpc_align_head_with_mask
                     # outputs space-T1w_desc-brain_mask for later - keep the mask (the user provided)

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -1627,6 +1627,55 @@ def ingress_raw_anat_data(wf, rpool, cfg, data_paths, unique_id, part_id,
         rpool.set_data('T2w', anat_flow_T2, 'outputspec.anat', {},
                     "", "anat_ingress")
 
+    if 'freesurfer_dir' in data_paths['anat']:
+        anat['freesurfer_dir'] = data_paths['anat']['freesurfer_dir']
+
+        fs_ingress = create_general_datasource('gather_freesurfer_dir')
+        fs_ingress.inputs.inputnode.set(
+            unique_id=unique_id,
+            data=data_paths['anat']['freesurfer_dir'],
+            creds_path=data_paths['creds_path'],
+            dl_dir=cfg.pipeline_setup['working_directory']['path'])
+        rpool.set_data("freesurfer-subject-dir", fs_ingress, 'outputspec.data',
+                       {}, "", "freesurfer_config_ingress")
+
+        recon_outs = {
+            'raw-average': 'mri/rawavg.mgz',
+            'subcortical-seg': 'mri/aseg.mgz',
+            'brainmask': 'mri/brainmask.mgz',
+            'wmparc': 'mri/wmparc.mgz',
+            'T1': 'mri/T1.mgz',
+            'hemi-L_desc-surface_curv': 'surf/lh.curv',
+            'hemi-R_desc-surface_curv': 'surf/rh.curv',
+            'hemi-L_desc-surfaceMesh_pial': 'surf/lh.pial',
+            'hemi-R_desc-surfaceMesh_pial': 'surf/rh.pial',
+            'hemi-L_desc-surfaceMesh_smoothwm': 'surf/lh.smoothwm',
+            'hemi-R_desc-surfaceMesh_smoothwm': 'surf/rh.smoothwm',
+            'hemi-L_desc-surfaceMesh_sphere': 'surf/lh.sphere',
+            'hemi-R_desc-surfaceMesh_sphere': 'surf/rh.sphere',
+            'hemi-L_desc-surfaceMap_sulc': 'surf/lh.sulc',
+            'hemi-R_desc-surfaceMap_sulc': 'surf/rh.sulc',
+            'hemi-L_desc-surfaceMap_thickness': 'surf/lh.thickness',
+            'hemi-R_desc-surfaceMap_thickness': 'surf/rh.thickness',
+            'hemi-L_desc-surfaceMap_volume': 'surf/lh.volume',
+            'hemi-R_desc-surfaceMap_volume': 'surf/rh.volume',
+            'hemi-L_desc-surfaceMesh_white': 'surf/lh.white',
+            'hemi-R_desc-surfaceMesh_white': 'surf/rh.white',
+        }
+        
+        for key, outfile in recon_outs.items():
+            fullpath = os.path.join(data_paths['anat']['freesurfer_dir'],
+                                    outfile)
+            if os.path.exists(fullpath):
+                fs_ingress = create_general_datasource(f'gather_fs_{key}_dir')
+                fs_ingress.inputs.inputnode.set(
+                    unique_id=unique_id,
+                    data=fullpath,
+                    creds_path=data_paths['creds_path'],
+                    dl_dir=cfg.pipeline_setup['working_directory']['path'])
+                rpool.set_data(key, fs_ingress, 'outputspec.data',
+                               {}, "", f"fs_{key}_ingress")
+
     return rpool
 
 
@@ -1944,17 +1993,6 @@ def ingress_pipeconfig_paths(cfg, rpool, unique_id, creds_path=None):
                 )
                 rpool.set_data(key, config_ingress, 'outputspec.data',
                                json_info, "", f"{key}_config_ingress")
-
-    # Freesurfer directory, not a template, so not in cpac_templates.tsv
-    if cfg.surface_analysis['freesurfer']['freesurfer_dir']:
-        fs_ingress = create_general_datasource('gather_freesurfer_dir')
-        fs_ingress.inputs.inputnode.set(
-            unique_id=unique_id,
-            data=cfg.surface_analysis['freesurfer']['freesurfer_dir'],
-            creds_path=creds_path,
-            dl_dir=cfg.pipeline_setup['working_directory']['path'])
-        rpool.set_data("freesurfer-subject-dir", fs_ingress, 'outputspec.data',
-                       json_info, "", "freesurfer_config_ingress")
 
     # templates, resampling from config
     '''

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -711,8 +711,7 @@ latest_schema = Schema({
     'surface_analysis': {
         'freesurfer': {
             'run_reconall': bool1_1,
-            'reconall_args': Maybe(str),
-            'run_postproc': bool1_1
+            'reconall_args': Maybe(str)
         },
         'post_freesurfer': {
             'run': bool1_1,

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -710,9 +710,9 @@ latest_schema = Schema({
     },
     'surface_analysis': {
         'freesurfer': {
-            'run': bool1_1,
+            'run_reconall': bool1_1,
             'reconall_args': Maybe(str),
-            'freesurfer_dir': Maybe(str)
+            'run_postproc': bool1_1
         },
         'post_freesurfer': {
             'run': bool1_1,

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -32,15 +32,6 @@ surface_analysis:
   post_freesurfer:
     run: On
 
-  # Will run Freesurfer for surface-based analysis. Will output traditional Freesurfer derivatives.
-  # If you wish to employ Freesurfer outputs for brain masking or tissue segmentation in the voxel-based pipeline,
-  # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
-  freesurfer:
-
-    # If anatomical_preproc['brain_extraction']['using'] includes FreeSurfer-ABCD and this switch is On, C-PAC will automatically turn this switch Off to avoid running FreeSurfer twice unnecessarily
-    # FreeSurfer will run as part of configured brain extraction in this specific configuration, so FreeSurfer's independent run was automatically disabled.
-    run: Off
-
 anatomical_preproc:
   run: On
   acpc_alignment:

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -32,6 +32,14 @@ surface_analysis:
   post_freesurfer:
     run: On
 
+  # Will run Freesurfer for surface-based analysis. Will output traditional Freesurfer derivatives.
+  # If you wish to employ Freesurfer outputs for brain masking or tissue segmentation in the voxel-based pipeline,
+  # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
+  freesurfer:
+
+    # FreeSurfer will run as part of configured brain extraction in this specific configuration, so FreeSurfer's independent run was automatically disabled.
+    run_reconall: Off
+
 anatomical_preproc:
   run: On
   acpc_alignment:

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -207,7 +207,6 @@ surface_analysis:
     # Add extra arguments to recon-all command
     reconall_args:
 
-
   # Run ABCD-HCP post FreeSurfer and fMRISurface pipeline
   post_freesurfer:
     run: Off

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -207,9 +207,6 @@ surface_analysis:
     # Add extra arguments to recon-all command
     reconall_args:
 
-    # Run recon-all post-processing steps
-    #   Includes conversions of .mgz to .nii, and generation of tissue masks
-    run_postproc: Off
 
   # Run ABCD-HCP post FreeSurfer and fMRISurface pipeline
   post_freesurfer:

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -209,7 +209,8 @@ surface_analysis:
     reconall_args:
 
     # Run recon-all post-processing steps
-    run: Off
+    #   Includes conversions of .mgz to .nii, and generation of tissue masks
+    run_postproc: Off
 
   # Run ABCD-HCP post FreeSurfer and fMRISurface pipeline
   post_freesurfer:

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -202,7 +202,6 @@ surface_analysis:
   # If you wish to employ Freesurfer outputs for brain masking or tissue segmentation in the voxel-based pipeline,
   # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
   freesurfer:
-
     run_reconall: Off
 
     # Add extra arguments to recon-all command

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -203,13 +203,12 @@ surface_analysis:
   # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
   freesurfer:
 
+    run_reconall: Off
+
     # Add extra arguments to recon-all command
     reconall_args:
 
-    # (Optional) Provide an already-existing FreeSurfer output directory to ingress already-computed surfaces
-    freesurfer_dir:
-
-    # If anatomical_preproc['brain_extraction']['using'] includes FreeSurfer-ABCD and this switch is On, C-PAC will automatically turn this switch Off to avoid running FreeSurfer twice unnecessarily
+    # Run recon-all post-processing steps
     run: Off
 
   # Run ABCD-HCP post FreeSurfer and fMRISurface pipeline

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -49,8 +49,9 @@ surface_analysis:
     # Add extra arguments to recon-all command
     reconall_args: -clean-bm -gcut
 
-    # If anatomical_preproc['brain_extraction']['using'] includes FreeSurfer-ABCD and this switch is On, C-PAC will automatically turn this switch Off to avoid running FreeSurfer twice unnecessarily
-    run: On
+    # Run recon-all post-processing steps
+    #   Includes conversions of .mgz to .nii, and generation of tissue masks
+    run_postproc: On
 
 anatomical_preproc:
   run: On

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -48,9 +48,6 @@ surface_analysis:
     # Add extra arguments to recon-all command
     reconall_args: -clean-bm -gcut
 
-    # Run recon-all post-processing steps
-    #   Includes conversions of .mgz to .nii, and generation of tissue masks
-    run_postproc: On
 
 anatomical_preproc:
   run: On

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -48,7 +48,6 @@ surface_analysis:
     # Add extra arguments to recon-all command
     reconall_args: -clean-bm -gcut
 
-
 anatomical_preproc:
   run: On
   acpc_alignment:

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -44,6 +44,8 @@ surface_analysis:
   # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
   freesurfer:
 
+    run_reconall: On
+
     # Add extra arguments to recon-all command
     reconall_args: -clean-bm -gcut
 

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -43,7 +43,6 @@ surface_analysis:
   # If you wish to employ Freesurfer outputs for brain masking or tissue segmentation in the voxel-based pipeline,
   # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
   freesurfer:
-
     run_reconall: On
 
     # Add extra arguments to recon-all command

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -203,9 +203,6 @@ surface_analysis:
     # Add extra arguments to recon-all command
     reconall_args:
 
-    # Run recon-all post-processing steps
-    #   Includes conversions of .mgz to .nii, and generation of tissue masks
-    run_postproc: Off
 
   # Run ABCD-HCP post FreeSurfer and fMRISurface pipeline
   post_freesurfer: 

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -198,14 +198,14 @@ surface_analysis:
   # select those 'Freesurfer-' labeled options further below in anatomical_preproc.
   freesurfer: 
 
-    # If anatomical_preproc['brain_extraction']['using'] includes FreeSurfer-ABCD and this switch is On, C-PAC will automatically turn this switch Off to avoid running FreeSurfer twice unnecessarily
-    run: Off
+    run_reconall: Off
 
     # Add extra arguments to recon-all command
-    reconall_args: None
-    
-    # (Optional) Provide an already-existing FreeSurfer output directory to ingress already-computed surfaces
-    freesurfer_dir: None
+    reconall_args:
+
+    # Run recon-all post-processing steps
+    #   Includes conversions of .mgz to .nii, and generation of tissue masks
+    run_postproc: Off
 
   # Run ABCD-HCP post FreeSurfer and fMRISurface pipeline
   post_freesurfer: 

--- a/CPAC/utils/configuration/configuration.py
+++ b/CPAC/utils/configuration/configuration.py
@@ -123,7 +123,8 @@ class Configuration:
             if 'FreeSurfer-ABCD' in config_map['anatomical_preproc'][
                     'brain_extraction']['using']:
                 self.set_nested(config_map,
-                                ['surface_analysis', 'freesurfer', 'run'],
+                                ['surface_analysis', 'freesurfer', 
+                                 'run_reconall'],
                                 False)
                 warn(DOUBLERUN_GUARD_MESSAGE)
         except (KeyError, TypeError):

--- a/CPAC/utils/configuration/yaml_template.py
+++ b/CPAC/utils/configuration/yaml_template.py
@@ -87,7 +87,7 @@ class YamlTemplate():  # pylint: disable=too-few-public-methods
         -------
         str
         """
-        # Initialize variable for autmatically updated value
+        # Initialize variable for automatically updated value
         if parents == ['surface_analysis', 'freesurfer'] or parents is None:
             freesurfer_extraction = False
             try:
@@ -119,7 +119,8 @@ class YamlTemplate():  # pylint: disable=too-few-public-methods
             # Insert automatically-changed value in original dict
             if freesurfer_extraction:
                 new_dict = set_nested_value(
-                    new_dict, ['surface_analysis', 'freesurfer', 'run'], False)
+                    new_dict, ['surface_analysis', 'freesurfer', 
+                    'run_reconall'], False)
         else:
             _dump = []
         # Prepare for indentation
@@ -143,7 +144,7 @@ class YamlTemplate():  # pylint: disable=too-few-public-methods
             except KeyError:  # exclude unincluded keys
                 continue
             # Add comment for automatically changed value
-            if (keys == ['surface_analysis', 'freesurfer', 'run'] and
+            if (keys == ['surface_analysis', 'freesurfer', 'run_reconall'] and
                     freesurfer_extraction):
                 if comment is None:
                     comment = []


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1861 by @sgiavasis

## Description
<!-- Concisely describe what the pull request does. -->
- Moves Freesurfer data ingress to the data configuration YAML file.
  - It is now under `anat:`, as the key `freesurfer_dir:`
- Splits the existing Freesurfer recon-all post-proc/conversion nodes into their own separate node block.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
- [ ] Correct Freesurfer data gets ingressed into the resource pool.
- [ ] Freesurfer recon-all is skipped if data is ingressed.
- [ ] mgz-to-nii conversion nodes continue with the ingressed data.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
