### PR TITLE
🥅 Handle having `freesurfer_dir` but no FreeSurfer options

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2626,9 +2626,8 @@ def freesurfer_postproc(wf, cfg, strat_pool, pipe_num, opt=None):
                  "label-WM_mask",
                  "label-GM_mask"]}
     '''
-    inputs = flatten_input_list(
-        grab_docstring_dct(freesurfer_postproc).get('inputs', []))
-    inputs.remove('T1')  # not necessary to exist
+    inputs = flatten_input_list(freesurfer_postproc)
+    inputs.remove('T1')  # optional input
     if not all(strat_pool.check_rpool(_input) for _input in inputs):
         # warn and continue if we have FreeSurfer outputs but
         # don't have a FreeSurfer configuration

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1088,11 +1088,11 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
             nb = NodeBlock(block)
             wf, logtail = nb.connect_block(wf, cfg, rpool)
             if logtail:
-                LOGTAIL['warning'] += f'\n{logtail}'
+                LOGTAIL['warnings'].append(logtail)
         except LookupError as e:
             if nb.name == 'freesurfer_postproc':
                 logger.warning(WARNING_FREESURFER_OFF_WITH_DATA)
-                LOGTAIL['warning'] += f'\n{WARNING_FREESURFER_OFF_WITH_DATA}'
+                LOGTAIL['warnings'].append(WARNING_FREESURFER_OFF_WITH_DATA)
                 continue
             previous_nb_str = (
                 f"after node block '{previous_nb.get_name()}': "

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1086,9 +1086,7 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
     for block in pipeline_blocks:
         try:
             nb = NodeBlock(block)
-            wf, logtail = nb.connect_block(wf, cfg, rpool)
-            if logtail:
-                LOGTAIL['warnings'].append(logtail)
+            wf = nb.connect_block(wf, cfg, rpool)
         except LookupError as e:
             if nb.name == 'freesurfer_postproc':
                 logger.warning(WARNING_FREESURFER_OFF_WITH_DATA)

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1088,6 +1088,12 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
             nb = NodeBlock(block)
             wf = nb.connect_block(wf, cfg, rpool)
         except LookupError as e:
+            if nb.name == 'freesurfer_postproc':
+                logger.warning('The provided data configuration includes '
+                               "'freesurfer_dir' but the provided pipeline "
+                               'config is not configured to use FreeSurfer '
+                               'outputs.')
+                continue
             previous_nb_str = (
                 f"after node block '{previous_nb.get_name()}': "
             ) if previous_nb else 'at beginning:'

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -20,6 +20,8 @@ from itertools import chain
 import logging
 import os
 import re
+from types import FunctionType
+from typing import Tuple, Union
 import warnings
 
 from CPAC.pipeline import \
@@ -1521,18 +1523,28 @@ class NodeBlock:
         return wf, logtail
 
 
-def flatten_input_list(resource_list: list) -> list:
-    """Take a list of input resources and return a flat list
+def flatten_input_list(node_block_function: Union[FunctionType, list, Tuple]
+                       ) -> list:
+    """Take a Node Block function or list of inputs and return a flat list
 
     Parameters
     ----------
-    resource_list : list
+    node_block_function : function, list or tuple
+        a Node Block function or a list or tuple for recursion
 
     Returns
     -------
     list
     """
     flat_list = []
+    resource_list = []
+    if isinstance(node_block_function, (list, tuple)):
+        resource_list = node_block_function
+    elif isinstance(node_block_function, FunctionType):
+        resource_list = grab_docstring_dct(node_block_function).get('inputs',
+                                                                    [])
+    elif isinstance(node_block_function, str):
+        resource_list = [node_block_function]
     for resource in resource_list:
         if isinstance(resource, str):
             flat_list.append(resource)

--- a/CPAC/utils/docs.py
+++ b/CPAC/utils/docs.py
@@ -7,6 +7,7 @@ from CPAC import __version__
 
 def docstring_parameter(*args, **kwargs):
     """Decorator to parameterize docstrings.
+    Use double-curly-braces ({{}}) for literal curly braces.
 
     Examples
     --------
@@ -16,6 +17,12 @@ def docstring_parameter(*args, **kwargs):
     ...     pass
     >>> print(do_nothing.__doc__)
     Does this test do anything? Yes it does.
+    >>> @docstring_parameter('test', answer='It should not.')
+    ... def how_about_now():
+    ...     '''How about {{ this }}?'''
+    ...     pass
+    >>> print(how_about_now.__doc__)
+    How about { this }?
     """
     def dec(obj):
         if obj.__doc__ is None:
@@ -59,7 +66,7 @@ def grab_docstring_dct(fn):
                        'option_val', 'inputs', 'outputs']
     if 'Node Block:' in fn_docstring:
         fn_docstring = fn_docstring.split('Node Block:')[1]
-    fn_docstring = fn_docstring.lstrip().replace('\n', '')
+    fn_docstring = fn_docstring.lstrip().replace('\n', '').rstrip()
     dct = ast.literal_eval(fn_docstring)
     for key in init_dct_schema:
         if key not in dct.keys():

--- a/CPAC/utils/monitoring/__init__.py
+++ b/CPAC/utils/monitoring/__init__.py
@@ -2,6 +2,7 @@
 
 See https://fcp-indi.github.io/docs/developer/nodes for C-PAC-specific documentation.
 See https://nipype.readthedocs.io/en/latest/api/generated/nipype.utils.profiler.html for Nipype's documentation.'''  # noqa: E501  # pylint: disable=line-too-long
+from .config import LOGTAIL, WARNING_FREESURFER_OFF_WITH_DATA
 from .custom_logging import failed_to_start, getLogger, set_up_logger
 from .monitoring import LoggingHTTPServer, LoggingRequestHandler, \
                         log_nodes_cb, log_nodes_initial, monitor_server, \
@@ -9,4 +10,5 @@ from .monitoring import LoggingHTTPServer, LoggingRequestHandler, \
 
 __all__ = ['failed_to_start', 'getLogger', 'LoggingHTTPServer',
            'LoggingRequestHandler', 'log_nodes_cb', 'log_nodes_initial',
-           'monitor_server', 'recurse_nodes', 'set_up_logger']
+           'LOGTAIL', 'monitor_server', 'recurse_nodes', 'set_up_logger',
+           'WARNING_FREESURFER_OFF_WITH_DATA']

--- a/CPAC/utils/monitoring/config.py
+++ b/CPAC/utils/monitoring/config.py
@@ -1,5 +1,5 @@
 """Global variables for logging"""
-LOGTAIL = {'warning': ''}
+LOGTAIL = {'warnings': []}
 MOCK_LOGGERS = {}
 WARNING_FREESURFER_OFF_WITH_DATA = (
     'The provided data configuration includes \'freesurfer_dir\' but the '

--- a/CPAC/utils/monitoring/config.py
+++ b/CPAC/utils/monitoring/config.py
@@ -1,1 +1,6 @@
+"""Global variables for logging"""
+LOGTAIL = {'warning': ''}
 MOCK_LOGGERS = {}
+WARNING_FREESURFER_OFF_WITH_DATA = (
+    'The provided data configuration includes \'freesurfer_dir\' but the '
+    'provided pipeline config is not configured to use FreeSurfer outputs.')

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -800,6 +800,7 @@ def run_main():
                         ' have been written to %s and %s respectively.\n',
                         pipeline_config_file, data_config_file)
 
+            # wait to import `LOGTAIL` here so it has any runtime updates
             from CPAC.utils.monitoring import LOGTAIL
             for warning in LOGTAIL['warnings']:
                 logger.warning('%s\n', warning.rstrip())

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -793,11 +793,16 @@ def run_main():
             if monitoring:
                 monitoring.join(10)
 
-            if args.analysis_level == "test_config" and exitcode == 0:
-                print(
-                    '\nPipeline and data configuration files should'
-                    f' have been written to {pipeline_config_file} and ',
-                    f'{data_config_file} respectively.')
+            if args.analysis_level == "test_config":
+                if exitcode == 0:
+                    logger.info(
+                        '\nPipeline and data configuration files should'
+                        ' have been written to %s and %s respectively.\n',
+                        pipeline_config_file, data_config_file)
+
+            from CPAC.utils.monitoring import LOGTAIL
+            if LOGTAIL['warning']:
+                logger.warning('%s\n', LOGTAIL['warning'].rstrip())
 
     sys.exit(exitcode)
 

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -801,8 +801,8 @@ def run_main():
                         pipeline_config_file, data_config_file)
 
             from CPAC.utils.monitoring import LOGTAIL
-            if LOGTAIL['warning']:
-                logger.warning('%s\n', LOGTAIL['warning'].rstrip())
+            for warning in LOGTAIL['warnings']:
+                logger.warning('%s\n', warning.rstrip())
 
     sys.exit(exitcode)
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #1862 by @sgiavasis & #1865 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->

1. Catches various potential points of failure when provided a `freesurfer_dir` in a data config but not a pipeline config that uses FreeSurfer outputs
1. Throws a warning at the point of failure
1. Repeats that warning at the end of `pypeline.log`

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* Checks for all required resources and throws the warning if we have 'freesurfer-subject-dir' but are missing any others https://github.com/FCP-INDI/C-PAC/blob/d48a4716d5467433c18278b959e5245610402c69/CPAC/anat_preproc/anat_preproc.py#L2570-L2577
* Updates this print statement https://github.com/FCP-INDI/C-PAC/blob/af2d7f160d29129ef8ef4b9546734404139c7715/dev/docker_data/run.py#L806-L809 to a `logger.info` https://github.com/FCP-INDI/C-PAC/blob/c5b6f0dc34d2a79631ed5b1acd0d417f941d88f4/dev/docker_data/run.py#L798-L801 
* Keeps any warnings to repeat at the end in a global dictionary of lists https://github.com/FCP-INDI/C-PAC/blob/c5b6f0dc34d2a79631ed5b1acd0d417f941d88f4/CPAC/utils/monitoring/config.py#L2
* Hacky/specific thing for `freesurfer_postproc`:
  1. If we're given `freesurfer_dir` in the data config, we put `freesurfer_postproc` in the stack. https://github.com/FCP-INDI/C-PAC/blob/d48a4716d5467433c18278b959e5245610402c69/CPAC/pipeline/cpac_pipeline.py#L848-L851 This is in #1865 but doesn't quite work right in the running-`reconall` case.
  2. If we're running `reconall`, that NodeBlock calls `freesurfer_postproc` directly like so:
      1. We grab the output list from `freesurfer_postproc` and append it to the output list of `freesurfer_reconall` https://github.com/FCP-INDI/C-PAC/blob/d48a4716d5467433c18278b959e5245610402c69/CPAC/anat_preproc/anat_preproc.py#L2680-L2700
      2. We stick the `freesurfer_reconall` outputs in `strat_pool` https://github.com/FCP-INDI/C-PAC/blob/d48a4716d5467433c18278b959e5245610402c69/CPAC/anat_preproc/anat_preproc.py#L2730-L2744
      3. We connect `freesurfer_preproc` from within `freesurfer_reconall` https://github.com/FCP-INDI/C-PAC/blob/d48a4716d5467433c18278b959e5245610402c69/CPAC/anat_preproc/anat_preproc.py#L2745-L2746
      4. We update the `freesurfer_reconall` outputs to include the `freesurfer_preproc` outputs and return the whole thing for the engine to connect https://github.com/FCP-INDI/C-PAC/blob/d48a4716d5467433c18278b959e5245610402c69/CPAC/anat_preproc/anat_preproc.py#L2747-L2750

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
### In-place warning
![screenshot of in-place warning](https://user-images.githubusercontent.com/5974438/210867654-501df046-f210-43c6-86a5-75f574ea1cce.png)

### Repeated warning at end of pipeline
![screenshot of repeated warning](https://user-images.githubusercontent.com/5974438/210867735-d524138c-73aa-49e7-8677-00a9110aef92.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `bugfix/freesurfer_postproc` branch of the repository.
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that ~~there are no visible errors~~ the errors I was trying to catch are handled.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
