### PR TITLE
abcd-options postfreesurfer /tmp directory fix 

### DIFF
--- a/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
+++ b/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
@@ -100,7 +100,7 @@ fi
 
 #delete the temp space directory
 # trap clean_up EXIT SIGTERM SIGHUP SIGINT SIGQUIT
-#rm -rf ${TempSubjectDIR}
+rm -rf ${TempSubjectDIR}
 
 #delete common temporaries
 rm -f ${ResultsFolder}/${NameOffMRI}_temp_subject_dilate.dtseries.nii

--- a/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
+++ b/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
@@ -48,7 +48,7 @@ unset POSIXLY_CORRECT
 #mkdir -p $TempSubjectDIR
 
 #hj edit: make a temp dir
-TempSubjectDIR="/tmp/TempSubjectDIR"
+TempSubjectDIR="/output/working/tmp/TempSubjectDIR"
 mkdir -p $TempSubjectDIR
 chmod 770 $TempSubjectDIR
 

--- a/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
+++ b/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
@@ -100,7 +100,7 @@ fi
 
 #delete the temp space directory
 # trap clean_up EXIT SIGTERM SIGHUP SIGINT SIGQUIT
-rm -rf ${TempSubjectDIR}
+#rm -rf ${TempSubjectDIR}
 
 #delete common temporaries
 rm -f ${ResultsFolder}/${NameOffMRI}_temp_subject_dilate.dtseries.nii

--- a/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
+++ b/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
@@ -48,7 +48,7 @@ unset POSIXLY_CORRECT
 #mkdir -p $TempSubjectDIR
 
 #hj edit: make a temp dir
-TempSubjectDIR="$ResultsFolder/tmp/TempSubjectDIR"
+TempSubjectDIR="$ResultsFolder/TempSubjectDIR"
 mkdir -p $TempSubjectDIR
 chmod 770 $TempSubjectDIR
 

--- a/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
+++ b/CPAC/surface/fMRISurface/SubcorticalProcessing.sh
@@ -48,7 +48,7 @@ unset POSIXLY_CORRECT
 #mkdir -p $TempSubjectDIR
 
 #hj edit: make a temp dir
-TempSubjectDIR="/output/working/tmp/TempSubjectDIR"
+TempSubjectDIR="$ResultsFolder/tmp/TempSubjectDIR"
 mkdir -p $TempSubjectDIR
 chmod 770 $TempSubjectDIR
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
Fixes abcd-options [crash](https://drive.google.com/drive/u/0/folders/1VSQjZ0-hlaF91_NvLMEN5gDIalvMGnpB) in post_freesurfer node. 

## Description
<!-- Concisely describe what the pull request does. -->
Crash states: 
```
subprocess.CalledProcessError: Command '['bash', '/code/CPAC/surface/fMRISurface/run.sh', '--post_freesurfer_folder', '/ocean/projects/med220004p/agutierr/reg_test_1.8.5/all_pipelines_2/abcd-options/KKI/working/pipeline_abcd-options-seed/cpac_1019436_1/post_freesurfer_496', '--subject', '1019436_1', '--fmri', '/ocean/projects/med220004p/agutierr/reg_test_1.8.5/all_pipelines_2/abcd-options/KKI/working/pipeline_abcd-options-seed/cpac_1019436_1/_scan_rest_acq-1_run-1/extract_func_brain_250/vol0000_warp_merged_maths.nii.gz', '--scout', '/ocean/projects/med220004p/agutierr/reg_test_1.8.5/all_pipelines_2/abcd-options/KKI/working/pipeline_abcd-options-seed/cpac_1019436_1/_scan_rest_acq-1_run-1/extract_scout_brain_228/sub-1019436_ses-1_task-rest_acq-1_run-1_bold_resample_calc_calc_warp_maths.nii.gz', '--lowresmesh', '32', '--grayordinatesres', '2', '--fmrires', '2', '--smoothingFWHM', '2']' returned non-zero exit status 255.
```
But does not indicate where the crash was occuring. @shnizzedy confirmed [here](https://gist.github.com/shnizzedy/21d9e9388fe71f84b264d96fcffb1f56#file-230111-19-02-53-749-nipype-interface-error-log) from their [branch](https://github.com/FCP-INDI/C-PAC/tree/debug/abcd-options) that the error was coming from the line: 
```
While running:
wb_command -cifti-resample /tmp/TempSubjectDIR/task-rest01_temp_subject_smooth.dtseries.nii COLUMN /tmp/TempSubjectDIR/task-rest01_temp_template.dlabel.nii COLUMN ADAP_BARY_AREA CUBIC /tmp/TempSubjectDIR/task-rest01_temp_atlas.dtseries.nii -volume-predilate 10

ERROR: failed to open file '/tmp/TempSubjectDIR/task-rest01_temp_atlas.dtseries.nii', unable to create file
```
When the bash script `/code/CPAC/surface/fMRISurface/run.sh` is executed in terminal, no errors occur. 

## Technical details
After running abcd-options, I saved the container and shelled into the container to view the `/tmp` directory. This directory is a default directory that comes with Linux OS. After viewing the permissions it looks like the directory did not have enough permissions, thus why the files were not able to be used in the script. 
```
root@e43c8684b55c:/# ls -al tmp/TempSubjectDIR
total 158140
drwxrwx--- 2 root root     4096 Jan 13 06:26 .
drwxrwxrwx 1 root root     4096 Jan 13 16:15 ..
-rw-r--r-- 1 root root 53833568 Jan 13 06:47 task-rest01_temp_atlas.dtseries.nii
-rw-r--r-- 1 root root 53833440 Jan 13 06:26 task-rest01_temp_subject_dilate.dtseries.nii
-rw-r--r-- 1 root root 53833264 Jan 13 06:26 task-rest01_temp_subject_smooth.dtseries.nii
-rw-r--r-- 1 root root   420936 Jan 13 06:26 task-rest01_temp_template.dlabel.nii
```

This /tmp directory was switched to be saved in the working directory where there are execute permissions for all user types. 
[CPAC/surface/fMRISurface/SubcorticalProcessing.sh](https://github.com/FCP-INDI/C-PAC/pull/1871/commits/3fbdb12f2b66ba40756d7222f3e23f7929618078)
<img width="675" alt="image" src="https://user-images.githubusercontent.com/58920810/213478973-b59aeb0d-7bc8-4761-aa89-3eaba7bdc9a3.png">

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
abcd-options was run again with the directory changes made. There were no crashes after the run and all expected outputs were there.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
