### PR TITLE
Refactor TR_string_to_float

### DIFF
--- a/CPAC/nuisance/tests/utils/test_compcor.py
+++ b/CPAC/nuisance/tests/utils/test_compcor.py
@@ -1,0 +1,25 @@
+import pytest
+
+from CPAC.nuisance.utils import compcor
+
+
+def test_TR_string_to_float():
+    assert abs(compcor.TR_string_to_float('123') - 123.) < 1e-08
+    assert abs(compcor.TR_string_to_float('123s') - 123.) < 1e-08
+    assert abs(compcor.TR_string_to_float('123ms') - 123. / 1000) < 1e-08
+
+    assert abs(compcor.TR_string_to_float('1.23') - 1.23) < 1e-08
+    assert abs(compcor.TR_string_to_float('1.23s') - 1.23) < 1e-08
+    assert abs(compcor.TR_string_to_float('1.23ms') - 1.23 / 1000) < 1e-08
+
+    with pytest.raises(Exception):
+        compcor.TR_string_to_float(None)
+
+    with pytest.raises(Exception):
+        compcor.TR_string_to_float(['123'])
+
+    with pytest.raises(Exception):
+        compcor.TR_string_to_float(123)
+
+    with pytest.raises(Exception):
+        compcor.TR_string_to_float('ms')

--- a/CPAC/nuisance/utils/compcor.py
+++ b/CPAC/nuisance/utils/compcor.py
@@ -198,17 +198,13 @@ def TR_string_to_float(tr):
         raise TypeError(f'Improper type for TR_string_to_float ({tr}).')
 
     tr_str = tr.replace(' ', '')
-    factor = 1.
-
-    if tr_str.endswith('ms'):
-        tr_str = tr_str[:-2]
-        factor = 0.001
-    elif tr.endswith('s'):
-        tr_str = tr_str[:-1]
 
     try:
-        tr_numeric = float(tr_str)
+        if tr_str.endswith('ms'):
+            tr_numeric = float(tr_str[:-2]) * 0.001
+        elif tr.endswith('s'):
+            tr_numeric = float(tr_str[:-1])
     except Exception as exc:
         raise ValueError(f'Can not convert TR string to float: "{tr}".') from exc
 
-    return tr_numeric * factor
+    return tr_numeric

--- a/CPAC/nuisance/utils/compcor.py
+++ b/CPAC/nuisance/utils/compcor.py
@@ -204,6 +204,8 @@ def TR_string_to_float(tr):
             tr_numeric = float(tr_str[:-2]) * 0.001
         elif tr.endswith('s'):
             tr_numeric = float(tr_str[:-1])
+        else:
+            tr_numeric = float(tr_str)
     except Exception as exc:
         raise ValueError(f'Can not convert TR string to float: "{tr}".') from exc
 

--- a/CPAC/nuisance/utils/compcor.py
+++ b/CPAC/nuisance/utils/compcor.py
@@ -181,9 +181,34 @@ def fallback_svd(a, full_matrices=True, compute_uv=True):
 
 
 def TR_string_to_float(tr):
-    if 'ms' in tr:
-        tr = float(tr.replace('ms', '')) / 1000
-    else:
-        tr = float(tr.replace('s', ''))
+    """
+    Convert TR string to seconds (float). Suffixes 's' or 'ms' to indicate
+    seconds or milliseconds.
 
-    return tr
+    Parameters
+    ----------
+    tr : TR string representation. May use suffixes 's' or 'ms' to indicate
+    seconds or milliseconds.
+
+    Returns
+    -------
+    tr in seconds (float)
+    """
+    if not isinstance(tr, str):
+        raise TypeError(f'Improper type for TR_string_to_float ({tr}).')
+
+    tr_str = tr.replace(' ', '')
+    factor = 1.
+
+    if tr_str.endswith('ms'):
+        tr_str = tr_str[:-2]
+        factor = 0.001
+    elif tr.endswith('s'):
+        tr_str = tr_str[:-1]
+
+    try:
+        tr_numeric = float(tr_str)
+    except Exception as exc:
+        raise ValueError(f'Can not convert TR string to float: "{tr}".') from exc
+
+    return tr_numeric * factor


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->

Refactor `CPAC.nuisance.utils.compcor.TR_string_to_float`:
- Added documentation
- Added input validation
- Better error reporting
- More explicit logic

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
