### PR TITLE
🔊 Verbose debugging update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `fail_fast` configuration setting and CLI flag
 - Added abililty to fork on motion filter
 - Added [`sdcflows`](https://www.nipreps.org/sdcflows/2.0/) to CPAC requirements
+- Added NodeBlock information to verbose debugging log (`engine.log`)
 
 ### Changed
 - Freesurfer output directory ingress moved to the data configuration YAML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `fail_fast` configuration setting and CLI flag
 - Added abililty to fork on motion filter
 - Added [`sdcflows`](https://www.nipreps.org/sdcflows/2.0/) to CPAC requirements
-- Added NodeBlock information to verbose debugging log (`engine.log`)
+- Added NodeBlock information to `pypeline.log` when verbose debugging is on
 
 ### Changed
 - Freesurfer output directory ingress moved to the data configuration YAML

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -290,7 +290,6 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
             'resource_monitor_frequency': 0.2,
             'stop_on_first_crash': c['pipeline_setup', 'system_config',
                                      'fail_fast']}})
-
     config.enable_resource_monitor()
     logging.update_logging(config)
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1106,7 +1106,8 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
     previous_nb = None
     for block in pipeline_blocks:
         try:
-            nb = NodeBlock(block)
+            nb = NodeBlock(block, debug=cfg['pipeline_setup', 'Debugging',
+                                            'verbose'])
             wf = nb.connect_block(wf, cfg, rpool)
         except LookupError as e:
             if nb.name == 'freesurfer_postproc':


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Facilitates debugging NodeBlock connections by adding inputs and outputs to `pypeline.log` when verbose debugging is on.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
This feature moves the 'connecting {name}…' statements into the NodeBlock initialization function and involves toggling debugging-level logging around these statements https://github.com/FCP-INDI/C-PAC/blob/10a0e955b79234612a9a16d9afb3ea2f6e8891db/CPAC/pipeline/engine.py#L1240-L1250 to avoid excessively verbose logging like
```Python
230222-14:54:07,611 nipype.workflow INFO:
	 Connecting anatomical_init...
230222-14:54:07,612 nipype.workflow DEBUG:
	 "inputs": ['T1w']
	 "outputs": ['desc-preproc_T1w', 'desc-reorient_T1w', 'desc-head_T1w']
230222-14:54:07,615 nipype.workflow DEBUG:
	 (cpac_sub-5518204_ses-1.anat_T1w_gather_sub-5518204_ses-1, cpac_sub-5518204_ses-1.anat_deoblique_0): No edge data
230222-14:54:07,616 nipype.workflow DEBUG:
	 (cpac_sub-5518204_ses-1.anat_T1w_gather_sub-5518204_ses-1, cpac_sub-5518204_ses-1.anat_deoblique_0): new edge data: {'connect': [('outputspec.anat', 'in_file')]}
230222-14:54:07,617 nipype.workflow DEBUG:
	 (cpac_sub-5518204_ses-1.anat_deoblique_0, cpac_sub-5518204_ses-1.anat_reorient_0): No edge data
230222-14:54:07,618 nipype.workflow DEBUG:
	 (cpac_sub-5518204_ses-1.anat_deoblique_0, cpac_sub-5518204_ses-1.anat_reorient_0): new edge data: {'connect': [('out_file', 'in_file')]}
```

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

### `verbose: Off`
with
```YAML
FROM: default

pipeline_setup:
  Debugging:
    verbose: Off
```
:
```Python
230222-14:42:55,753 nipype.workflow INFO:
	 Connecting anatomical_init...
230222-14:42:55,755 nipype.workflow INFO:
	 Connecting freesurfer_reconall...
230222-14:42:55,756 nipype.workflow INFO:
	 Connecting acpc_alignment_head...
230222-14:42:55,757 nipype.workflow INFO:
	 Connecting nlm_filtering...
230222-14:42:55,757 nipype.workflow INFO:
	 Connecting n4_bias_correction...
230222-14:42:55,758 nipype.workflow INFO:
	 Connecting freesurfer_abcd_preproc...
230222-14:42:55,759 nipype.workflow INFO:
	 Connecting brain_mask_afni...
230222-14:42:55,759 nipype.workflow INFO:
	 Connecting brain_mask_fsl...
230222-14:42:55,760 nipype.workflow INFO:
	 Connecting brain_mask_niworkflows_ants...
230222-14:42:55,761 nipype.workflow INFO:
	 Connecting brain_mask_unet...
230222-14:42:55,761 nipype.workflow INFO:
	 Connecting brain_mask_freesurfer_abcd...
230222-14:42:55,762 nipype.workflow INFO:
	 Connecting brain_mask_freesurfer_fsl_tight...
230222-14:42:55,763 nipype.workflow INFO:
	 Connecting brain_mask_freesurfer_fsl_loose...
230222-14:42:55,765 nipype.workflow INFO:
	 Connecting brain_extraction...
230222-14:42:55,766 nipype.workflow INFO:
	 Connecting brain_mask_T2...
230222-14:42:55,767 nipype.workflow INFO:
	 Connecting brain_extraction_T2...
230222-14:42:55,768 nipype.workflow INFO:
	 Connecting register_ANTs_anat_to_template...
230222-14:42:55,769 nipype.workflow INFO:
	 Connecting register_FSL_anat_to_template...
230222-14:42:55,827 nipype.workflow INFO:
	 Connecting overwrite_transform_anat_to_template...
230222-14:42:55,828 nipype.workflow INFO:
	 Connecting transform_whole_head_T1w_to_T1template...
230222-14:42:55,832 nipype.workflow INFO:
	 Connecting transform_T1mask_to_T1template...
230222-14:42:55,836 nipype.workflow INFO:
	 Connecting correct_restore_brain_intensity_abcd...
230222-14:42:55,837 nipype.workflow INFO:
	 Connecting register_symmetric_ANTs_anat_to_template...
230222-14:42:55,838 nipype.workflow INFO:
	 Connecting register_symmetric_FSL_anat_to_template...
230222-14:42:55,873 nipype.workflow INFO:
	 Connecting tissue_seg_fsl_fast...
230222-14:42:55,873 nipype.workflow INFO:
	 Connecting tissue_seg_ants_prior...
230222-14:42:55,920 nipype.workflow INFO:
	 Connecting tissue_seg_T1_template_based...
230222-14:42:55,921 nipype.workflow INFO:
	 Connecting warp_tissuemask_to_T1template...
230222-14:42:55,934 nipype.workflow INFO:
	 Connecting func_reorient...
230222-14:42:55,935 nipype.workflow INFO:
	 Connecting func_scaling...
230222-14:42:55,936 nipype.workflow INFO:
	 Connecting func_truncate...
230222-14:42:55,961 nipype.workflow INFO:
	 Connecting func_despike...
230222-14:42:55,962 nipype.workflow INFO:
	 Connecting func_slice_time...
230222-14:42:55,978 nipype.workflow INFO:
	 Connecting func_mean...
230222-14:42:55,979 nipype.workflow INFO:
	 Connecting get_motion_ref...
230222-14:42:55,981 nipype.workflow INFO:
	 Connecting motion_correction...
230222-14:42:55,992 nipype.workflow INFO:
	 Connecting motion_estimate_filter...
230222-14:42:55,992 nipype.workflow INFO:
	 Connecting bold_mask_afni...
230222-14:42:55,993 nipype.workflow INFO:
	 Connecting bold_mask_fsl...
230222-14:42:55,994 nipype.workflow INFO:
	 Connecting bold_mask_fsl_afni...
230222-14:42:55,995 nipype.workflow INFO:
	 Connecting bold_mask_anatomical_refined...
230222-14:42:55,995 nipype.workflow INFO:
	 Connecting bold_mask_anatomical_based...
230222-14:42:55,996 nipype.workflow INFO:
	 Connecting bold_mask_anatomical_resampled...
230222-14:42:55,997 nipype.workflow INFO:
	 Connecting bold_mask_ccs...
230222-14:42:55,998 nipype.workflow INFO:
	 Connecting bold_masking...
230222-14:42:56,0 nipype.workflow INFO:
	 Connecting calc_motion_stats...
230222-14:42:56,8 nipype.workflow INFO:
	 Connecting func_normalize...
230222-14:42:56,9 nipype.workflow INFO:
	 Connecting coregistration_prep_vol...
230222-14:42:56,10 nipype.workflow INFO:
	 Connecting coregistration_prep_mean...
230222-14:42:56,11 nipype.workflow INFO:
	 Connecting coregistration_prep_fmriprep...
230222-14:42:56,11 nipype.workflow INFO:
	 Connecting coregistration...
230222-14:42:56,42 nipype.workflow INFO:
	 Connecting register_ANTs_EPI_to_template...
230222-14:42:56,42 nipype.workflow INFO:
	 Connecting register_FSL_EPI_to_template...
230222-14:42:56,43 nipype.workflow INFO:
	 Connecting create_func_to_T1template_xfm...
230222-14:42:56,49 nipype.workflow INFO:
	 Connecting create_func_to_T1template_symmetric_xfm...
230222-14:42:56,56 nipype.workflow INFO:
	 Connecting ICA_AROMA_ANTsreg...
230222-14:42:56,57 nipype.workflow INFO:
	 Connecting ICA_AROMA_FSLreg...
230222-14:42:56,57 nipype.workflow INFO:
	 Connecting ICA_AROMA_ANTsEPIreg...
230222-14:42:56,58 nipype.workflow INFO:
	 Connecting ICA_AROMA_FSLEPIreg...
230222-14:42:56,59 nipype.workflow INFO:
	 Connecting erode_mask_T1w...
230222-14:42:56,60 nipype.workflow INFO:
	 Connecting erode_mask_CSF...
230222-14:42:56,60 nipype.workflow INFO:
	 Connecting erode_mask_GM...
230222-14:42:56,61 nipype.workflow INFO:
	 Connecting erode_mask_WM...
230222-14:42:56,62 nipype.workflow INFO:
	 Connecting erode_mask_bold...
230222-14:42:56,62 nipype.workflow INFO:
	 Connecting erode_mask_boldCSF...
230222-14:42:56,63 nipype.workflow INFO:
	 Connecting erode_mask_boldGM...
230222-14:42:56,64 nipype.workflow INFO:
	 Connecting erode_mask_boldWM...
230222-14:42:56,64 nipype.workflow INFO:
	 Connecting nuisance_regressors_generation...
230222-14:42:56,132 nipype.workflow INFO:
	 Connecting nuisance_regression_native...
230222-14:42:56,188 nipype.workflow INFO:
	 Connecting apply_phasediff_to_timeseries_separately...
230222-14:42:56,188 nipype.workflow INFO:
	 Connecting apply_blip_to_timeseries_separately...
230222-14:42:56,189 nipype.workflow INFO:
	 Connecting transform_timeseries_to_T1template...
230222-14:42:56,190 nipype.workflow INFO:
	 Connecting transform_timeseries_to_T1template_dcan_nhp...
230222-14:42:56,191 nipype.workflow INFO:
	 Connecting transform_timeseries_to_T1template_abcd...
230222-14:42:56,192 nipype.workflow INFO:
	 Connecting single_step_resample_stc_timeseries_to_T1template...
230222-14:42:56,388 nipype.workflow INFO:
	 Connecting transform_sbref_to_T1template...
230222-14:42:56,396 nipype.workflow INFO:
	 Connecting transform_bold_mask_to_T1template...
230222-14:42:56,402 nipype.workflow INFO:
	 Connecting transform_deriv_mask_to_T1template...
230222-14:42:56,408 nipype.workflow INFO:
	 Connecting func_despike_template...
230222-14:42:56,409 nipype.workflow INFO:
	 Connecting transform_bold_mask_to_EPItemplate...
230222-14:42:56,409 nipype.workflow INFO:
	 Connecting transform_deriv_mask_to_EPItemplate...
230222-14:42:56,410 nipype.workflow INFO:
	 Connecting surface_preproc...
230222-14:42:56,411 nipype.workflow INFO:
	 Connecting timeseries_extraction_AVG...
230222-14:42:56,559 nipype.workflow INFO:
	 Connecting spatial_regression...
230222-14:42:56,601 nipype.workflow INFO:
	 Connecting alff_falff...
230222-14:42:56,788 nipype.workflow INFO:
	 Connecting ReHo...
230222-14:42:56,897 nipype.workflow INFO:
	 Connecting smooth_func_vmhc...
230222-14:42:56,922 nipype.workflow INFO:
	 Connecting transform_timeseries_to_sym_template...
230222-14:42:56,952 nipype.workflow INFO:
	 Connecting vmhc...
230222-14:42:56,967 nipype.workflow INFO:
	 Connecting network_centrality...
230222-14:42:57,316 nipype.workflow INFO:
	 Connecting qc_snr_plot...
230222-14:42:57,384 nipype.workflow INFO:
	 Connecting qc_coregistration...
230222-14:42:57,390 nipype.workflow INFO:
	 Connecting qc_motion_plot...
230222-14:42:57,392 nipype.workflow INFO:
	 Connecting qc_fd_plot...
230222-14:42:57,395 nipype.workflow INFO:
	 Connecting qc_brain_extraction...
230222-14:42:57,399 nipype.workflow INFO:
	 Connecting qc_brain_extraction...
230222-14:42:57,404 nipype.workflow INFO:
	 Connecting qc_segmentation...
230222-14:42:57,410 nipype.workflow INFO:
	 Connecting qc_carpet_plot...
230222-14:42:57,451 nipype.workflow INFO:
	 Connecting qc_bold_registration...
230222-14:43:00,295 nipype.workflow INFO:
	 This has been a test of the pipeline configuration file, the pipeline was built successfully, but was not run
```
### `verbose: On`
with 
```YAML
FROM: default

pipeline_setup:
  Debugging:
    verbose: On
```
:
```Python
230222-13:57:22,365 nipype.workflow INFO:
	 Connecting anatomical_init...
230222-13:57:22,366 nipype.workflow DEBUG:
	 "inputs": ['T1w']
	 "outputs": ['desc-preproc_T1w', 'desc-reorient_T1w', 'desc-head_T1w']
230222-13:57:22,370 nipype.workflow INFO:
	 Connecting freesurfer_reconall...
230222-13:57:22,371 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w']
	 "outputs": ['freesurfer-subject-dir', 'raw-average', 'subcortical-seg', 'brainmask', 'wmparc', 'T1', 'space-T1w_desc-brain_mask', 'hemi-L_desc-surface_curv', 'hemi-R_desc-surface_curv', 'hemi-L_desc-surfaceMesh_pial', 'hemi-R_desc-surfaceMesh_pial', 'hemi-L_desc-surfaceMesh_smoothwm', 'hemi-R_desc-surfaceMesh_smoothwm', 'hemi-L_desc-surfaceMesh_sphere', 'hemi-R_desc-surfaceMesh_sphere', 'hemi-L_desc-surfaceMap_sulc', 'hemi-R_desc-surfaceMap_sulc', 'hemi-L_desc-surfaceMap_thickness', 'hemi-R_desc-surfaceMap_thickness', 'hemi-L_desc-surfaceMap_volume', 'hemi-R_desc-surfaceMap_volume', 'hemi-L_desc-surfaceMesh_white', 'hemi-R_desc-surfaceMesh_white', 'label-CSF_mask', 'label-WM_mask', 'label-GM_mask']
230222-13:57:22,372 nipype.workflow INFO:
	 Connecting acpc_alignment_head...
230222-13:57:22,373 nipype.workflow DEBUG:
	 "inputs": ['desc-head_T1w', 'desc-preproc_T1w', 'T1w-ACPC-template']
	 "outputs": ['desc-head_T1w', 'desc-preproc_T1w', 'from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm']
230222-13:57:22,373 nipype.workflow INFO:
	 Connecting nlm_filtering...
230222-13:57:22,374 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w']
	 "outputs": ['desc-preproc_T1w']
230222-13:57:22,375 nipype.workflow INFO:
	 Connecting n4_bias_correction...
230222-13:57:22,376 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w']
	 "outputs": ['desc-preproc_T1w', 'desc-n4_T1w']
230222-13:57:22,376 nipype.workflow INFO:
	 Connecting freesurfer_abcd_preproc...
230222-13:57:22,377 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w', 'T1w-template', 'T1w-brain-template-mask', 'template-ref-mask-res-2', 'T1w-template-res-2', 'freesurfer-subject-dir']
	 "outputs": ['desc-restore_T1w', 'desc-restore-brain_T1w', 'desc-fast_biasfield', 'hemi-L_desc-surface_curv', 'hemi-R_desc-surface_curv', 'hemi-L_desc-surfaceMesh_pial', 'hemi-R_desc-surfaceMesh_pial', 'hemi-L_desc-surfaceMesh_smoothwm', 'hemi-R_desc-surfaceMesh_smoothwm', 'hemi-L_desc-surfaceMesh_sphere', 'hemi-R_desc-surfaceMesh_sphere', 'hemi-L_desc-surfaceMap_sulc', 'hemi-R_desc-surfaceMap_sulc', 'hemi-L_desc-surfaceMap_thickness', 'hemi-R_desc-surfaceMap_thickness', 'hemi-L_desc-surfaceMap_volume', 'hemi-R_desc-surfaceMap_volume', 'hemi-L_desc-surfaceMesh_white', 'hemi-R_desc-surfaceMesh_white', 'wmparc', 'freesurfer-subject-dir']
230222-13:57:22,378 nipype.workflow INFO:
	 Connecting brain_mask_afni...
230222-13:57:22,379 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w']
	 "outputs": ['space-T1w_desc-brain_mask']
230222-13:57:22,380 nipype.workflow INFO:
	 Connecting brain_mask_fsl...
230222-13:57:22,380 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w']
	 "outputs": ['space-T1w_desc-brain_mask']
230222-13:57:22,381 nipype.workflow INFO:
	 Connecting brain_mask_niworkflows_ants...
230222-13:57:22,382 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w']
	 "outputs": ['space-T1w_desc-brain_mask', 'desc-preproc_T1w']
230222-13:57:22,383 nipype.workflow INFO:
	 Connecting brain_mask_unet...
230222-13:57:22,383 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w', 'T1w-brain-template', 'T1w-template', 'unet-model']
	 "outputs": ['space-T1w_desc-brain_mask']
230222-13:57:22,384 nipype.workflow INFO:
	 Connecting brain_mask_freesurfer_abcd...
230222-13:57:22,385 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w', 'wmparc', 'freesurfer-subject-dir']
	 "outputs": ['space-T1w_desc-brain_mask']
230222-13:57:22,386 nipype.workflow INFO:
	 Connecting brain_mask_freesurfer_fsl_tight...
230222-13:57:22,386 nipype.workflow DEBUG:
	 "inputs": ['brainmask', 'T1', 'raw-average', 'freesurfer-subject-dir', 'T1w-brain-template-mask-ccs', 'T1w-ACPC-template']
	 "outputs": ['space-T1w_desc-tight_brain_mask']
230222-13:57:22,387 nipype.workflow INFO:
	 Connecting brain_mask_freesurfer_fsl_loose...
230222-13:57:22,388 nipype.workflow DEBUG:
	 "inputs": ['brainmask', 'T1', 'raw-average', 'freesurfer-subject-dir', 'T1w-brain-template-mask-ccs', 'T1w-ACPC-template']
	 "outputs": ['space-T1w_desc-loose_brain_mask']
230222-13:57:22,393 nipype.workflow INFO:
	 Connecting brain_extraction...
230222-13:57:22,394 nipype.workflow DEBUG:
	 "inputs": [('desc-head_T1w', 'desc-preproc_T1w', ['space-T1w_desc-brain_mask', 'space-T1w_desc-acpcbrain_mask'])]
	 "outputs": ['desc-preproc_T1w', 'desc-brain_T1w', 'desc-head_T1w']
230222-13:57:22,403 nipype.workflow INFO:
	 Connecting brain_mask_T2...
230222-13:57:22,417 nipype.workflow DEBUG:
	 "inputs": [(['desc-reorient_T1w', 'T1w', 'desc-preproc_T1w'], ['desc-reorient_T2w', 'T2w', 'desc-preproc_T2w'], ['space-T1w_desc-brain_mask', 'space-T1w_desc-acpcbrain_mask'], 'space-T2w_desc-acpcbrain_mask')]
	 "outputs": ['space-T2w_desc-brain_mask']
230222-13:57:22,418 nipype.workflow INFO:
	 Connecting brain_extraction_T2...
230222-13:57:22,419 nipype.workflow DEBUG:
	 "inputs": [('desc-acpcbrain_T2w', 'desc-preproc_T2w', ['space-T2w_desc-brain_mask', 'space-T2w_desc-acpcbrain_mask'])]
	 "outputs": ['desc-brain_T2w']
230222-13:57:22,420 nipype.workflow INFO:
	 Connecting register_ANTs_anat_to_template...
230222-13:57:22,420 nipype.workflow DEBUG:
	 "inputs": [(['desc-preproc_T1w', 'space-longitudinal_desc-brain_T1w'], ['space-T1w_desc-brain_mask', 'space-longitudinal_desc-brain_mask', 'space-T1w_desc-acpcbrain_mask'], ['desc-restore_T1w', 'desc-head_T1w', 'desc-preproc_T1w', 'space-longitudinal_desc-reorient_T1w']), 'T1w-template', 'T1w-brain-template', 'T1w-brain-template-mask', 'label-lesion_mask']
	 "outputs": ['space-template_desc-preproc_T1w', 'from-T1w_to-template_mode-image_desc-linear_xfm', 'from-template_to-T1w_mode-image_desc-linear_xfm', 'from-T1w_to-template_mode-image_desc-nonlinear_xfm', 'from-template_to-T1w_mode-image_desc-nonlinear_xfm', 'from-T1w_to-template_mode-image_xfm', 'from-template_to-T1w_mode-image_xfm', 'from-longitudinal_to-template_mode-image_desc-linear_xfm', 'from-template_to-longitudinal_mode-image_desc-linear_xfm', 'from-longitudinal_to-template_mode-image_desc-nonlinear_xfm', 'from-template_to-longitudinal_mode-image_desc-nonlinear_xfm', 'from-longitudinal_to-template_mode-image_xfm', 'from-template_to-longitudinal_mode-image_xfm']
230222-13:57:22,421 nipype.workflow INFO:
	 Connecting register_FSL_anat_to_template...
230222-13:57:22,422 nipype.workflow DEBUG:
	 "inputs": [(['desc-preproc_T1w', 'space-longitudinal_desc-reorient_T1w'], ['desc-brain_T1w', 'space-longitudinal_desc-brain_T1w']), 'T1w-template', 'T1w-brain-template', 'FNIRT-T1w-template', 'FNIRT-T1w-brain-template', 'template-ref-mask']
	 "outputs": ['space-template_desc-preproc_T1w', 'space-template_desc-head_T1w', 'space-template_desc-T1w_mask', 'space-template_desc-T1wT2w_biasfield', 'from-T1w_to-template_mode-image_desc-linear_xfm', 'from-template_to-T1w_mode-image_desc-linear_xfm', 'from-T1w_to-template_mode-image_xfm', 'from-T1w_to-template_mode-image_warp', 'from-longitudinal_to-template_mode-image_desc-linear_xfm', 'from-template_to-longitudinal_mode-image_desc-linear_xfm', 'from-longitudinal_to-template_mode-image_xfm']
230222-13:57:22,470 nipype.workflow INFO:
	 Connecting overwrite_transform_anat_to_template...
230222-13:57:22,471 nipype.workflow DEBUG:
	 "inputs": [('desc-restore-brain_T1w', ['desc-preproc_T1w', 'space-longitudinal_desc-brain_T1w'], ['desc-restore_T1w', 'desc-preproc_T1w', 'desc-reorient_T1w', 'T1w'], ['desc-preproc_T1w', 'desc-reorient_T1w', 'T1w'], 'space-T1w_desc-brain_mask', 'T1w-template', 'from-T1w_to-template_mode-image_xfm', 'from-template_to-T1w_mode-image_xfm', 'space-template_desc-brain_T1w')]
	 "outputs": ['space-template_desc-preproc_T1w', 'space-template_desc-head_T1w', 'space-template_desc-T1w_mask', 'from-T1w_to-template_mode-image_xfm', 'from-template_to-T1w_mode-image_xfm']
230222-13:57:22,472 nipype.workflow INFO:
	 Connecting transform_whole_head_T1w_to_T1template...
230222-13:57:22,472 nipype.workflow DEBUG:
	 "inputs": [('desc-head_T1w', 'from-T1w_to-template_mode-image_xfm'), 'T1w-template']
	 "outputs": ['space-template_desc-head_T1w']
230222-13:57:22,486 nipype.workflow INFO:
	 Connecting transform_T1mask_to_T1template...
230222-13:57:22,487 nipype.workflow DEBUG:
	 "inputs": [('space-T1w_desc-brain_mask', 'from-T1w_to-template_mode-image_xfm'), 'T1w-template']
	 "outputs": ['space-template_desc-brain_mask']
230222-13:57:22,500 nipype.workflow INFO:
	 Connecting correct_restore_brain_intensity_abcd...
230222-13:57:22,501 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_T1w', 'desc-n4_T1w', 'desc-restore-brain_T1w', 'space-T1w_desc-brain_mask', 'desc-fast_biasfield', 'from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm', 'from-T1w_to-template_mode-image_xfm')]
	 "outputs": ['desc-restore-brain_T1w']
230222-13:57:22,503 nipype.workflow INFO:
	 Connecting register_symmetric_ANTs_anat_to_template...
230222-13:57:22,504 nipype.workflow DEBUG:
	 "inputs": [(['desc-preproc_T1w', 'space-longitudinal_desc-brain_T1w'], ['space-T1w_desc-brain_mask', 'space-longitudinal_desc-brain_mask'], ['desc-head_T1w', 'desc-preproc_T1w', 'space-longitudinal_desc-reorient_T1w']), 'T1w-template-symmetric', 'T1w-brain-template-symmetric', 'dilated-symmetric-brain-mask', 'label-lesion_mask']
	 "outputs": ['space-symtemplate_desc-preproc_T1w', 'from-T1w_to-symtemplate_mode-image_desc-linear_xfm', 'from-symtemplate_to-T1w_mode-image_desc-linear_xfm', 'from-T1w_to-symtemplate_mode-image_desc-nonlinear_xfm', 'from-symtemplate_to-T1w_mode-image_desc-nonlinear_xfm', 'from-T1w_to-symtemplate_mode-image_xfm', 'from-symtemplate_to-T1w_mode-image_xfm', 'from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm', 'from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm', 'from-longitudinal_to-symtemplate_mode-image_desc-nonlinear_xfm', 'from-symtemplate_to-longitudinal_mode-image_desc-nonlinear_xfm', 'from-longitudinal_to-symtemplate_mode-image_xfm', 'from-symtemplate_to-longitudinal_mode-image_xfm']
230222-13:57:22,505 nipype.workflow INFO:
	 Connecting register_symmetric_FSL_anat_to_template...
230222-13:57:22,505 nipype.workflow DEBUG:
	 "inputs": [(['desc-preproc_T1w', 'space-longitudinal_desc-reorient_T1w'], ['desc-brain_T1w', 'space-longitudinal_desc-brain_T1w']), 'T1w-template-symmetric', 'T1w-brain-template-symmetric', 'dilated-symmetric-brain-mask']
	 "outputs": ['space-symtemplate_desc-preproc_T1w', 'from-T1w_to-symtemplate_mode-image_desc-linear_xfm', 'from-symtemplate_to-T1w_mode-image_desc-linear_xfm', 'from-T1w_to-symtemplate_mode-image_xfm', 'from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm', 'from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm', 'from-longitudinal_to-symtemplate_mode-image_xfm']
230222-13:57:22,552 nipype.workflow INFO:
	 Connecting tissue_seg_fsl_fast...
230222-13:57:22,553 nipype.workflow DEBUG:
	 "inputs": [(['desc-brain_T1w', 'space-longitudinal_desc-brain_T1w'], ['space-T1w_desc-brain_mask', 'space-longitudinal_desc-brain_mask'], ['from-template_to-T1w_mode-image_desc-linear_xfm', 'from-template_to-longitudinal_mode-image_desc-linear_xfm']), 'CSF-path', 'GM-path', 'WM-path']
	 "outputs": ['label-CSF_mask', 'label-GM_mask', 'label-WM_mask', 'label-CSF_desc-preproc_mask', 'label-GM_desc-preproc_mask', 'label-WM_desc-preproc_mask', 'label-CSF_probseg', 'label-GM_probseg', 'label-WM_probseg', 'label-CSF_pveseg', 'label-GM_pveseg', 'label-WM_pveseg', 'space-longitudinal_label-CSF_mask', 'space-longitudinal_label-GM_mask', 'space-longitudinal_label-WM_mask', 'space-longitudinal_label-CSF_desc-preproc_mask', 'space-longitudinal_label-GM_desc-preproc_mask', 'space-longitudinal_label-WM_desc-preproc_mask', 'space-longitudinal_label-CSF_probseg', 'space-longitudinal_label-GM_probseg', 'space-longitudinal_label-WM_probseg']
230222-13:57:22,554 nipype.workflow INFO:
	 Connecting tissue_seg_ants_prior...
230222-13:57:22,555 nipype.workflow DEBUG:
	 "inputs": [('desc-brain_T1w', ['space-T1w_desc-brain_mask', 'space-T1w_desc-acpcbrain_mask'])]
	 "outputs": ['label-CSF_mask', 'label-GM_mask', 'label-WM_mask']
230222-13:57:22,598 nipype.workflow INFO:
	 Connecting tissue_seg_T1_template_based...
230222-13:57:22,599 nipype.workflow DEBUG:
	 "inputs": [('desc-brain_T1w', 'from-template_to-T1w_mode-image_desc-linear_xfm')]
	 "outputs": ['label-CSF_mask', 'label-GM_mask', 'label-WM_mask']
230222-13:57:22,600 nipype.workflow INFO:
	 Connecting warp_tissuemask_to_T1template...
230222-13:57:22,600 nipype.workflow DEBUG:
	 "inputs": [('label-CSF_mask', 'label-WM_mask', 'label-GM_mask', 'from-T1w_to-template_mode-image_xfm'), 'T1w-template']
	 "outputs": ['space-template_label-CSF_mask', 'space-template_label-WM_mask', 'space-template_label-GM_mask']
230222-13:57:22,634 nipype.workflow INFO:
	 Connecting func_reorient...
230222-13:57:22,635 nipype.workflow DEBUG:
	 "inputs": ['bold']
	 "outputs": ['desc-preproc_bold', 'desc-reorient_bold']
230222-13:57:22,639 nipype.workflow INFO:
	 Connecting func_scaling...
230222-13:57:22,640 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['desc-preproc_bold']
230222-13:57:22,641 nipype.workflow INFO:
	 Connecting func_truncate...
230222-13:57:22,641 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['desc-preproc_bold']
230222-13:57:22,649 nipype.workflow INFO:
	 Connecting func_despike...
230222-13:57:22,650 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['desc-preproc_bold']
230222-13:57:22,651 nipype.workflow INFO:
	 Connecting func_slice_time...
230222-13:57:22,652 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold', 'TR', 'tpattern']
	 "outputs": ['desc-preproc_bold', 'desc-stc_bold']
230222-13:57:22,660 nipype.workflow INFO:
	 Connecting func_mean...
230222-13:57:22,661 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['desc-mean_bold']
230222-13:57:22,667 nipype.workflow INFO:
	 Connecting get_motion_ref...
230222-13:57:22,667 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold', 'desc-reorient_bold']
	 "outputs": ['motion-basefile']
230222-13:57:22,674 nipype.workflow INFO:
	 Connecting motion_correction...
230222-13:57:22,675 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'motion-basefile')]
	 "outputs": ['desc-preproc_bold', 'desc-motion_bold', 'max-displacement', 'rels-displacement', 'movement-parameters', 'coordinate-transformation']
230222-13:57:22,692 nipype.workflow INFO:
	 Connecting motion_estimate_filter...
230222-13:57:22,692 nipype.workflow DEBUG:
	 "inputs": ['movement-parameters', 'TR']
	 "outputs": ['movement-parameters', 'motion-filter-info', 'motion-filter-plot']
230222-13:57:22,693 nipype.workflow INFO:
	 Connecting bold_mask_afni...
230222-13:57:22,694 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['space-bold_desc-brain_mask']
230222-13:57:22,695 nipype.workflow INFO:
	 Connecting bold_mask_fsl...
230222-13:57:22,695 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['space-bold_desc-brain_mask']
230222-13:57:22,696 nipype.workflow INFO:
	 Connecting bold_mask_fsl_afni...
230222-13:57:22,697 nipype.workflow DEBUG:
	 "inputs": [('motion-basefile', 'desc-preproc_bold'), 'FSL-AFNI-bold-ref', 'FSL-AFNI-brain-mask', 'FSL-AFNI-brain-probseg']
	 "outputs": ['space-bold_desc-brain_mask', 'desc-ref_bold']
230222-13:57:22,698 nipype.workflow INFO:
	 Connecting bold_mask_anatomical_refined...
230222-13:57:22,699 nipype.workflow DEBUG:
	 "inputs": [('bold', 'desc-preproc_bold'), ('desc-brain_T1w', ['space-T1w_desc-brain_mask', 'space-T1w_desc-acpcbrain_mask'])]
	 "outputs": ['space-bold_desc-brain_mask']
230222-13:57:22,699 nipype.workflow INFO:
	 Connecting bold_mask_anatomical_based...
230222-13:57:22,700 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold', ('desc-brain_T1w', ['desc-preproc_T1w', 'desc-reorient_T1w', 'T1w'])]
	 "outputs": ['space-bold_desc-brain_mask']
230222-13:57:22,701 nipype.workflow INFO:
	 Connecting bold_mask_anatomical_resampled...
230222-13:57:22,702 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold', 'T1w-template-funcreg', 'space-template_desc-preproc_T1w', 'space-template_desc-T1w_mask']
	 "outputs": ['space-template_res-bold_desc-brain_T1w', 'space-template_desc-bold_mask', 'space-bold_desc-brain_mask']
230222-13:57:22,702 nipype.workflow INFO:
	 Connecting bold_mask_ccs...
230222-13:57:22,703 nipype.workflow DEBUG:
	 "inputs": [['desc-motion_bold', 'desc-preproc_bold', 'bold'], 'desc-brain_T1w', ['desc-preproc_T1w', 'desc-reorient_T1w', 'T1w']]
	 "outputs": ['space-bold_desc-brain_mask', 'desc-ROIbrain_bold']
230222-13:57:22,709 nipype.workflow INFO:
	 Connecting bold_masking...
230222-13:57:22,709 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'space-bold_desc-brain_mask')]
	 "outputs": ['desc-preproc_bold', 'desc-brain_bold']
230222-13:57:22,717 nipype.workflow INFO:
	 Connecting calc_motion_stats...
230222-13:57:22,718 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'space-bold_desc-brain_mask', 'movement-parameters', 'max-displacement', 'rels-displacement', 'coordinate-transformation'), 'subject', 'scan']
	 "outputs": ['framewise-displacement-power', 'framewise-displacement-jenkinson', 'dvars', 'power-params', 'motion-params']
230222-13:57:22,740 nipype.workflow INFO:
	 Connecting func_normalize...
230222-13:57:22,741 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold']
	 "outputs": ['desc-preproc_bold']
230222-13:57:22,747 nipype.workflow INFO:
	 Connecting coregistration_prep_vol...
230222-13:57:22,748 nipype.workflow DEBUG:
	 "inputs": [('desc-brain_bold', ['desc-motion_bold', 'bold'], 'sbref')]
	 "outputs": ['sbref']
230222-13:57:22,748 nipype.workflow INFO:
	 Connecting coregistration_prep_mean...
230222-13:57:22,749 nipype.workflow DEBUG:
	 "inputs": ['desc-mean_bold']
	 "outputs": ['sbref']
230222-13:57:22,750 nipype.workflow INFO:
	 Connecting coregistration_prep_fmriprep...
230222-13:57:22,751 nipype.workflow DEBUG:
	 "inputs": ['desc-ref_bold']
	 "outputs": ['sbref']
230222-13:57:22,756 nipype.workflow INFO:
	 Connecting coregistration...
230222-13:57:22,757 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'desc-motion_bold', 'space-bold_label-WM_mask', 'despiked-fieldmap', 'fieldmap-mask', 'effectiveEchoSpacing', 'pe-direction'), ('desc-preproc_T1w', 'desc-restore-brain_T1w', 'desc-preproc_T2w', 'desc-preproc_T2w', 'T2w', ['label-WM_probseg', 'label-WM_mask'], ['label-WM_pveseg', 'label-WM_mask'], 'desc-head_T1w', 'desc-head_T2w')]
	 "outputs": ['space-T1w_sbref', 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'from-bold_to-T1w_mode-image_desc-linear_warp']
230222-13:57:22,795 nipype.workflow INFO:
	 Connecting register_ANTs_EPI_to_template...
230222-13:57:22,796 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'space-bold_desc-brain_mask'), 'EPI-template', 'EPI-template-mask']
	 "outputs": ['space-template_desc-preproc_bold', 'from-bold_to-EPItemplate_mode-image_desc-linear_xfm', 'from-EPItemplate_to-bold_mode-image_desc-linear_xfm', 'from-bold_to-EPItemplate_mode-image_desc-nonlinear_xfm', 'from-EPItemplate_to-bold_mode-image_desc-nonlinear_xfm', 'from-bold_to-EPItemplate_mode-image_xfm', 'from-EPItemplate_to-bold_mode-image_xfm']
230222-13:57:22,796 nipype.workflow INFO:
	 Connecting register_FSL_EPI_to_template...
230222-13:57:22,797 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'space-bold_desc-brain_mask'), 'EPI-template', 'EPI-template-mask']
	 "outputs": ['space-template_desc-preproc_bold', 'from-bold_to-EPItemplate_mode-image_desc-linear_xfm', 'from-EPItemplate_to-bold_mode-image_desc-linear_xfm', 'from-bold_to-EPItemplate_mode-image_xfm']
230222-13:57:22,798 nipype.workflow INFO:
	 Connecting create_func_to_T1template_xfm...
230222-13:57:22,799 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'ants-blip-warp', 'fsl-blip-warp'), ('from-T1w_to-template_mode-image_xfm', 'from-template_to-T1w_mode-image_xfm', 'desc-brain_T1w'), 'T1w-brain-template-funcreg']
	 "outputs": ['from-bold_to-template_mode-image_xfm', 'from-template_to-bold_mode-image_xfm']
230222-13:57:22,829 nipype.workflow INFO:
	 Connecting create_func_to_T1template_symmetric_xfm...
230222-13:57:22,830 nipype.workflow DEBUG:
	 "inputs": [('from-T1w_to-symtemplate_mode-image_xfm', 'from-symtemplate_to-T1w_mode-image_xfm', 'desc-brain_T1w'), ('sbref', 'from-bold_to-T1w_mode-image_desc-linear_xfm'), 'T1w-brain-template-symmetric-deriv']
	 "outputs": ['from-bold_to-symtemplate_mode-image_xfm', 'from-symtemplate_to-bold_mode-image_xfm']
230222-13:57:22,861 nipype.workflow INFO:
	 Connecting ICA_AROMA_ANTsreg...
230222-13:57:22,861 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'sbref', 'from-bold_to-template_mode-image_xfm', 'from-template_to-bold_mode-image_xfm'), 'T1w-brain-template-funcreg']
	 "outputs": ['desc-preproc_bold', 'desc-cleaned_bold']
230222-13:57:22,862 nipype.workflow INFO:
	 Connecting ICA_AROMA_FSLreg...
230222-13:57:22,863 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold', 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'from-T1w_to-template_mode-image_xfm']
	 "outputs": ['desc-preproc_bold', 'desc-cleaned_bold']
230222-13:57:22,864 nipype.workflow INFO:
	 Connecting ICA_AROMA_ANTsEPIreg...
230222-13:57:22,864 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'sbref', 'from-bold_to-EPItemplate_mode-image_xfm', 'from-EPItemplate_to-bold_mode-image_xfm'), 'EPI-template']
	 "outputs": ['desc-preproc_bold', 'desc-cleaned_bold']
230222-13:57:22,865 nipype.workflow INFO:
	 Connecting ICA_AROMA_FSLEPIreg...
230222-13:57:22,866 nipype.workflow DEBUG:
	 "inputs": [['desc-brain_bold', 'desc-motion_bold', 'desc-preproc_bold', 'bold'], 'from-bold_to-EPItemplate_mode-image_xfm']
	 "outputs": ['desc-preproc_bold', 'desc-cleaned_bold']
230222-13:57:22,867 nipype.workflow INFO:
	 Connecting erode_mask_T1w...
230222-13:57:22,867 nipype.workflow DEBUG:
	 "inputs": [('space-T1w_desc-brain_mask', ['label-CSF_desc-preproc_mask', 'label-CSF_mask'])]
	 "outputs": ['space-T1w_desc-eroded_mask']
230222-13:57:22,868 nipype.workflow INFO:
	 Connecting erode_mask_CSF...
230222-13:57:22,869 nipype.workflow DEBUG:
	 "inputs": [(['label-CSF_desc-preproc_mask', 'label-CSF_mask'], 'space-T1w_desc-brain_mask')]
	 "outputs": ['label-CSF_desc-eroded_mask']
230222-13:57:22,870 nipype.workflow INFO:
	 Connecting erode_mask_GM...
230222-13:57:22,870 nipype.workflow DEBUG:
	 "inputs": [['label-GM_desc-preproc', 'label-GM_mask']]
	 "outputs": ['label-GM_desc-eroded_mask']
230222-13:57:22,871 nipype.workflow INFO:
	 Connecting erode_mask_WM...
230222-13:57:22,872 nipype.workflow DEBUG:
	 "inputs": [(['label-WM_desc-preproc_mask', 'label-WM_mask'], 'space-T1w_desc-brain_mask')]
	 "outputs": ['label-WM_desc-eroded_mask']
230222-13:57:22,873 nipype.workflow INFO:
	 Connecting erode_mask_bold...
230222-13:57:22,873 nipype.workflow DEBUG:
	 "inputs": [('space-bold_desc-brain_mask', ['space-bold_label-CSF_desc-preproc_mask', 'space-bold_label-CSF_mask'])]
	 "outputs": ['space-bold_desc-eroded_mask']
230222-13:57:22,874 nipype.workflow INFO:
	 Connecting erode_mask_boldCSF...
230222-13:57:22,875 nipype.workflow DEBUG:
	 "inputs": [(['space-bold_label-CSF_desc-preproc_mask', 'space-bold_label-CSF_mask'], 'space-bold_desc-brain_mask')]
	 "outputs": ['space-bold_label-CSF_desc-eroded_mask']
230222-13:57:22,876 nipype.workflow INFO:
	 Connecting erode_mask_boldGM...
230222-13:57:22,876 nipype.workflow DEBUG:
	 "inputs": [['space-bold_label-GM_desc-preproc', 'space-bold_label-GM_mask']]
	 "outputs": ['space-bold_label-GM_desc-eroded_mask']
230222-13:57:22,877 nipype.workflow INFO:
	 Connecting erode_mask_boldWM...
230222-13:57:22,878 nipype.workflow DEBUG:
	 "inputs": [(['space-bold_label-WM_desc-preproc_mask', 'space-bold_label-WM_mask'], 'space-bold_desc-brain_mask')]
	 "outputs": ['space-bold_label-WM_desc-eroded_mask']
230222-13:57:22,879 nipype.workflow INFO:
	 Connecting nuisance_regressors_generation...
230222-13:57:22,879 nipype.workflow DEBUG:
	 "inputs": ['lateral-ventricles-mask', 'TR', ('space-bold_desc-brain_mask', 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'movement-parameters', 'framewise-displacement-jenkinson', 'framewise-displacement-power', 'dvars', 'desc-brain_T1w', ['space-T1w_desc-eroded_mask', 'space-T1w_desc-brain_mask'], ['label-CSF_desc-eroded_mask', 'label-CSF_desc-preproc_mask', 'label-CSF_mask'], ['label-WM_desc-eroded_mask', 'label-WM_desc-preproc_mask', 'label-WM_mask'], ['label-GM_desc-eroded_mask', 'label-GM_desc-preproc_mask', 'label-GM_mask'], 'from-template_to-T1w_mode-image_desc-linear_xfm', 'from-T1w_to-template_mode-image_desc-linear_xfm', ['desc-preproc_bold', 'bold'])]
	 "outputs": ['regressors', 'censor-indices']
230222-13:57:23,43 nipype.workflow INFO:
	 Connecting nuisance_regression_native...
230222-13:57:23,44 nipype.workflow DEBUG:
	 "inputs": ['TR', ('regressors', 'space-bold_desc-brain_mask', 'framewise-displacement-jenkinson', 'framewise-displacement-power', 'dvars', ['desc-preproc_bold', 'bold'])]
	 "outputs": ['desc-preproc_bold', 'desc-cleaned_bold', 'desc-denoisedNofilt_bold', 'regressors']
230222-13:57:23,258 nipype.workflow INFO:
	 Connecting apply_phasediff_to_timeseries_separately...
230222-13:57:23,259 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'desc-preproc_bold', 'desc-stc_bold', 'bold', 'from-bold_to-T1w_mode-image_desc-linear_xfm'), 'despiked-fieldmap', 'pe-direction', 'effectiveEchoSpacing']
	 "outputs": ['sbref', 'desc-preproc_bold', 'desc-stc_bold', 'bold']
230222-13:57:23,260 nipype.workflow INFO:
	 Connecting apply_blip_to_timeseries_separately...
230222-13:57:23,261 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'desc-preproc_bold', 'desc-stc_bold', 'bold', 'from-bold_to-template_mode-image_xfm', 'ants-blip-warp', 'fsl-blip-warp')]
	 "outputs": ['desc-preproc_bold', 'desc-stc_bold', 'bold']
230222-13:57:23,261 nipype.workflow INFO:
	 Connecting transform_timeseries_to_T1template...
230222-13:57:23,262 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'from-bold_to-template_mode-image_xfm'), 'T1w-brain-template-funcreg']
	 "outputs": ['space-template_desc-preproc_bold']
230222-13:57:23,263 nipype.workflow INFO:
	 Connecting transform_timeseries_to_T1template_dcan_nhp...
230222-13:57:23,264 nipype.workflow DEBUG:
	 "inputs": [(['desc-reorient_bold', 'bold'], 'coordinate-transformation', 'from-T1w_to-template_mode-image_warp', 'from-bold_to-T1w_mode-image_desc-linear_warp', 'T1w-template', 'space-template_desc-head_T1w', 'space-template_desc-T1w_mask', 'space-template_desc-T1wT2w_biasfield')]
	 "outputs": ['space-template_desc-preproc_bold', 'space-template_desc-bold_mask']
230222-13:57:23,265 nipype.workflow INFO:
	 Connecting transform_timeseries_to_T1template_abcd...
230222-13:57:23,265 nipype.workflow DEBUG:
	 "inputs": ['from-T1w_to-template_mode-image_xfm', 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'from-bold_to-template_mode-image_xfm', 'fsl-blip-warp', 'desc-preproc_T1w', 'space-template_res-bold_desc-brain_T1w', 'space-template_desc-bold_mask', 'T1w-brain-template-funcreg', ('bold', 'motion-basefile', 'coordinate-transformation', 'bold')]
	 "outputs": ['space-template_desc-preproc_bold', 'space-template_desc-scout_bold', 'space-template_desc-head_bold']
230222-13:57:23,266 nipype.workflow INFO:
	 Connecting single_step_resample_stc_timeseries_to_T1template...
230222-13:57:23,267 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'desc-stc_bold', 'motion-basefile', 'space-bold_desc-brain_mask', 'coordinate-transformation', 'from-T1w_to-template_mode-image_xfm', 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'from-bold_to-template_mode-image_xfm', 'ants-blip-warp', 'fsl-blip-warp', 'T1w', 'desc-preproc_T1w', 'T1w-brain-template-funcreg', 'T1w-brain-template-deriv')]
	 "outputs": ['space-template_desc-preproc_bold', 'space-template_desc-brain_bold', 'space-template_desc-bold_mask', 'space-template_desc-head_bold', 'space-template_res-derivative_desc-preproc_bold', 'space-template_res-derivative_desc-bold_mask']
230222-13:57:23,481 nipype.workflow INFO:
	 Connecting transform_sbref_to_T1template...
230222-13:57:23,482 nipype.workflow DEBUG:
	 "inputs": [('sbref', 'from-bold_to-template_mode-image_xfm'), 'T1w-brain-template-funcreg']
	 "outputs": ['space-template_sbref']
230222-13:57:23,499 nipype.workflow INFO:
	 Connecting transform_bold_mask_to_T1template...
230222-13:57:23,500 nipype.workflow DEBUG:
	 "inputs": [('space-bold_desc-brain_mask', 'from-bold_to-template_mode-image_xfm'), 'T1w-brain-template-funcreg']
	 "outputs": ['space-template_desc-bold_mask']
230222-13:57:23,516 nipype.workflow INFO:
	 Connecting transform_deriv_mask_to_T1template...
230222-13:57:23,517 nipype.workflow DEBUG:
	 "inputs": [('space-bold_desc-brain_mask', 'from-bold_to-template_mode-image_xfm'), 'T1w-brain-template-deriv']
	 "outputs": ['space-template_res-derivative_desc-bold_mask']
230222-13:57:23,533 nipype.workflow INFO:
	 Connecting func_despike_template...
230222-13:57:23,534 nipype.workflow DEBUG:
	 "inputs": [('space-template_desc-preproc_bold', 'space-template_res-derivative_desc-preproc_bold'), 'T1w-template-funcreg', 'T1w-template-deriv']
	 "outputs": ['space-template_desc-preproc_bold', 'space-template_res-derivative_desc-preproc_bold']
230222-13:57:23,535 nipype.workflow INFO:
	 Connecting transform_bold_mask_to_EPItemplate...
230222-13:57:23,536 nipype.workflow DEBUG:
	 "inputs": [('space-bold_desc-brain_mask', 'from-bold_to-EPItemplate_mode-image_xfm'), 'EPI-template']
	 "outputs": ['space-template_desc-bold_mask']
230222-13:57:23,536 nipype.workflow INFO:
	 Connecting transform_deriv_mask_to_EPItemplate...
230222-13:57:23,537 nipype.workflow DEBUG:
	 "inputs": [('space-bold_desc-brain_mask', 'from-bold_to-EPItemplate_mode-image_xfm'), 'EPI-template']
	 "outputs": ['space-template_res-derivative_desc-bold_mask']
230222-13:57:23,538 nipype.workflow INFO:
	 Connecting surface_preproc...
230222-13:57:23,539 nipype.workflow DEBUG:
	 "inputs": ['freesurfer-subject-dir', ['desc-restore_T1w', 'desc-preproc_T1w', 'desc-reorient_T1w', 'T1w', 'space-longitudinal_desc-reorient_T1w'], ['space-template_desc-head_T1w', 'space-template_desc-brain_T1w', 'space-template_desc-T1w_mask'], ['from-T1w_to-template_mode-image_xfm', 'from-T1w_to-template_mode-image_desc-linear_xfm'], ['from-template_to-T1w_mode-image_xfm', 'from-template_to-T1w_mode-image_desc-linear_xfm'], ['space-template_desc-brain_bold', 'space-template_desc-preproc_bold'], ['space-template_desc-scout_bold', 'space-template_desc-cleaned_bold', 'space-template_desc-brain_bold', 'space-template_desc-preproc_bold', 'space-template_desc-motion_bold', 'space-template_bold']]
	 "outputs": ['atlas-DesikanKilliany_space-fsLR_den-32k_dlabel', 'atlas-Destrieux_space-fsLR_den-32k_dlabel', 'atlas-DesikanKilliany_space-fsLR_den-164k_dlabel', 'atlas-Destrieux_space-fsLR_den-164k_dlabel', 'space-fsLR_den-32k_bold-dtseries']
230222-13:57:23,540 nipype.workflow INFO:
	 Connecting timeseries_extraction_AVG...
230222-13:57:23,540 nipype.workflow DEBUG:
	 "inputs": ['space-template_desc-preproc_bold', 'space-template_desc-brain_mask']
	 "outputs": ['space-template_desc-Mean_timeseries', 'space-template_desc-ndmg_correlations', 'atlas_name', 'space-template_desc-PearsonAfni_correlations', 'space-template_desc-PartialAfni_correlations', 'space-template_desc-PearsonNilearn_correlations', 'space-template_desc-PartialNilearn_correlations']
230222-13:57:23,641 nipype.workflow INFO:
	 Connecting spatial_regression...
230222-13:57:23,642 nipype.workflow DEBUG:
	 "inputs": ['space-template_desc-preproc_bold', 'space-template_desc-bold_mask']
	 "outputs": ['desc-SpatReg_timeseries', 'atlas_name']
230222-13:57:23,708 nipype.workflow INFO:
	 Connecting alff_falff...
230222-13:57:23,709 nipype.workflow DEBUG:
	 "inputs": [(['desc-denoisedNofilt_bold', 'desc-preproc_bold'], 'space-bold_desc-brain_mask')]
	 "outputs": ['alff', 'falff']
230222-13:57:23,981 nipype.workflow INFO:
	 Connecting ReHo...
230222-13:57:23,982 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_bold', 'space-bold_desc-brain_mask']
	 "outputs": ['reho']
230222-13:57:24,100 nipype.workflow INFO:
	 Connecting smooth_func_vmhc...
230222-13:57:24,101 nipype.workflow DEBUG:
	 "inputs": [['desc-cleaned_bold', 'desc-brain_bold', 'desc-preproc_bold', 'bold'], 'space-bold_desc-brain_mask']
	 "outputs": ['desc-sm_bold', 'fwhm']
230222-13:57:24,148 nipype.workflow INFO:
	 Connecting transform_timeseries_to_sym_template...
230222-13:57:24,149 nipype.workflow DEBUG:
	 "inputs": [['desc-cleaned-sm_bold', 'desc-brain-sm_bold', 'desc-preproc-sm_bold', 'desc-sm_bold'], 'from-bold_to-symtemplate_mode-image_xfm', 'T1w-brain-template-symmetric']
	 "outputs": ['space-symtemplate_desc-sm_bold']
230222-13:57:24,206 nipype.workflow INFO:
	 Connecting vmhc...
230222-13:57:24,207 nipype.workflow DEBUG:
	 "inputs": [['space-symtemplate_desc-cleaned-sm_bold', 'space-symtemplate_desc-brain-sm_bold', 'space-symtemplate_desc-preproc-sm_bold', 'space-symtemplate_desc-sm_bold']]
	 "outputs": ['vmhc']
230222-13:57:24,251 nipype.workflow INFO:
	 Connecting network_centrality...
230222-13:57:24,252 nipype.workflow DEBUG:
	 "inputs": [('space-template_desc-preproc_bold', 'T1w-brain-template-funcreg'), 'template-specification-file']
	 "outputs": ['space-template_dcw', 'space-template_dcb', 'space-template_ecw', 'space-template_ecb', 'space-template_lfcdw', 'space-template_lfcdb']
230222-13:57:24,477 nipype.workflow INFO:
	 Connecting qc_snr_plot...
230222-13:57:24,479 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_bold', 'space-bold_desc-brain_mask'), 'from-bold_to-T1w_mode-image_desc-linear_xfm', 'desc-preproc_T1w', 'space-T1w_sbref']
	 "outputs": ['desc-boldSnrAxial_quality', 'desc-boldSnrSagittal_quality', 'desc-boldSnrHist_quality', 'desc-boldSnr_quality']
230222-13:57:24,694 nipype.workflow INFO:
	 Connecting qc_coregistration...
230222-13:57:24,695 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_T1w', 'space-T1w_sbref')]
	 "outputs": ['space-T1w_desc-boldAxial_quality', 'space-T1w_desc-boldSagittal_quality']
230222-13:57:24,710 nipype.workflow INFO:
	 Connecting qc_motion_plot...
230222-13:57:24,711 nipype.workflow DEBUG:
	 "inputs": ['movement-parameters']
	 "outputs": ['desc-movementParametersTrans_quality', 'desc-movementParametersRot_quality']
230222-13:57:24,719 nipype.workflow INFO:
	 Connecting qc_fd_plot...
230222-13:57:24,720 nipype.workflow DEBUG:
	 "inputs": ['framewise-displacement-jenkinson']
	 "outputs": ['desc-framewiseDisplacementJenkinsonPlot_quality']
230222-13:57:24,737 nipype.workflow INFO:
	 Connecting qc_brain_extraction...
230222-13:57:24,738 nipype.workflow DEBUG:
	 "inputs": ['desc-preproc_T1w', 'desc-head_T1w']
	 "outputs": ['desc-brain_desc-T1wAxial_quality', 'desc-brain_desc-T1wSagittal_quality']
230222-13:57:24,748 nipype.workflow INFO:
	 Connecting qc_brain_extraction...
230222-13:57:24,749 nipype.workflow DEBUG:
	 "inputs": ['space-template_desc-preproc_T1w', 'T1w-brain-template']
	 "outputs": ['space-template_desc-brain_desc-T1wAxial_quality', 'space-template_desc-brain_desc-T1wSagittal_quality']
230222-13:57:24,760 nipype.workflow INFO:
	 Connecting qc_segmentation...
230222-13:57:24,761 nipype.workflow DEBUG:
	 "inputs": [('desc-preproc_T1w', ['label-CSF_desc-preproc_mask', 'label-CSF_mask'], ['label-WM_desc-preproc_mask', 'label-WM_mask'], ['label-GM_desc-preproc_mask', 'label-GM_mask'])]
	 "outputs": ['desc-dsegAxial_quality', 'desc-dsegSagittal_quality']
230222-13:57:24,786 nipype.workflow INFO:
	 Connecting qc_carpet_plot...
230222-13:57:24,786 nipype.workflow DEBUG:
	 "inputs": [('space-template_desc-preproc_bold', 'space-template_sbref'), 'GM-path', 'WM-path', 'CSF-path']
	 "outputs": ['space-template_desc-preprocBoldCarpet_quality']
230222-13:57:24,859 nipype.workflow INFO:
	 Connecting qc_bold_registration...
230222-13:57:24,860 nipype.workflow DEBUG:
	 "inputs": ['space-template_sbref', 'T1w-brain-template-funcreg']
	 "outputs": ['space-template_desc-boldAxial_quality', 'space-template_desc-boldSagittal_quality']
230222-13:57:27,676 nipype.workflow INFO:
	 This has been a test of the pipeline configuration file, the pipeline was built successfully, but was not run
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I updated the changelog.
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
