### PR TITLE
📦️ Fix FSL resource paths for ABCD-HCP variant image

### DIFF
--- a/.github/Dockerfiles/FSL.5.0.10-bionic.Dockerfile
+++ b/.github/Dockerfiles/FSL.5.0.10-bionic.Dockerfile
@@ -10,8 +10,8 @@ RUN mkdir -p /usr/share/fsl/5.0/data/atlases /usr/share/fsl/5.0/data/standard/ti
     && cp -n /tmp/cpac_image_resources/MNI_4mm/* $FSLDIR/data/standard \
     && cp -n /tmp/cpac_image_resources/symmetric/* $FSLDIR/data/standard \
     && cp -n /tmp/cpac_image_resources/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz $FSLDIR/data/atlases/HarvardOxford \
-    && cp -nr /tmp/cpac_image_resources/tissuepriors/2mm/* $FSLDIR/data/standard/tissuepriors/2mm/ \
-    && cp -nr /tmp/cpac_image_resources/tissuepriors/3mm/* $FSLDIR/data/standard/tissuepriors/3mm/
+    && cp -nr /tmp/cpac_image_resources/tissuepriors/2mm $FSLDIR/data/standard/tissuepriors \
+    && cp -nr /tmp/cpac_image_resources/tissuepriors/3mm $FSLDIR/data/standard/tissuepriors
 
 FROM ghcr.io/fcp-indi/c-pac/ubuntu:bionic-non-free AS FSL
 
@@ -28,8 +28,7 @@ ENV FSLDIR=/usr/share/fsl/5.0 \
     PATH=/usr/lib/fsl/5.0:$PATH \
     TZ=America/New_York
 
-
-# Installing and setting up FSL
+# # Installing and setting up FSL
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     &&  echo $TZ > /etc/timezone \
     && apt-get update \
@@ -58,5 +57,5 @@ COPY --from=FSL /usr/bin/wish /usr/bin/wish
 COPY --from=FSL /usr/share/fsl/ /usr/share/fsl/
 COPY --from=FSL /usr/lib/ /usr/lib/
 COPY --from=FSL /lib/x86_64-linux-gnu/lib*so* /lib/x86_64-linux-gnu/
-COPY --from=FSL-Neurodebian /usr/share/fsl/5.0/data/standard/* /usr/share/fsl/5.0/data/standard/
+COPY --from=FSL-Neurodebian /usr/share/fsl/5.0/data/standard/ /usr/share/fsl/5.0/data/standard/
 COPY --from=FSL /lib/x86_64-linux-gnu/lib*so* /lib/x86_64-linux-gnu/

--- a/.github/Dockerfiles/FSL.5.0.10-bionic.Dockerfile
+++ b/.github/Dockerfiles/FSL.5.0.10-bionic.Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /usr/share/fsl/5.0/data/atlases /usr/share/fsl/5.0/data/standard/ti
     && cp -n /tmp/cpac_image_resources/symmetric/* $FSLDIR/data/standard \
     && cp -n /tmp/cpac_image_resources/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz $FSLDIR/data/atlases/HarvardOxford \
     && cp -nr /tmp/cpac_image_resources/tissuepriors/2mm/* $FSLDIR/data/standard/tissuepriors/2mm/ \
-    && cp -nr /tmp/cpac_image_resources/tissuepriors/3mm/* $FSLDIR/data/standard/tissuepriors/3mm
+    && cp -nr /tmp/cpac_image_resources/tissuepriors/3mm/* $FSLDIR/data/standard/tissuepriors/3mm/
 
 FROM ghcr.io/fcp-indi/c-pac/ubuntu:bionic-non-free AS FSL
 

--- a/.github/Dockerfiles/FSL.5.0.10-bionic.Dockerfile
+++ b/.github/Dockerfiles/FSL.5.0.10-bionic.Dockerfile
@@ -3,15 +3,15 @@ FROM ghcr.io/fcp-indi/c-pac/ubuntu:bionic-non-free as FSL-Neurodebian
 # install CPAC resources into FSL
 USER root
 ENV FSLDIR=/usr/share/fsl/5.0
-RUN mkdir -p /usr/share/fsl/5.0/data/atlases /usr/share/fsl/5.0/data/standard \
+RUN mkdir -p /usr/share/fsl/5.0/data/atlases /usr/share/fsl/5.0/data/standard/tissuepriors/2mm /usr/share/fsl/5.0/data/standard/tissuepriors/3mm \
     && curl -sL http://fcon_1000.projects.nitrc.org/indi/cpac_resources.tar.gz -o /tmp/cpac_resources.tar.gz \
     && tar xfz /tmp/cpac_resources.tar.gz -C /tmp \
     && cp -n /tmp/cpac_image_resources/MNI_3mm/* $FSLDIR/data/standard \
     && cp -n /tmp/cpac_image_resources/MNI_4mm/* $FSLDIR/data/standard \
     && cp -n /tmp/cpac_image_resources/symmetric/* $FSLDIR/data/standard \
     && cp -n /tmp/cpac_image_resources/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz $FSLDIR/data/atlases/HarvardOxford \
-    && cp -nr /tmp/cpac_image_resources/tissuepriors/2mm $FSLDIR/data/standard/tissuepriors \
-    && cp -nr /tmp/cpac_image_resources/tissuepriors/3mm $FSLDIR/data/standard/tissuepriors
+    && cp -nr /tmp/cpac_image_resources/tissuepriors/2mm/* $FSLDIR/data/standard/tissuepriors/2mm/ \
+    && cp -nr /tmp/cpac_image_resources/tissuepriors/3mm/* $FSLDIR/data/standard/tissuepriors/3mm
 
 FROM ghcr.io/fcp-indi/c-pac/ubuntu:bionic-non-free AS FSL
 

--- a/.github/Dockerfiles/base-ABCD-HCP.Dockerfile
+++ b/.github/Dockerfiles/base-ABCD-HCP.Dockerfile
@@ -41,7 +41,7 @@ COPY --from=ANTs /ants_template /ants_template
 # install FSL
 COPY --from=FSL /usr/bin/tclsh /usr/bin/tclsh
 COPY --from=FSL /usr/bin/wish /usr/bin/wish
-COPY --from=FSL /usr/share/fsl/ /usr/share/fsl/
+COPY --from=FSL /usr/share/fsl /usr/share/fsl
 COPY --from=FSL /lib/x86_64-linux-gnu/lib*so* /lib/x86_64-linux-gnu/
 COPY --from=FSL /usr/lib/lib*so* /usr/lib/
 # set up FSL environment


### PR DESCRIPTION
Continues #1894 by @shnizzedy & #1896 by @tergeorge 

Gets more specific in copying resources (removes `*` that was hoisting some files)