### PR TITLE
Don't check system dependencies with test_config

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -420,15 +420,16 @@ def run_workflow(sub_dict, c, run, pipeline_timing_info=None, p_name=None,
                                     'local_functional_connectivity_density'][
                                     'weight_options']) != 0
 
-    # Check system dependencies
-    check_ica_aroma = c.nuisance_corrections['1-ICA-AROMA']['run']
-    if isinstance(check_ica_aroma, list):
-        check_ica_aroma = True in check_ica_aroma
-    check_system_deps(check_ants='ANTS' in c.registration_workflows[
-        'anatomical_registration']['registration']['using'],
-                      check_ica_aroma=check_ica_aroma,
-                      check_centrality_degree=check_centrality_degree,
-                      check_centrality_lfcd=check_centrality_lfcd)
+    if not test_config:
+        # Check system dependencies
+        check_ica_aroma = c.nuisance_corrections['1-ICA-AROMA']['run']
+        if isinstance(check_ica_aroma, list):
+            check_ica_aroma = True in check_ica_aroma
+        check_system_deps(check_ants='ANTS' in c.registration_workflows[
+            'anatomical_registration']['registration']['using'],
+                        check_ica_aroma=check_ica_aroma,
+                        check_centrality_degree=check_centrality_degree,
+                        check_centrality_lfcd=check_centrality_lfcd)
 
     # absolute paths of the dirs
     c.pipeline_setup['working_directory']['path'] = os.path.join(


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->

Don't run system dependency checks when using `test_config`.
This allows workflow testing and debugging locally without having the system dependencies installed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
