### PR TITLE
📦️ Restore `wb_command` installation in ABCD-HCP variant image

### DIFF
--- a/.github/Dockerfiles/base-ABCD-HCP.Dockerfile
+++ b/.github/Dockerfiles/base-ABCD-HCP.Dockerfile
@@ -45,11 +45,6 @@ COPY --from=FSL /usr/bin/wish /usr/bin/wish
 COPY --from=FSL /usr/share/fsl /usr/share/fsl
 COPY --from=FSL /lib/x86_64-linux-gnu/lib*so* /lib/x86_64-linux-gnu/
 COPY --from=FSL /usr/lib/lib*so* /usr/lib/
-
-COPY --from=FSL-Neurodebian /usr/share/fsl/5.0/data/standard/tissuepriors/2mm /usr/share/fsl/5.0/data/standard/tissuepriors
-COPY --from=FSL /lib/x86_64-linux-gnu/lib*so* /lib/x86_64-linux-gnu/
-COPY --from=FSL-Neurodebian /usr/share/fsl/5.0/data/standard/tissuepriors/3mm /usr/share/fsl/5.0/data/standard/tissuepriors
-
 # set up FSL environment
 ENV FSLDIR=/usr/share/fsl/5.0 \
     FSL_DIR=/usr/share/fsl/5.0 \

--- a/.github/Dockerfiles/base-ABCD-HCP.Dockerfile
+++ b/.github/Dockerfiles/base-ABCD-HCP.Dockerfile
@@ -79,7 +79,7 @@ RUN APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --keyserver keyserver.ubu
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138 && \
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DCC9EFBF77E11517 && \
     printf '\ndeb http://httpredir.debian.org/debian/ buster main non-free' >> /etc/apt/sources.list && \
-    apt-get update && \
+    apt-get update --allow-insecure-repositories && \
     apt-get install connectome-workbench=1.3.2-1 -y && \
     strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
 ENV PATH=/usr:$PATH


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to
> Use of apt-key is deprecated, except for the use of apt-key del in maintainer scripts to remove existing keys from the main keyring. If such usage of apt-key is desired the additional installation of the GNU Privacy Guard suite (packaged in gnupg) is required.

― <a href="https://manpages.debian.org/testing/apt/apt-key.8.en.html#:~:text=Use%20of%20apt%2Dkey%20is,packaged%20in%20gnupg)%20is%20required."><code>man apt-key</code></a>

## Description
<!-- Concisely describe what the pull request does. -->
* Updates the `connectome-workbench` install command to skip checking the key / signature

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* Also reverts f09ff0c8640b4e8204e2f9ce6b0dc272d8878728

## Screenshots
```BASH
% docker run --rm -it --entrypoint /bin/bash  ghcr.io/fcp-indi/c-pac:feature_surface_derivatives-wb_command-ABCD-HCP
# tree /usr/share/fsl/5.0/data/standard/tissuepriors
/usr/share/fsl/5.0/data/standard/tissuepriors
├── 2mm
│   ├── avg152T1_csf_bin.nii.gz
│   ├── avg152T1_gray_bin.nii.gz
│   └── avg152T1_white_bin.nii.gz
├── 3mm
│   ├── avg152T1_csf_bin.nii.gz
│   ├── avg152T1_gray_bin.nii.gz
│   └── avg152T1_white_bin.nii.gz
├── avg152T1_brain.hdr
├── avg152T1_brain.img
├── avg152T1_csf.hdr
├── avg152T1_csf.img
├── avg152T1_gray.hdr
├── avg152T1_gray.img
├── avg152T1_white.hdr
└── avg152T1_white.img

2 directories, 14 files
# wb_command -version
Connectome Workbench
Type: Command Line Application
Version: 1.3.2
Qt Compiled Version: 5.11.1
Qt Runtime Version: 5.11.3
Commit: unknown
Commit Date: unknown
Compiled with OpenMP: YES
Compiler: c++ (/usr/bin)
Compiler Version: 8.2.0
Compiled Debug: NO
Operating System: Linux
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `feature/surface_derivatives` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [ ] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
