### PR TITLE
🔥 Remove `monkey-ABCD` tests for 1.8.5

### DIFF
--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -122,14 +122,6 @@ jobs:
           - ''
         participant:
           - 032102 032106 032164 032167 032130 032128 2215 2312 032191 032195
-        include:
-          # requires T2w
-          - preconfig: monkey-ABCD
-            variant: ''
-            participant: 032102 032106 032130 032128 032191 032195
-          - preconfig: monkey-ABCD
-            variant: ABCD-HCP
-            participant: 032102 032106 032130 032128 032191 032195
     steps:
       - name: Get C-PAC
         run: |

--- a/CPAC/pipeline/__init__.py
+++ b/CPAC/pipeline/__init__.py
@@ -25,7 +25,8 @@ ALL_PIPELINE_CONFIGS = [x.split('_')[2].replace('.yml', '') for
                         x in ALL_PIPELINE_CONFIGS if 'pipeline_config' in x]
 ALL_PIPELINE_CONFIGS.sort()
 AVAILABLE_PIPELINE_CONFIGS = [preconfig for preconfig in ALL_PIPELINE_CONFIGS
-                              if preconfig != 'benchmark-ANTS' and
+                              if preconfig not in
+                              ['benchmark-ANTS', 'monkey-ABCD'] and
                               not preconfig.startswith('regtest-')]
 
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Removes `monkey-ABCD` tests from 1.8.5 develop branch and removes `monkey-ABCD` from listed preconfigs.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
These tests are failing.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
