### PR TITLE
👽 Update CLI to accept dashes and underscores where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates develop version numbers to adhere to [PEP440](https://peps.python.org/pep-0440) by changing `{major}.{minor}.{patch}.{SHA}-{dev}` to `{major}.{minor}.{patch}.dev{integer}+{SHA}`
 - Adds checksum steps to `curl`d steps in Docker build process (for standard and `lite` images)
 - Makes in-container root directory writable by all
+- Updates multiword CLI commands and options to accept either standard `-`s or backwards-compatible `_`s interchangeably
 
-### Added dependency
+### Added dependencies
 
+- `click-aliases`
 - `dc`
 
 ### Removed dependencies

--- a/CPAC/__main__.py
+++ b/CPAC/__main__.py
@@ -356,7 +356,7 @@ def build(data_settings_file):
     run(data_settings_file)
 
 
-@utils.group(aliases=['pipe_config'])
+@utils.group(aliases=['pipe_config'], cls=ClickAliasedGroup)
 @click.option('--tracking-opt-out', '--tracking_opt-out', is_flag=True,
               help='Disable usage tracking.')
 def pipe_config(tracking_opt_out):

--- a/CPAC/__main__.py
+++ b/CPAC/__main__.py
@@ -147,7 +147,7 @@ def group():
 
 
 # Group analysis - FSL FEAT
-@group.group()
+@group.group(cls=ClickAliasedGroup)
 def feat():
     pass
 
@@ -173,7 +173,7 @@ def randomise(group_config):
     cgr.run_feat(group_config, feat=False)
 
 
-@feat.group(cls=ClickAliasedGroup)
+@feat.group(aliases=['load_preset'], cls=ClickAliasedGroup)
 def load_preset():
     pass
 

--- a/CPAC/__main__.py
+++ b/CPAC/__main__.py
@@ -18,6 +18,7 @@
 import os
 import pkg_resources as p
 import click
+from click_aliases import ClickAliasedGroup
 from CPAC.utils.docs import version_report
 
 # CLI tree
@@ -61,9 +62,9 @@ def version():
 
 @main.command()
 @click.argument('data_config')
-@click.option('--pipe_config')
-@click.option('--num_cores')
-@click.option('--ndmg_mode', is_flag=True)
+@click.option('--pipe-config', '--pipe_config')
+@click.option('--num-cores', '--num_cores')
+@click.option('--ndmg-mode', '--ndmg_mode', is_flag=True)
 @click.option('--debug', is_flag=True)
 def run(data_config, pipe_config=None, num_cores=None, ndmg_mode=False,
         debug=False):
@@ -172,17 +173,17 @@ def randomise(group_config):
     cgr.run_feat(group_config, feat=False)
 
 
-@feat.group()
+@feat.group(cls=ClickAliasedGroup)
 def load_preset():
     pass
 
-@load_preset.command()
+@load_preset.command(aliases=['single_grp_avg'])
 @click.argument('pipeline_dir')
 @click.argument('z_thresh')
 @click.argument('p_thresh')
 @click.argument('model_name')
-@click.option('--output_dir', default=None)
-@click.option('--group_participants', default=None)
+@click.option('--output-dir', '--output_dir', default=None)
+@click.option('--group-participants', '--group_participants', default=None)
 def single_grp_avg(pipeline_dir, z_thresh, p_thresh, model_name,
                    output_dir=None, group_participants=None):
     from CPAC.utils import create_fsl_flame_preset
@@ -193,7 +194,7 @@ def single_grp_avg(pipeline_dir, z_thresh, p_thresh, model_name,
                                 output_dir=output_dir,
                                 model_name=model_name)
 
-@load_preset.command()
+@load_preset.command(aliases=['single_grp_cov'])
 @click.argument('pipeline_dir')
 @click.argument('z_thresh')
 @click.argument('p_thresh')
@@ -201,8 +202,8 @@ def single_grp_avg(pipeline_dir, z_thresh, p_thresh, model_name,
 @click.argument('pheno_sub')
 @click.argument('covariate')
 @click.argument('model_name')
-@click.option('--output_dir', default=None)
-@click.option('--group_participants', default=None)
+@click.option('--output-dir', '--output_dir', default=None)
+@click.option('--group-participants', '--group_participants', default=None)
 def single_grp_cov(pipeline_dir, z_thresh, p_thresh, pheno_file,
                    pheno_sub, covariate, model_name, output_dir=None,
                    group_participants=None):
@@ -216,7 +217,7 @@ def single_grp_cov(pipeline_dir, z_thresh, p_thresh, pheno_file,
                                 covariate=covariate, output_dir=output_dir,
                                 model_name=model_name)
 
-@load_preset.command()
+@load_preset.command(aliases=['unpaired_two'])
 @click.argument('pipeline_dir')
 @click.argument('z_thresh')
 @click.argument('p_thresh')
@@ -224,8 +225,8 @@ def single_grp_cov(pipeline_dir, z_thresh, p_thresh, pheno_file,
 @click.argument('pheno_sub')
 @click.argument('covariate')
 @click.argument('model_name')
-@click.option('--output_dir', default=None)
-@click.option('--group_participants', default=None)
+@click.option('--output-dir', '--output_dir', default=None)
+@click.option('--group-participants', '--group_participants', default=None)
 def unpaired_two(pipeline_dir, z_thresh, p_thresh, pheno_file,
                  pheno_sub, covariate, model_name, output_dir=None,
                  group_participants=None):
@@ -239,15 +240,15 @@ def unpaired_two(pipeline_dir, z_thresh, p_thresh, pheno_file,
                                 covariate=covariate, output_dir=output_dir,
                                 model_name=model_name)
 
-@load_preset.command()
+@load_preset.command(aliases=['paired_two'])
 @click.argument('pipeline_dir')
 @click.argument('z_thresh')
 @click.argument('p_thresh')
 @click.argument('conditions')
 @click.argument('condition_type')
 @click.argument('model_name')
-@click.option('--output_dir', default=None)
-@click.option('--group_participants', default=None)
+@click.option('--output-dir', '--output_dir', default=None)
+@click.option('--group-participants', '--group_participants', default=None)
 def paired_two(pipeline_dir, z_thresh, p_thresh, conditions,
                condition_type, model_name, output_dir=None,
                group_participants=None):
@@ -261,15 +262,15 @@ def paired_two(pipeline_dir, z_thresh, p_thresh, conditions,
                                 output_dir=output_dir, model_name=model_name)
 
 
-@load_preset.command()
+@load_preset.command(aliases=['tripled_two'])
 @click.argument('pipeline_dir')
 @click.argument('z_thresh')
 @click.argument('p_thresh')
 @click.argument('conditions')
 @click.argument('condition_type')
 @click.argument('model_name')
-@click.option('--output_dir', default=None)
-@click.option('--group_participants', default=None)
+@click.option('--output-dir', '--output_dir', default=None)
+@click.option('--group-participants', '--group_participants', default=None)
 def tripled_two(pipeline_dir, z_thresh, p_thresh, conditions,
                 condition_type, model_name, output_dir=None,
                 group_participants=None):
@@ -313,7 +314,7 @@ def qpp(group_config):
 
 
 # Utilities
-@main.group()
+@main.group(cls=ClickAliasedGroup)
 def utils():
     pass
 
@@ -332,8 +333,8 @@ def crash(crash_file):
         display_crash_file(crash_file, False, False, None)
 
 
-@utils.group()
-@click.option('--tracking_opt-out', is_flag=True,
+@utils.group(aliases=['data_config'], cls=ClickAliasedGroup)
+@click.option('--tracking-opt-out', '--tracking_opt-out', is_flag=True,
               help='Disable usage tracking.')
 def data_config(tracking_opt_out):
     if not tracking_opt_out:
@@ -342,7 +343,7 @@ def data_config(tracking_opt_out):
         track_config('cli')
 
 
-@data_config.command()
+@data_config.command(aliases=['new_settings_template'])
 def new_settings_template():
     from CPAC.utils.build_data_config import util_copy_template
     util_copy_template('data_settings')
@@ -355,8 +356,8 @@ def build(data_settings_file):
     run(data_settings_file)
 
 
-@utils.group()
-@click.option('--tracking_opt-out', is_flag=True,
+@utils.group(aliases=['pipe_config'])
+@click.option('--tracking-opt-out', '--tracking_opt-out', is_flag=True,
               help='Disable usage tracking.')
 def pipe_config(tracking_opt_out):
     if not tracking_opt_out:
@@ -365,14 +366,14 @@ def pipe_config(tracking_opt_out):
         track_config('cli')
 
 
-@pipe_config.command(name='new_template')
+@pipe_config.command(name='new-template', aliases=['new_template'])
 def new_pipeline_template():
     from CPAC.utils.build_data_config import util_copy_template
     util_copy_template('pipeline_config')
 
 
-@utils.group()
-@click.option('--tracking_opt-out', is_flag=True,
+@utils.group(aliases=['group_config'], cls=ClickAliasedGroup)
+@click.option('--tracking-opt-out', '--tracking_opt-out', is_flag=True,
               help='Disable usage tracking.')
 def group_config(tracking_opt_out):
     if not tracking_opt_out:
@@ -381,25 +382,25 @@ def group_config(tracking_opt_out):
         track_config('cli')
 
 
-@group_config.command(name='new_template')
+@group_config.command(name='new-template', aliases=['new_template'])
 def new_group_template():
     from CPAC.utils.build_data_config import util_copy_template
     util_copy_template('group_config')
 
 
-@utils.group()
+@utils.group(cls=ClickAliasedGroup)
 def tools():
     pass
 
 
-@tools.command()
+@tools.command(aliases=['ants_apply_warp'])
 @click.argument('moving_image')
 @click.argument('reference')
 @click.option('--initial', default=None)
 @click.option('--rigid', default=None)
 @click.option('--affine', default=None)
 @click.option('--nonlinear', default=None)
-@click.option('--func_to_anat', default=None)
+@click.option('--func-to-anat', '--func_to_anat', default=None)
 @click.option('--dim', default=3)
 @click.option('--interp', default='Linear')
 @click.option('--inverse', default=False)
@@ -424,12 +425,12 @@ def repickle(directory):
         repickle_util(directory)
 
 
-@utils.group()
+@utils.group(cls=ClickAliasedGroup)
 def test():
     pass
 
 
-@test.command()
+@test.command(aliases=['run_suite'])
 @click.option('--list', '-l', 'show_list', is_flag=True)
 @click.option('--filter', '-f', 'pipeline_filter', default='')
 def run_suite(show_list=False, pipeline_filter=''):
@@ -489,12 +490,12 @@ def run_suite(show_list=False, pipeline_filter=''):
         print("")
 
 
-@test.group()
+@test.group(cls=ClickAliasedGroup)
 def functions():
     pass
 
 
-@functions.command()
+@functions.command(aliases=['gather_outputs_func'])
 @click.argument('pipe_config')
 def gather_outputs_func(pipe_config):
     #from CPAC.pipeline.

--- a/CPAC/info.py
+++ b/CPAC/info.py
@@ -171,6 +171,7 @@ STATUS = 'stable'
 REQUIREMENTS = [
     "boto3",
     "click",
+    "click-aliases",
     "configparser",
     "cython",
     "future",

--- a/dev/circleci_data/test_external_utils.py
+++ b/dev/circleci_data/test_external_utils.py
@@ -14,19 +14,27 @@ DATA_DIR = os.path.join(CPAC_DIR, 'dev', 'circleci_data')
 from CPAC.__main__ import utils as CPAC_main_utils \
     # noqa: E402  # pylint: disable=wrong-import-position
 
-try:
-    _BACKPORT_CLICK = semver.compare(click.__version__, '8.0.0') < 0
-except ValueError:
-    try:
-        _BACKPORT_CLICK = semver.compare(f'{click.__version__}.0', '8.0.0') < 0
-    except ValueError:
-        _BACKPORT_CLICK = True
-
 
 def _click_backport(command, key):
     """Switch back to underscores for older versions of click"""
     return _resolve_alias(command,
                           key.replace('-', '_').replace('opt_out', 'opt-out'))
+
+
+def _compare_version(left: str, right: str) -> int:
+    """Handle required verbosity after ``semver.compare`` deprecation"""
+    return semver.Version.compare(semver.Version.parse(left),
+                                  semver.Version.parse(right))
+
+
+try:
+    _BACKPORT_CLICK = _compare_version(click.__version__, '7.0.0') < 0
+except ValueError:
+    try:
+        _BACKPORT_CLICK = _compare_version(f'{click.__version__}.0',
+                                           '7.0.0') < 0
+    except ValueError:
+        _BACKPORT_CLICK = True
 
 
 def _resolve_alias(command, key):

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -130,14 +130,14 @@ def run_main():
                         choices=['participant', 'group', 'test_config', 'cli'],
                         type=str.lower)
 
-    parser.add_argument('--pipeline_file',
+    parser.add_argument('--pipeline-file', '--pipeline_file',
                         help='Path for the pipeline configuration file to '
                              'use. Use the format s3://bucket/path/to/'
                              'pipeline_file to read data directly from an '
                              'S3 bucket. This may require AWS S3 credentials '
                              'specified via the --aws_input_creds option.',
                         default=preconfig_yaml('default'))
-    parser.add_argument('--group_file',
+    parser.add_argument('--group-file', '--group_file',
                         help='Path for the group analysis configuration file '
                              'to use. Use the format s3://bucket/path/to/'
                              'pipeline_file to read data directly from an S3 '
@@ -146,7 +146,7 @@ def run_main():
                              'The output directory needs to refer to the '
                              'output of a preprocessing individual pipeline.',
                         default=None)
-    parser.add_argument('--data_config_file',
+    parser.add_argument('--data-config-file', '--data_config_file',
                         help='Yaml file containing the location of the data '
                              'that is to be processed. This file is not '
                              'necessary if the data in bids_dir is organized '
@@ -169,16 +169,16 @@ def run_main():
                              'for more information about the preconfigured '
                              'pipelines.',
                         default=None)
-
-    if '--pipeline_override' in sys.argv:  # secret option
-        parser.add_argument('--pipeline_override', type=parse_yaml,
-                            action='append',
+    if [_ for _ in ['--pipeline-override',
+                    '--pipeline_override']if _ in sys.argv]:  # secret option
+        parser.add_argument('--pipeline-override', '--pipeline_override',
+                            type=parse_yaml, action='append',
                             help='Override specific options from the '
                                  'pipeline configuration. E.g.: '
                                  '"{\'pipeline_setup\': {\'system_config\': '
                                  '{\'maximum_memory_per_participant\': 1}}}"')
 
-    parser.add_argument('--aws_input_creds',
+    parser.add_argument('--aws-input-creds', '--aws_input_creds',
                         help='Credentials for reading from S3. If not '
                              'provided and s3 paths are specified in the '
                              'data config we will try to access the bucket '
@@ -186,7 +186,7 @@ def run_main():
                              'that input credentials should read from the '
                              'environment. (E.g. when using AWS iam roles).',
                         default=None)
-    parser.add_argument('--aws_output_creds',
+    parser.add_argument('--aws-output-creds', '--aws_output_creds',
                         help='Credentials for writing to S3. If not provided '
                              'and s3 paths are specified in the output '
                              'directory we will try to access the bucket '
@@ -197,26 +197,26 @@ def run_main():
     # TODO: restore <default=3> for <--n_cpus> once we remove
     #       <max_cores_per_participant> from config file
     #       <https://github.com/FCP-INDI/C-PAC/pull/1264#issuecomment-631643708>
-    parser.add_argument('--n_cpus', type=int, default=0,
+    parser.add_argument('--n-cpus', '--n_cpus', type=int, default=0,
                         help='Number of execution resources per participant '
                              'available for the pipeline. This flag takes '
                              'precidence over max_cores_per_participant in '
                              'the pipeline configuration file.')
-    parser.add_argument('--mem_mb', type=float,
+    parser.add_argument('--mem-mb', '--mem_mb', type=float,
                         help='Amount of RAM available per participant in '
                              'megabytes. Included for compatibility with '
                              'BIDS-Apps standard, but mem_gb is preferred. '
                              'This flag takes precedence over '
                              'maximum_memory_per_participant in the pipeline '
                              'configuration file.')
-    parser.add_argument('--mem_gb', type=float,
+    parser.add_argument('--mem-gb', '--mem_gb', type=float,
                         help='Amount of RAM available per participant in '
                              'gigabytes. If this is specified along with '
                              'mem_mb, this flag will take precedence. This '
                              'flag also takes precedence over '
                              'maximum_memory_per_participant in the pipeline '
                              'configuration file.')
-    parser.add_argument('--runtime_usage', type=str,
+    parser.add_argument('--runtime-usage', '--runtime_usage', type=str,
                         help='Path to a callback.log from a prior run of the '
                              'same pipeline configuration (including any '
                              'resource-management parameters that will be '
@@ -224,18 +224,19 @@ def run_main():
                              "'num_ants_threads'). This log will be used to "
                              'override per-node memory estimates with '
                              'observed values plus a buffer.')
-    parser.add_argument('--runtime_buffer', type=float,
+    parser.add_argument('--runtime-buffer', '--runtime_buffer', type=float,
                         help='Buffer to add to per-node memory estimates if '
                              '--runtime_usage is specified. This number is a '
                              'percentage of the observed memory usage.')
-    parser.add_argument('--num_ants_threads', type=int, default=0,
+    parser.add_argument('--num-ants-threads', '--num_ants_threads', type=int,
+                        default=0,
                         help='The number of cores to allocate to ANTS-'
                              'based anatomical registration per '
                              'participant. Multiple cores can greatly '
                              'speed up this preprocessing step. This '
                              'number cannot be greater than the number of '
                              'cores per participant.')
-    parser.add_argument('--random_seed', type=str,
+    parser.add_argument('--random-seed', '--random_seed', type=str,
                         help='Random seed used to fix the state of execution. '
                              'If unset, each process uses its own default. If '
                              'set, a `random.log` file will be generated '
@@ -245,18 +246,18 @@ def run_main():
                              'process. If set to \'random\', a random seed '
                              'will be generated and recorded for each '
                              'process.')
-    parser.add_argument('--save_working_dir', nargs='?',
+    parser.add_argument('--save-working-dir', '--save_working_dir', nargs='?',
                         help='Save the contents of the working directory.',
                         default=False)
-    parser.add_argument('--save_workflow',
+    parser.add_argument('--save-workflow', '--save_workflow',
                         help='Save a serialized version of the workflow. '
                              'Can be used with `test_config` to save workflow '
                              'without running the pipeline.',
                         action='store_true')
 
-    parser.add_argument('--fail_fast', type=str.title,
+    parser.add_argument('--fail-fast', '--fail_fast', type=str.title,
                         help='Stop worklow execution on first crash?')
-    parser.add_argument('--participant_label',
+    parser.add_argument('--participant-label', '--participant_label',
                         help='The label of the participant that should be '
                              'analyzed. The label corresponds to '
                              'sub-<participant_label> from the BIDS spec '
@@ -266,7 +267,7 @@ def run_main():
                              'can be specified with a space separated '
                              'list.',
                         nargs="+")
-    parser.add_argument('--participant_ndx',
+    parser.add_argument('--participant-ndx', '--participant_ndx',
                         help='The index of the participant that should be '
                              'analyzed. This corresponds to the index of '
                              'the participant in the data config file. '
@@ -282,7 +283,7 @@ def run_main():
                              'variable.',
                         default=None, type=int)
 
-    parser.add_argument('--T1w_label',
+    parser.add_argument('--T1w-label', '--T1w_label',
                         help='C-PAC only runs one T1w per participant-'
                              'session at a time, at this time. Use this '
                              'flag to specify any BIDS entity (e.g., "acq-'
@@ -301,7 +302,7 @@ def run_main():
                              'files will be filtered as well. If no T2w files '
                              'match this --T1w_label, T2w files will be '
                              'processed as if no --T1w_label were provided.')
-    parser.add_argument('--bold_label',
+    parser.add_argument('--bold-label', '--bold_label',
                         help='To include a specified subset of available '
                              'BOLD files, use this flag to specify any '
                              'BIDS entity (e.g., "task-rest") or sequence '
@@ -321,19 +322,20 @@ def run_main():
 
     parser.add_argument('-v', '--version', action='version',
                         version=f'C-PAC BIDS-App version {__version__}')
-    parser.add_argument('--bids_validator_config',
+    parser.add_argument('--bids-validator-config', '--bids_validator_config',
                         help='JSON file specifying configuration of '
                              'bids-validator: See https://github.com/bids-'
                              'standard/bids-validator for more info.')
-    parser.add_argument('--skip_bids_validator',
+    parser.add_argument('--skip-bids-validator', '--skip_bids_validator',
                         help='Skips bids validation.',
                         action='store_true')
 
-    parser.add_argument('--anat_only',
+    parser.add_argument('--anat-only', '--anat_only',
                         help='run only the anatomical preprocessing',
                         action='store_true')
 
-    parser.add_argument('--tracking_opt-out', action='store_true',
+    parser.add_argument('--tracking-opt-out', '--tracking_opt-out',
+                        action='store_true',
                         help='Disable usage tracking. Only the number of '
                              'participants on the analysis is tracked.',
                         default=False)
@@ -796,7 +798,7 @@ def run_main():
                 ] > 1 else 'Linear',
                 plugin_args=plugin_args,
                 tracking=not args.tracking_opt_out,
-                test_config=(1 if args.analysis_level == "test_config" else 0)
+                test_config=args.analysis_level == "test_config"
             )
 
             if monitoring:

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -128,7 +128,7 @@ def run_main():
                              'entire configuration process but will not '
                              'execute the pipeline.',
                         choices=['participant', 'group', 'test_config', 'cli'],
-                        type=str.lower)
+                        type=lambda choice: choice.replace('-', '_').lower())
 
     parser.add_argument('--pipeline-file', '--pipeline_file',
                         help='Path for the pipeline configuration file to '

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3==1.26.91
 ciftify==2.3.3
 click==8.1.3
+click-aliases==1.0.1
 configparser==5.3.0
 future==0.18.3
 INDI-Tools @ git+https://git@github.com/FCP-INDI/INDI-Tools.git@998c246c597209f06f8d5c5b92ddc2c9c1942f46


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1956 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
- Makes standardized commands like `data-config` backwards compatible by accepting underscores in place of dashes like `data_config`
- Adds dash'd versions for underscore'd options/arguments (e.g., `--output-dir` now works in place of `--output_dir`) and choices (e.g., `test-config` now works in place of `test_config`)
- The only option where dashes and underscores should still not be interchangeable after this PR is `opt_out` won't work in place of `opt-out` of `--tracking-opt-out`/`--tracking_opt-out` because that dash is semantic, not just delimiting

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- For commands, uses [`click-aliases`](https://pypi.org/project/click-aliases/1.0.1/) library to specify aliases without overriding the canonical names
- For arguments, just preprended the dash-delimited options/arguments to each relevant definition
- For choices, replaces `-` with `_` when parsing https://github.com/FCP-INDI/C-PAC/blob/05eb0d2ba6e2afc7a79587eea8b192bdd03b1fa5/dev/docker_data/run.py#L131

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
* Try any command or argument or option that used to require an underscore with an underscore, and try again with a dash and see that they both work the same now.
* Updated https://github.com/FCP-INDI/C-PAC/blob/05eb0d2ba6e2afc7a79587eea8b192bdd03b1fa5/dev/circleci_data/test_external_utils.py#L46-L70 to test calls iteratively with `-`s and `_`s unless `click` is v < 7.0.0, in which case just underscores.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

<details>
  <summary><code>run --help</code></summary>

```BASH
usage: run.py [-h] [--pipeline-file PIPELINE_FILE] [--group-file GROUP_FILE]
              [--data-config-file DATA_CONFIG_FILE] [--preconfig PRECONFIG]
              [--aws-input-creds AWS_INPUT_CREDS]
              [--aws-output-creds AWS_OUTPUT_CREDS] [--n-cpus N_CPUS]
              [--mem-mb MEM_MB] [--mem-gb MEM_GB]
              [--runtime-usage RUNTIME_USAGE]
              [--runtime-buffer RUNTIME_BUFFER]
              [--num-ants-threads NUM_ANTS_THREADS]
              [--random-seed RANDOM_SEED]
              [--save-working-dir [SAVE_WORKING_DIR]] [--save-workflow]
              [--fail-fast FAIL_FAST]
              [--participant-label PARTICIPANT_LABEL [PARTICIPANT_LABEL ...]]
              [--participant-ndx PARTICIPANT_NDX] [--T1w-label T1W_LABEL]
              [--bold-label BOLD_LABEL [BOLD_LABEL ...]] [-v]
              [--bids-validator-config BIDS_VALIDATOR_CONFIG]
              [--skip-bids-validator] [--anat-only] [--tracking-opt-out]
              [--monitoring]
              bids_dir output_dir {participant,group,test_config,cli}

C-PAC Pipeline Runner. Copyright (C) 2022 C-PAC Developers. This program comes
with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to
redistribute it under certain conditions. For details, see https://fcp-
indi.github.io/docs/nightly/license or the COPYING and COPYING.LESSER files
included in the source code.

positional arguments:
  bids_dir              The directory with the input dataset formatted
                        according to the BIDS standard. Use the format
                        s3://bucket/path/to/bidsdir to read data directly from
                        an S3 bucket. This may require AWS S3 credentials
                        specified via the --aws_input_creds option.
  output_dir            The directory where the output files should be stored.
                        If you are running group level analysis this folder
                        should be prepopulated with the results of the
                        participant level analysis. Use the format
                        s3://bucket/path/to/bidsdir to write data directly to
                        an S3 bucket. This may require AWS S3 credentials
                        specified via the --aws_output_creds option.
  {participant,group,test_config,cli}
                        Level of the analysis that will be performed. Multiple
                        participant level analyses can be run independently
                        (in parallel) using the same output_dir. test_config
                        will run through the entire configuration process but
                        will not execute the pipeline.

optional arguments:
  -h, --help            show this help message and exit
  --pipeline-file PIPELINE_FILE, --pipeline_file PIPELINE_FILE
                        Path for the pipeline configuration file to use. Use
                        the format s3://bucket/path/to/pipeline_file to read
                        data directly from an S3 bucket. This may require AWS
                        S3 credentials specified via the --aws_input_creds
                        option.
  --group-file GROUP_FILE, --group_file GROUP_FILE
                        Path for the group analysis configuration file to use.
                        Use the format s3://bucket/path/to/pipeline_file to
                        read data directly from an S3 bucket. This may require
                        AWS S3 credentials specified via the --aws_input_creds
                        option. The output directory needs to refer to the
                        output of a preprocessing individual pipeline.
  --data-config-file DATA_CONFIG_FILE, --data_config_file DATA_CONFIG_FILE
                        Yaml file containing the location of the data that is
                        to be processed. This file is not necessary if the
                        data in bids_dir is organized according to the BIDS
                        format. This enables support for legacy data
                        organization and cloud based storage. A bids_dir must
                        still be specified when using this option, but its
                        value will be ignored. Use the format
                        s3://bucket/path/to/data_config_file to read data
                        directly from an S3 bucket. This may require AWS S3
                        credentials specified via the --aws_input_creds
                        option.
  --preconfig PRECONFIG
                        Name of the preconfigured pipeline to run. Available
                        preconfigured pipelines: ['abcd-options', 'abcd-prep',
                        'anat-only', 'benchmark-FNIRT', 'blank', 'ccs-
                        options', 'default', 'default-deprecated', 'fmriprep-
                        options', 'fx-options', 'monkey', 'ndmg', 'nhp-
                        macaque', 'preproc', 'rbc-options', 'rodent']. See
                        https://fcp-
                        indi.github.io/docs/nightly/user/pipelines/preconfig
                        for more information about the preconfigured
                        pipelines.
  --aws-input-creds AWS_INPUT_CREDS, --aws_input_creds AWS_INPUT_CREDS
                        Credentials for reading from S3. If not provided and
                        s3 paths are specified in the data config we will try
                        to access the bucket anonymously use the string "env"
                        to indicate that input credentials should read from
                        the environment. (E.g. when using AWS iam roles).
  --aws-output-creds AWS_OUTPUT_CREDS, --aws_output_creds AWS_OUTPUT_CREDS
                        Credentials for writing to S3. If not provided and s3
                        paths are specified in the output directory we will
                        try to access the bucket anonymously use the string
                        "env" to indicate that output credentials should read
                        from the environment. (E.g. when using AWS iam roles).
  --n-cpus N_CPUS, --n_cpus N_CPUS
                        Number of execution resources per participant
                        available for the pipeline. This flag takes precidence
                        over max_cores_per_participant in the pipeline
                        configuration file.
  --mem-mb MEM_MB, --mem_mb MEM_MB
                        Amount of RAM available per participant in megabytes.
                        Included for compatibility with BIDS-Apps standard,
                        but mem_gb is preferred. This flag takes precedence
                        over maximum_memory_per_participant in the pipeline
                        configuration file.
  --mem-gb MEM_GB, --mem_gb MEM_GB
                        Amount of RAM available per participant in gigabytes.
                        If this is specified along with mem_mb, this flag will
                        take precedence. This flag also takes precedence over
                        maximum_memory_per_participant in the pipeline
                        configuration file.
  --runtime-usage RUNTIME_USAGE, --runtime_usage RUNTIME_USAGE
                        Path to a callback.log from a prior run of the same
                        pipeline configuration (including any resource-
                        management parameters that will be applied in this
                        run, like 'n_cpus' and 'num_ants_threads'). This log
                        will be used to override per-node memory estimates
                        with observed values plus a buffer.
  --runtime-buffer RUNTIME_BUFFER, --runtime_buffer RUNTIME_BUFFER
                        Buffer to add to per-node memory estimates if
                        --runtime_usage is specified. This number is a
                        percentage of the observed memory usage.
  --num-ants-threads NUM_ANTS_THREADS, --num_ants_threads NUM_ANTS_THREADS
                        The number of cores to allocate to ANTS-based
                        anatomical registration per participant. Multiple
                        cores can greatly speed up this preprocessing step.
                        This number cannot be greater than the number of cores
                        per participant.
  --random-seed RANDOM_SEED, --random_seed RANDOM_SEED
                        Random seed used to fix the state of execution. If
                        unset, each process uses its own default. If set, a
                        `random.log` file will be generated logging the random
                        state used by each process. If set to a positive
                        integer (up to 2147483647), that integer will be used
                        to seed each process. If set to 'random', a random
                        seed will be generated and recorded for each process.
  --save-working-dir [SAVE_WORKING_DIR], --save_working_dir [SAVE_WORKING_DIR]
                        Save the contents of the working directory.
  --save-workflow, --save_workflow
                        Save a serialized version of the workflow. Can be used
                        with `test_config` to save workflow without running
                        the pipeline.
  --fail-fast FAIL_FAST, --fail_fast FAIL_FAST
                        Stop worklow execution on first crash?
  --participant-label PARTICIPANT_LABEL [PARTICIPANT_LABEL ...], --participant_label PARTICIPANT_LABEL [PARTICIPANT_LABEL ...]
                        The label of the participant that should be analyzed.
                        The label corresponds to sub-<participant_label> from
                        the BIDS spec (so it does not include "sub-"). If this
                        parameter is not provided all participants should be
                        analyzed. Multiple participants can be specified with
                        a space separated list.
  --participant-ndx PARTICIPANT_NDX, --participant_ndx PARTICIPANT_NDX
                        The index of the participant that should be analyzed.
                        This corresponds to the index of the participant in
                        the data config file. This was added to make it easier
                        to accommodate SGE array jobs. Only a single
                        participant will be analyzed. Can be used with
                        participant label, in which case it is the index into
                        the list that follows the participant_label flag. Use
                        the value "-1" to indicate that the participant index
                        should be read from the AWS_BATCH_JOB_ARRAY_INDEX
                        environment variable.
  --T1w-label T1W_LABEL, --T1w_label T1W_LABEL
                        C-PAC only runs one T1w per participant-session at a
                        time, at this time. Use this flag to specify any BIDS
                        entity (e.g., "acq-VNavNorm") or sequence of BIDS
                        entities (e.g., "acq-VNavNorm_run-1") to specify which
                        of multiple T1w files to use. Specify "--T1w_label
                        T1w" to choose the T1w file with the fewest BIDS
                        entities (i.e., the final option of [*_acq-
                        VNavNorm_T1w.nii.gz, *_acq-HCP_T1w.nii.gz,
                        *_T1w.nii.gz"]). C-PAC will choose the first T1w it
                        finds if the user does not provide this flag, or if
                        multiple T1w files match the --T1w_label provided. If
                        multiple T2w files are present and a comparable filter
                        is possible, T2w files will be filtered as well. If no
                        T2w files match this --T1w_label, T2w files will be
                        processed as if no --T1w_label were provided.
  --bold-label BOLD_LABEL [BOLD_LABEL ...], --bold_label BOLD_LABEL [BOLD_LABEL ...]
                        To include a specified subset of available BOLD files,
                        use this flag to specify any BIDS entity (e.g., "task-
                        rest") or sequence of BIDS entities (e.g. "task-
                        rest_run-1"). To specify the bold file with the fewest
                        BIDS entities in the file name, specify "--bold_label
                        bold". Multiple `--bold_label`s can be specified with
                        a space-separated list. If multiple `--bold_label`s
                        are provided (e.g., "--bold_label task-rest_run-1
                        task-rest_run-2", each scan that includes all BIDS
                        entities specified in any of the provided
                        `--bold_label`s will be analyzed. If this parameter is
                        not provided all BOLD scans should be analyzed.
  -v, --version         show program's version number and exit
  --bids-validator-config BIDS_VALIDATOR_CONFIG, --bids_validator_config BIDS_VALIDATOR_CONFIG
                        JSON file specifying configuration of bids-validator:
                        See https://github.com/bids-standard/bids-validator
                        for more info.
  --skip-bids-validator, --skip_bids_validator
                        Skips bids validation.
  --anat-only, --anat_only
                        run only the anatomical preprocessing
  --tracking-opt-out, --tracking_opt-out
                        Disable usage tracking. Only the number of
                        participants on the analysis is tracked.
  --monitoring          Enable monitoring server on port 8080. You need to
                        bind the port using the Docker flag "-p".
```

</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I updated tests for the changes I made.
- [x] I updated the changelog.
- [x] I added or updated documentation (https://github.com/FCP-INDI/fcp-indi.github.io/pull/303 ― this PR needs to merge first for the <span title="single source of truth">SSOT</span>'d docs to generate with the updated code).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

