### PR TITLE
Remove np.alen

### DIFF
--- a/CPAC/timeseries/timeseries_analysis.py
+++ b/CPAC/timeseries/timeseries_analysis.py
@@ -704,7 +704,7 @@ def gen_voxel_timeseries(data_file, template):
     one = np.array([1])
     headers = ['volume/xyz']
     cordinates = np.argwhere(unit_data != 0)
-    for val in range(np.alen(cordinates)):
+    for val in range(len(cordinates)):
         ijk_mat = np.concatenate([cordinates[val], one])
         ijk_mat = ijk_mat.T
         product = np.dot(qform, ijk_mat)


### PR DESCRIPTION
Was deprecated for a while, not in numpy any more https://numpy.org/doc/stable/release/1.18.0-notes.html#deprecate-np-alen

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
