### PR TITLE
📦 Add tip info-box after missing output crash

### DIFF
--- a/CPAC/pipeline/check_outputs.py
+++ b/CPAC/pipeline/check_outputs.py
@@ -92,7 +92,12 @@ def check_outputs(output_dir: str, log_dir: str, pipe_name: str,
             except (AttributeError, IndexError):
                 log_note = ''
             message = '\n'.join([string for string in [
-                'Missing expected outputs:', str(missing_outputs), log_note
+                'Missing expected outputs:', str(missing_outputs), log_note,
+                '┌──────────────────────────────────────────────────────┐\n'
+                '│Tip: Look for "crash-*.txt" files in the log directory│\n'
+                '│for more information. Usually the chronological first │\n'
+                '│crash file is the most informative.                   │\n'
+                '└──────────────────────────────────────────────────────┘'
             ] if string])
             missing_log.delete()
         else:


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->

Add crash tip info box after missing outputs message.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
