### PR TITLE
🔧 Fix bold_mask crash

### DIFF
--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -295,6 +295,7 @@ functional_preproc:
     using: [PhaseDiff, Blip-FSL-TOPUP]
 
   func_masking:
+    run: On 
 
     # Apply functional mask in native space
     apply_func_mask_in_native_space: Off
@@ -311,6 +312,9 @@ functional_preproc:
   generate_func_mean:
 
     # Generate mean functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -295,7 +295,7 @@ functional_preproc:
     using: [PhaseDiff, Blip-FSL-TOPUP]
 
   func_masking:
-    run: On 
+    run: On
 
     # Apply functional mask in native space
     apply_func_mask_in_native_space: Off
@@ -315,6 +315,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
@@ -144,6 +144,9 @@ functional_preproc:
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
 
+  func_masking:
+    run: On
+
   generate_func_mean:
 
     # Generate mean functional image
@@ -152,6 +155,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+  
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
@@ -156,8 +156,10 @@ functional_preproc:
 
     # Normalize functional image
     run: On
-  
+
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
@@ -168,6 +168,9 @@ functional_preproc:
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
 
+  func_masking:
+    run: On 
+
   generate_func_mean:
 
     # Generate mean functional image
@@ -176,6 +179,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
@@ -169,7 +169,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
-    run: On 
+    run: On
 
   generate_func_mean:
 
@@ -182,6 +182,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1174,6 +1174,8 @@ functional_preproc:
     space: native
 
   coreg_prep:
+
+    # Generate sbref
     run: Off
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -171,6 +171,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
+    run: On 
 
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based', 'Anatomical_Resampled', 'CCS_Anatomical_Refined']
     # FSL_AFNI: fMRIPrep-style BOLD mask. Ref: https://github.com/nipreps/niworkflows/blob/a221f612/niworkflows/func/util.py#L246-L514
@@ -197,6 +198,9 @@ functional_preproc:
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+
+  coreg_prep:
+    run: On
 
 nuisance_corrections:
   2-nuisance_regression:

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -171,7 +171,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
-    run: On 
+    run: On
 
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based', 'Anatomical_Resampled', 'CCS_Anatomical_Refined']
     # FSL_AFNI: fMRIPrep-style BOLD mask. Ref: https://github.com/nipreps/niworkflows/blob/a221f612/niworkflows/func/util.py#L246-L514
@@ -200,6 +200,8 @@ functional_preproc:
     run: [On]
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_default-deprecated.yml
+++ b/CPAC/resources/configs/pipeline_config_default-deprecated.yml
@@ -75,6 +75,9 @@ functional_preproc:
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
 
+  func_masking:
+    run: On 
+
   generate_func_mean:
 
     # Generate mean functional image
@@ -83,6 +86,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_default-deprecated.yml
+++ b/CPAC/resources/configs/pipeline_config_default-deprecated.yml
@@ -76,7 +76,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
-    run: On 
+    run: On
 
   generate_func_mean:
 
@@ -89,6 +89,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1247,7 +1247,7 @@ functional_preproc:
       regrid: 1
 
   func_masking:
-
+    run: On
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based', 'Anatomical_Resampled', 'CCS_Anatomical_Refined']
 
     # FSL_AFNI: fMRIPrep-style BOLD mask. Ref: https://github.com/nipreps/niworkflows/blob/a221f612/niworkflows/func/util.py#L246-L514
@@ -1335,7 +1335,11 @@ functional_preproc:
 
     # Normalize functional image
     run: On
+  
+  coreg_prep:
 
+    # Generate sbref
+    run: On
 
 nuisance_corrections:
 

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -382,8 +382,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
-    run: On 
-
+    run: On
     FSL_AFNI:
       bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
       brain_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-brain_mask.nii.gz
@@ -404,6 +403,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -382,6 +382,8 @@ functional_preproc:
     run: [On]
 
   func_masking:
+    run: On 
+
     FSL_AFNI:
       bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
       brain_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-brain_mask.nii.gz
@@ -399,6 +401,9 @@ functional_preproc:
   generate_func_mean:
 
     # Generate mean functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
@@ -338,6 +338,7 @@ functional_preproc:
     using: []
 
   func_masking:
+    run: On
     FSL_AFNI:
       brain_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
@@ -359,6 +360,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
@@ -363,6 +363,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -304,8 +304,10 @@ functional_preproc:
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
-  
+
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -274,6 +274,7 @@ functional_preproc:
     using: []
 
   func_masking:
+    run: On
     FSL_AFNI:
       brain_mask: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: /usr/share/fsl/5.0/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
@@ -303,6 +304,9 @@ functional_preproc:
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+  
+  coreg_prep:
+    run: On
 
 nuisance_corrections:
   2-nuisance_regression:

--- a/CPAC/resources/configs/pipeline_config_ndmg.yml
+++ b/CPAC/resources/configs/pipeline_config_ndmg.yml
@@ -119,9 +119,6 @@ functional_preproc:
   motion_estimates_and_correction:
     run: On
 
-  func_masking:
-    run: On
-
   distortion_correction:
 
     # this is a fork point
@@ -134,6 +131,9 @@ functional_preproc:
     #   Blip-FSL-TOPUP - Uses FSL TOPUP to calculate the distortion unwarp for EPI field maps of opposite/same phase encoding direction.
     using: []
 
+  func_masking:
+    run: On
+
   generate_func_mean:
 
     # Generate mean functional image
@@ -145,6 +145,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_ndmg.yml
+++ b/CPAC/resources/configs/pipeline_config_ndmg.yml
@@ -119,6 +119,9 @@ functional_preproc:
   motion_estimates_and_correction:
     run: On
 
+  func_masking:
+    run: On
+
   distortion_correction:
 
     # this is a fork point
@@ -139,6 +142,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_regtest-1.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-1.yml
@@ -138,14 +138,14 @@ functional_preproc:
   motion_estimates_and_correction:
     run: On
 
-  func_masking:
-    run: On 
-
   distortion_correction:
 
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+
+  func_masking:
+    run: On
 
   generate_func_mean:
 
@@ -158,8 +158,10 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
-    
+
 nuisance_corrections:
   2-nuisance_regression:
 

--- a/CPAC/resources/configs/pipeline_config_regtest-1.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-1.yml
@@ -138,6 +138,9 @@ functional_preproc:
   motion_estimates_and_correction:
     run: On
 
+  func_masking:
+    run: On 
+
   distortion_correction:
 
     # this is a fork point
@@ -154,6 +157,9 @@ functional_preproc:
     # Normalize functional image
     run: On
 
+  coreg_prep:
+    run: On
+    
 nuisance_corrections:
   2-nuisance_regression:
 

--- a/CPAC/resources/configs/pipeline_config_regtest-2.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-2.yml
@@ -166,6 +166,9 @@ functional_preproc:
   motion_estimates_and_correction:
     run: On
 
+  func_masking:
+    run: On 
+
   distortion_correction:
 
     # this is a fork point
@@ -180,6 +183,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_regtest-2.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-2.yml
@@ -166,14 +166,14 @@ functional_preproc:
   motion_estimates_and_correction:
     run: On
 
-  func_masking:
-    run: On 
-
   distortion_correction:
 
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+
+  func_masking:
+    run: On
 
   generate_func_mean:
 
@@ -186,6 +186,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -192,6 +192,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
+    run: On
     FSL_AFNI:
       bold_ref: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
 
@@ -234,6 +235,9 @@ functional_preproc:
     # this is a fork point
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
+
+  coreg_prep:
+    run: On 
 
 nuisance_corrections:
   2-nuisance_regression:

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -237,7 +237,9 @@ functional_preproc:
     run: [On]
 
   coreg_prep:
-    run: On 
+
+    # Generate sbref
+    run: On
 
 nuisance_corrections:
   2-nuisance_regression:

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -206,6 +206,7 @@ functional_preproc:
     run: [On]
 
   func_masking:
+    run: On
 
     # using: ['AFNI', 'FSL', 'FSL_AFNI', 'Anatomical_Refined', 'Anatomical_Based', 'Anatomical_Resampled', 'CCS_Anatomical_Refined']
     # FSL_AFNI: fMRIPrep-style BOLD mask. Ref: https://github.com/nipreps/niworkflows/blob/a221f612/niworkflows/func/util.py#L246-L514
@@ -239,6 +240,9 @@ functional_preproc:
     # Last timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
     # Note: the selection here applies to all scans of all participants.
     stop_tr: 100
+  
+  coreg_prep:
+    run: On
 
 nuisance_corrections:
   2-nuisance_regression:

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -240,8 +240,10 @@ functional_preproc:
     # Last timepoint selection in the scan parameters in the data configuration file, if present, will over-ride this selection.
     # Note: the selection here applies to all scans of all participants.
     stop_tr: 100
-  
+
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -241,6 +241,7 @@ functional_preproc:
         functional_volreg_twopass: Off
 
   func_masking:
+    run: On
     FSL-BET:
 
       # Set an intensity threshold to improve skull stripping performances of FSL BET on rodent scans.
@@ -282,6 +283,9 @@ functional_preproc:
   normalize_func:
 
     # Normalize functional image
+    run: On
+
+  coreg_prep:
     run: On
 
 nuisance_corrections:

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -286,6 +286,8 @@ functional_preproc:
     run: On
 
   coreg_prep:
+
+    # Generate sbref
     run: On
 
 nuisance_corrections:


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->

## Description
Fixes bug in develop where `bold_masking` doesn't run with any preconfigs. The new `func_preproc` switches were set to 'off' in `pipeline_config_blank`, so they weren't running in any of the other preconfigs. I set the switches to 'on' in develop so that the other preconfigs will be updated and those steps will run.

## Tests
Ran `default` and `abcd-options` pipelines which verified that the crashes in the smoke tests are fixed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
