### PR TITLE
🐛 `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`

### DIFF
--- a/CPAC/utils/versioning/dependencies.py
+++ b/CPAC/utils/versioning/dependencies.py
@@ -53,7 +53,8 @@ def cli_version(command, dependency=None, in_result=True, delimiter=' ',
     """
     with Popen(command, stdout=PIPE, stderr=STDOUT, shell=True) as _command:
         _version = _command.stdout.read().decode('utf-8')
-        if int(_command.poll()) == 127:  # handle missing command
+        poll = _command.poll()
+        if poll is None or int(poll) == 127:  # handle missing command
             return {}
     if formatting is not None:
         _version = formatting(_version)

--- a/CPAC/utils/versioning/dependencies.py
+++ b/CPAC/utils/versioning/dependencies.py
@@ -52,6 +52,7 @@ def cli_version(command, dependency=None, in_result=True, delimiter=' ',
         {software: version}
     """
     with Popen(command, stdout=PIPE, stderr=STDOUT, shell=True) as _command:
+        assert _command.stdout is not None
         _version = _command.stdout.read().decode('utf-8')
         poll = _command.poll()
         if poll is None or int(poll) == 127:  # handle missing command


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes 

```Python
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

by [:octocat:](https://github.com/FCP-INDI/cpac/actions/runs/5718162615/job/15496889411)

## Description
<!-- Concisely describe what the pull request does. -->

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [ ] My commit messages follow best practices.
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
