### PR TITLE
:triangular_flag_on_post: Add flag to specify functional input

### DIFF
--- a/CPAC/aroma/aroma.py
+++ b/CPAC/aroma/aroma.py
@@ -60,6 +60,7 @@ def create_aroma(tr=None, wf_name='create_aroma'):
     bet_aroma = pe.Node(interface=fsl.BET(),name='bet_aroma')
     bet_aroma.inputs.frac = 0.3
     bet_aroma.inputs.mask = True
+    bet_aroma.inputs.functional = True
     preproc.connect(inputNode,'denoise_file', bet_aroma,'in_file')
     preproc.connect(bet_aroma,'mask_file', outputNode,'mask_aroma')
     


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->

## Description
The input for the fsl.BET() brain extraction function is a functional image, but only the first volume is required. This function used to automatically grab the first volume, but this feature is now deprecated. I added a [flag](https://nipype.readthedocs.io/en/0.12.0/interfaces/generated/nipype.interfaces.fsl.preprocess.html#:~:text=functional%3A%20(a%20boolean)%0A%20%20%20%20%20%20%20%20apply%20to%204D%20fMRI%20data%0A%20%20%20%20%20%20%20%20flag%3A%20%2DF%0A%20%20%20%20%20%20%20%20mutually_exclusive%3A%20functional%2C%20reduce_bias%2C%20robust%2C%20padding%2C%0A%20%20%20%20%20%20%20%20%20remove_eyes%2C%20surfaces%2C%20t2_guided) that indicates a 4D input and prevents this crash.

## Tests
I re-ran the benchmark-FNIRT pipeline, which was where I first saw this error, and it completed without crashes.

## Screenshots
<img width="323" alt="Screenshot 2023-08-14 at 11 54 58 AM" src="https://github.com/FCP-INDI/C-PAC/assets/113037677/8eca37bf-5e0b-4dc8-8d20-f807bab6745e">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
