### PR TITLE
🎨 Accomodate type hinting for `Function` node functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Some automatic handling of user-provided BIDSy atlas names.
+- `sig_imports` static method decorator for `Function` nodes, to accommodate type hinting in signatures of `Function` node functions.
 
 ## Fixed
 

--- a/CPAC/generate_motion_statistics/generate_motion_statistics.py
+++ b/CPAC/generate_motion_statistics/generate_motion_statistics.py
@@ -351,6 +351,10 @@ def calculate_FD_P(in_file):
     return out_file
 
 
+@Function.sig_imports(['import os', 'import sys',
+                       'from typing import Literal, Optional',
+                       'import numpy as np',
+                       'from CPAC.utils.pytest import skipif'])
 @skipif(sys.version_info < (3, 10),
         reason="Test requires Python 3.10 or higher")
 def calculate_FD_J(in_file: str, calc_from: Literal['affine', 'rms'],

--- a/CPAC/generate_motion_statistics/generate_motion_statistics.py
+++ b/CPAC/generate_motion_statistics/generate_motion_statistics.py
@@ -17,10 +17,6 @@
 """Functions to calculate motion statistics"""
 import os
 import sys
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 from typing import Optional
 import numpy as np
 import nibabel as nb
@@ -30,6 +26,7 @@ import nipype.interfaces.utility as util
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.utils.interfaces.function import Function
 from CPAC.utils.pytest import skipif
+from CPAC.utils.typing import LITERAL
 
 
 def motion_power_statistics(name='motion_stats',
@@ -352,12 +349,13 @@ def calculate_FD_P(in_file):
 
 
 @Function.sig_imports(['import os', 'import sys',
-                       'from typing import Literal, Optional',
+                       'from typing import Optional',
                        'import numpy as np',
-                       'from CPAC.utils.pytest import skipif'])
+                       'from CPAC.utils.pytest import skipif',
+                       'from CPAC.utils.typing import LITERAL'])
 @skipif(sys.version_info < (3, 10),
         reason="Test requires Python 3.10 or higher")
-def calculate_FD_J(in_file: str, calc_from: Literal['affine', 'rms'],
+def calculate_FD_J(in_file: str, calc_from: LITERAL['affine', 'rms'],
                    center: Optional[np.ndarray] = None) -> str:
     """
     Method to calculate framewise displacement as per Jenkinson et al. 2002

--- a/CPAC/pipeline/utils.py
+++ b/CPAC/pipeline/utils.py
@@ -85,10 +85,10 @@ def present_outputs(outputs: dict, keys: list) -> dict:
     """
     Given an outputs dictionary and a list of output keys, returns
     the subset of ``outputs`` that includes all keys in ``keys`` that are
-    present. I.e., ~:py:func:`CPAC.func_preproc.func_motion.motion_correct_connections`
+    present. I.e., :py:func:`~CPAC.func_preproc.func_motion.motion_correct_connections`
     will have different items in its ``outputs`` dictionary at different
     times depending on the ``motion_correction`` configuration;
-    ~:py:func:`CPAC.func_preproc.func_motion.func_motion_estimates` can
+    :py:func:`~CPAC.func_preproc.func_motion.func_motion_estimates` can
     then wrap that ``outputs`` in this function and provide a list of
     keys of the desired outputs to include, if they are present in the
     provided ``outputs`` dictionary, eliminating the need for multiple

--- a/CPAC/utils/interfaces/function/function.py
+++ b/CPAC/utils/interfaces/function/function.py
@@ -132,7 +132,7 @@ class Function(IOBase):
         Examples
         --------
         See the defintion of
-        ~:py:func:`CPAC.generate_motion_statistics.calculate_FD_J` to see the
+        :py:func:`~CPAC.generate_motion_statistics.calculate_FD_J` to see the
         decorator tested here being applied.
         >>> from CPAC.generate_motion_statistics import calculate_FD_J
         >>> calc_fdj = Function(input_names=['in_file', 'calc_from', 'center'],

--- a/CPAC/utils/interfaces/function/function.py
+++ b/CPAC/utils/interfaces/function/function.py
@@ -121,7 +121,7 @@ class Function(IOBase):
         imports : list of str
             import statements to import the function in an otherwise empty
             namespace. If these collide with imports defined via the
-            ~:py:meth:`Function.__init__` initialization method, the
+            :py:meth:`Function.__init__` initialization method, the
             imports given as a parameter here will be overridden by
             those from the initializer.
 

--- a/CPAC/utils/interfaces/function/function.py
+++ b/CPAC/utils/interfaces/function/function.py
@@ -143,9 +143,10 @@ class Function(IOBase):
         ['from CPAC.utils.interfaces.function import Function',
          'import os',
          'import sys',
-         'from typing import Literal, Optional',
+         'from typing import Optional',
          'import numpy as np',
-         'from CPAC.utils.pytest import skipif']
+         'from CPAC.utils.pytest import skipif',
+         'from CPAC.utils.typing import LITERAL']
         >>> from inspect import signature
         >>> from nipype.utils.functions import (getsource,
         ...     create_function_from_source)

--- a/CPAC/utils/typing.py
+++ b/CPAC/utils/typing.py
@@ -25,6 +25,12 @@ import sys
 from CPAC.utils.docs import DOCS_URL_PREFIX
 __doc__ = __doc__.replace(r'{DOCS_URL_PREFIX}', DOCS_URL_PREFIX)
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+    LITERAL = Literal
+else:
+    from typing_extensions import Literal
+    LITERAL = Literal
 if sys.version_info >= (3, 10):
     LIST_OR_STR = list | str
     TUPLE = tuple
@@ -33,4 +39,4 @@ else:
     LIST_OR_STR = Union[list, str]
     TUPLE = Tuple
 
-__all__ = ['LIST_OR_STR', 'TUPLE']
+__all__ = ['LIST_OR_STR', 'LITERAL', 'TUPLE']


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Nipype long predates Python support for type hinting, and the way [`Function`](https://github.com/nipy/nipype/blob/71411b0ba6c413190f64e15292e0cab79840087f/nipype/interfaces/utility/wrappers.py#L28-L159) nodes are handled, type hints only work if the types are builtin or defined in the same file that the `Function` node is called from or if the necessary `import` statements are provided in the `Function(…, imports=)` constructor.

### Alternatives

* Use string annotations instead of type annotations for anything that's not built-in
* Don't use type annotations

### Additional context

I discovered this behavior when I was testing changes for #1989. The final changes don't need this decorator, but I think it's nice to future developers to supply type hints where we can.

## Description
<!-- Concisely describe what the pull request does. -->
This PR adds a `@sig_imports` decorator to supply the `import` statements necessary to load the function at the function definition, rather than needing to supply them each time a Function node is created for the function.



## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
This decorator can also be used to move the `import` statements within function node functions out into the decorator to avoid reimports, but that might just be an aesthetic change since it's moving, not removing, those statements.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
https://github.com/FCP-INDI/C-PAC/blob/d3589b81cf46db8580da6e701c6e41c5957f5a1e/CPAC/utils/interfaces/function/function.py#L132-L156 https://github.com/FCP-INDI/C-PAC/blob/d3589b81cf46db8580da6e701c6e41c5957f5a1e/CPAC/generate_motion_statistics/generate_motion_statistics.py#L351-L359


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
