### PR TITLE
♻️ Move mutual-exclusivity check to schema validation

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1309,15 +1309,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                                     generate_only)
 
         pipeline_blocks += nuisance
-        
+
     pipeline_blocks.append(ingress_regressors)
-    
-    # Check for mutually exclusive options
-    if cfg.nuisance_corrections['2-nuisance_regression']['ingress_regressors'] and \
-        cfg.nuisance_corrections['2-nuisance_regression']['create_regressors']:
-        err_msg = "[!] Ingress_regressors and create_regressors can't both run! " \
-                    " Try turning one option off.\n "
-        raise Exception(err_msg)
 
     apply_func_warp = {}
     _r_w_f_r = cfg.registration_workflows['functional_registration']

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1155,6 +1155,17 @@ def schema(config_dict):
                     path=[*mec_path, 'motion_correction', 'using'])
     except KeyError:
         pass
+    try:
+        # Check for mutually exclusive options
+        if (partially_validated['nuisance_corrections'][
+            '2-nuisance_regression']['ingress_regressors']['run'] and
+            partially_validated['nuisance_corrections'][
+                '2-nuisance_regression']['create_regressors']):
+            raise ExclusiveInvalid(
+                "[!] Ingress_regressors and create_regressors can't both run! "
+                " Try turning one option off.\n ")
+    except KeyError:
+        pass
     return partially_validated
 
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Follow-up to 676705c by @e-kenneally
Fixes af72ff8 by @sgiavasis 
Fixes #1952 by @e-kenneally 

## Description
<!-- Concisely describe what the pull request does. -->
Smoke tests are failing in current `develop` after merging #1952 because, for example,
```Python
bool({'run': False,
      'Regressors': {'Name': 'default', 'Columns': ['global_signal']}
     }) == True
```
and https://github.com/FCP-INDI/C-PAC/blob/2fb9d13c997c9509a04ce9938f0492409bd63403/CPAC/pipeline/cpac_pipeline.py#L1315-L1320 is checking `cfg.nuisance_corrections['2-nuisance_regression']['ingress_regressors']` which includes dictionary values like that.

This PR: 

1. Adds `'run'` to https://github.com/FCP-INDI/C-PAC/blob/3a2a06ae90332c8685812d2e8e7e9946db76b8f4/CPAC/pipeline/schema.py#L1160-L1161
2. Moves the check from pipeline building to schema validation (so the check happens sooner)
3. Changes the exception type from generic `Exception` to the more specific [`ExclusiveInvalid`](https://alecthomas.github.io/voluptuous/docs/_build/html/_modules/voluptuous/error.html#ExclusiveInvalid)
https://github.com/FCP-INDI/C-PAC/blob/2fb9d13c997c9509a04ce9938f0492409bd63403/CPAC/pipeline/cpac_pipeline.py#L1318-L1320 → https://github.com/FCP-INDI/C-PAC/blob/3a2a06ae90332c8685812d2e8e7e9946db76b8f4/CPAC/pipeline/schema.py#L1164-L1166

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
The smoke tests should start passing again once this is merged to `develop`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
