### PR TITLE
🐛 Fix some bugs found via 1.8.6-dev smoke tests

### DIFF
--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -18,6 +18,7 @@ name: Run participant smoke test
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   smoke_test_human:

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1369,7 +1369,7 @@ def bold_mask_anatomical_resampled(wf, cfg, strat_pool, pipe_num, opt=None):
     option_val='CCS_Anatomical_Refined',
     inputs=[['desc-motion_bold', 'desc-preproc_bold', 'bold'], 'desc-brain_T1w',
             ['desc-preproc_T1w', 'desc-reorient_T1w', 'T1w']],
-    outputs=['space-bold_desc-brain_mask', 'desc-ROIbrain_bold']
+    outputs=['space-bold_desc-brain_mask', 'desc-ref_bold']
 )
 def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
     '''Generate the BOLD mask by basing it off of the anatomical brain.
@@ -1496,7 +1496,7 @@ def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
 
     outputs = {
         'space-bold_desc-brain_mask': (intersect_mask, 'out_file'),
-        'desc-ROIbrain_bold': (example_func_brain, 'out_file')
+        'desc-ref_bold': (example_func_brain, 'out_file')
     }
 
     return (wf, outputs)

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -2514,24 +2514,7 @@ def nuisance_regression(wf, cfg, strat_pool, pipe_num, opt, space, res=None):
 
     outputs : dict
     '''
-    ingress = strat_pool.check_rpool('parsed_regressors')
-    if not ingress:
-        try:
-            regressor_prov = strat_pool.get_cpac_provenance('desc-confounds_timeseries')
-            regressor_strat_name = regressor_prov[-1].split('_')[-1]
-        except KeyError:
-            raise Exception("[!] No regressors in resource pool. \n\n Try turning " \
-                            "on create_regressors or ingress_regressors.")
-    else:
-        # name regressor workflow without regressor_prov
-        regressor_strat_name = cfg.nuisance_corrections['2-nuisance_regression'][
-                'ingress_regressors']['Regressors']['Name']
-    for regressor_dct in cfg['nuisance_corrections']['2-nuisance_regression'][
-            'Regressors']:
-        if regressor_dct['Name'] == regressor_strat_name:
-            opt = regressor_dct
-            break
-
+    opt = strat_pool.regressor_dct(cfg)
     bandpass = 'Bandpass' in opt
     bandpass_before = bandpass and cfg['nuisance_corrections',
                                        '2-nuisance_regression',

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -22,6 +22,7 @@ from itertools import chain
 import logging
 import os
 import re
+from typing import Any, Optional, Union
 import warnings
 
 from CPAC.pipeline import \
@@ -49,6 +50,7 @@ from CPAC.utils.interfaces.datasink import DataSink
 from CPAC.utils.monitoring import getLogger, LOGTAIL, \
                                   WARNING_FREESURFER_OFF_WITH_DATA
 from CPAC.utils.outputs import Outputs
+from CPAC.utils.typing import LIST_OR_STR, TUPLE
 from CPAC.utils.utils import check_prov_for_regtool, \
     create_id_string, get_last_prov_entry, read_json, write_output_json
 
@@ -328,54 +330,44 @@ class ResourcePool:
             self.pipe_list.append(new_pipe_idx)
 
         self.rpool[resource][new_pipe_idx]['data'] = (node, output)
-        self.rpool[resource][new_pipe_idx]['json'] = json_info 
+        self.rpool[resource][new_pipe_idx]['json'] = json_info
 
-    def get(self, resource, pipe_idx=None, report_fetched=False,
-            optional=False):
+    def get(self, resource: LIST_OR_STR, pipe_idx: Optional[str] = None,
+            report_fetched: Optional[bool] = False,
+            optional: Optional[bool] = False) -> Union[
+                TUPLE[Optional[dict], Optional[str]], Optional[dict]]:
         # NOTE!!!
         #   if this is the main rpool, this will return a dictionary of strats, and inside those, are dictionaries like {'data': (node, out), 'json': info}
         #   BUT, if this is a sub rpool (i.e. a strat_pool), this will return a one-level dictionary of {'data': (node, out), 'json': info} WITHOUT THE LEVEL OF STRAT KEYS ABOVE IT
-        
-        info_msg = "\n\n[!] C-PAC says: None of the listed resources are in " \
-                   f"the resource pool:\n\n  {resource}\n\nOptions:\n- You " \
-                   "can enable a node block earlier in the pipeline which " \
-                   "produces these resources. Check the 'outputs:' field in " \
-                   "a node block's documentation.\n- You can directly " \
-                   "provide this required data by pulling it from another " \
-                   "BIDS directory using 'source_outputs_dir:' in the " \
-                   "pipeline configuration, or by placing it directly in " \
-                   "your C-PAC output directory.\n- If you have done these, " \
-                   "and you still get this message, please let us know " \
-                   "through any of our support channels at: " \
-                   "https://fcp-indi.github.io/\n"
-        
-        if isinstance(resource, list):
-            # if a list of potential inputs are given, pick the first one
-            # found
-            for label in resource:
-                if label in self.rpool.keys():
-                    if report_fetched:
-                        return (self.rpool[label], label)
-                    return self.rpool[label]
-            if optional:
-                if report_fetched:
-                    return (None, None)
-                return None
-            raise LookupError(info_msg)
-        else:
-            if resource not in self.rpool.keys():
-                if optional:
-                    if report_fetched:
-                        return (None, None)
-                    return None
-                raise LookupError(info_msg)
-            if report_fetched:
+        if not isinstance(resource, list):
+            resource = [resource]
+        # if a list of potential inputs are given, pick the first one
+        # found
+        for label in resource:
+            if label in self.rpool.keys():
+                _found = self.rpool[label]
                 if pipe_idx:
-                    return (self.rpool[resource][pipe_idx], resource)
-                return (self.rpool[resource], resource)
-            if pipe_idx:
-                return self.rpool[resource][pipe_idx]
-            return self.rpool[resource]
+                    _found = _found[pipe_idx]
+                if report_fetched:
+                    return _found, label
+                return _found
+        if optional:
+            if report_fetched:
+                return (None, None)
+            return None
+        raise LookupError(
+            "\n\n[!] C-PAC says: None of the listed resources are in "
+            f"the resource pool:\n\n  {resource}\n\nOptions:\n- You "
+            "can enable a node block earlier in the pipeline which "
+            "produces these resources. Check the 'outputs:' field in "
+            "a node block's documentation.\n- You can directly "
+            "provide this required data by pulling it from another "
+            "BIDS directory using 'source_outputs_dir:' in the "
+            "pipeline configuration, or by placing it directly in "
+            "your C-PAC output directory.\n- If you have done these, "
+            "and you still get this message, please let us know "
+            "through any of our support channels at: "
+            "https://fcp-indi.github.io/\n")
 
     def get_data(self, resource, pipe_idx=None, report_fetched=False,
                  quick_single=False):

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -350,9 +350,6 @@ nuisance_corrections:
         # If using erosion, using both proportion and millimeters is not recommended.
         gm_erosion_prop: 0.6
 
-    # switch to Off if nuisance regression is off and you don't want to write out the regressors
-    create_regressors: On
-
 timeseries_extraction:
   connectivity_matrix:
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1276,7 +1276,7 @@ nuisance_corrections:
         Columns: [global_signal]
 
     # switch to Off if nuisance regression is off and you don't want to write out the regressors
-    create_regressors: Off
+    create_regressors: On
 
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -286,9 +286,6 @@ nuisance_corrections:
         # If using erosion, using both proportion and millimeters is not recommended.
         gm_erosion_prop: 0.6
 
-    # switch to Off if nuisance regression is off and you don't want to write out the regressors
-    create_regressors: On
-
 timeseries_extraction:
   connectivity_matrix:
 

--- a/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
@@ -124,7 +124,8 @@ nuisance_corrections:
       run: On
       Regressors:
         Columns: [global_signal, white_matter]
-    
+
+    # switch to Off if nuisance regression is off and you don't want to write out the regressors
     create_regressors: Off
 
 timeseries_extraction:

--- a/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
@@ -124,6 +124,8 @@ nuisance_corrections:
       run: On
       Regressors:
         Columns: [global_signal, white_matter]
+    
+    create_regressors: Off
 
 timeseries_extraction:
   run: On

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -484,9 +484,6 @@ nuisance_corrections:
     #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must only be set to template
     space: [template]
 
-    # switch to Off if nuisance regression is off and you don't want to write out the regressors
-    create_regressors: On
-
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions
     lateral_ventricles_mask:

--- a/CPAC/utils/typing.py
+++ b/CPAC/utils/typing.py
@@ -41,11 +41,11 @@ else:
     from typing import Iterable, List
     LIST = List
 if sys.version_info >= (3, 10):
-    LIST_OR_STR = list | str  # pylint: disable=invalid-name
+    LIST_OR_STR = LIST[str] | str  # pylint: disable=invalid-name
     TUPLE = tuple
 else:
     from typing import Tuple
-    LIST_OR_STR = Union[list, str]  # pylint: disable=invalid-name
+    LIST_OR_STR = Union[LIST[str], str]  # pylint: disable=invalid-name
     TUPLE = Tuple
 ITERABLE = Iterable
 ConfigKeyType = Union[str, LIST[str]]


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
- Fixes 

   ```Python
   TypeError: string indices must be integers
   ```
   
   in https://github.com/FCP-INDI/C-PAC/actions/runs/6669328783/job/18127204189

- Fixes

   ```Python
   TypeError: cannot unpack non-iterable NoneType object
   ```
   
   in https://github.com/FCP-INDI/C-PAC/actions/runs/6669328783/job/18127204189

- Fixes
   > Where it seems to try to look up the error message itself in a list?

   by @nx10 on Slack

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
### `string indices must be integers`
Dashes and spaces in the regressor names were causing problems in the regressors downstream from forked filters, so I updated the regressor naming to only include alphanumeric characters and no-more-than-one-in-a-row underscores, which renamed some regressors in some preconfigs to names including underscores, which doesn't play well with https://github.com/FCP-INDI/C-PAC/blob/7ff4a9341eb0784443bef1680cae7b2017ec11a1/CPAC/nuisance/nuisance.py#L2521 https://github.com/FCP-INDI/C-PAC/blob/7ff4a9341eb0784443bef1680cae7b2017ec11a1/CPAC/nuisance/nuisance.py#L2529-L2532, so I abstracted this lookup into a strat_pool (ResourcePool) method that tries names with zero underscores up through as many as are in the prov in https://github.com/FCP-INDI/C-PAC/blob/a873f68b6ac7243d1338f7b6ffe0fc2601985fb4/CPAC/pipeline/engine.py#L276-L282 https://github.com/FCP-INDI/C-PAC/blob/a873f68b6ac7243d1338f7b6ffe0fc2601985fb4/CPAC/nuisance/nuisance.py#L2517

### `cannot unpack non-iterable NoneType object`
I overtrimmed in https://github.com/FCP-INDI/C-PAC/commit/6ca33b941f9e3d94753ed49b1ef6741abdc32411, repaired the damage with https://github.com/FCP-INDI/C-PAC/blob/a873f68b6ac7243d1338f7b6ffe0fc2601985fb4/CPAC/pipeline/engine.py#L360-L364

These tests will still be failing after these changes, but they should be more-helpful missing-resource exceptions

### Where it seems to try to look up the error message itself in a list?
This one was some exception handling that needed updated. The lookup was from trying to parse the key out of the error to see if we should https://github.com/FCP-INDI/C-PAC/blob/a873f68b6ac7243d1338f7b6ffe0fc2601985fb4/CPAC/pipeline/cpac_pipeline.py#L1498-L1503 instead of a less-informative-to-an-end-user error. This PR beefs up the key searching and should gracefully just fall back to the original exception if it fails to find the key in the exception message.

## Tests

[Manually launched smoke tests](https://github.com/FCP-INDI/C-PAC/actions/runs/6674617016)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
