### PR TITLE
🎨 DRY `ResourcePool.get`

### DIFF
--- a/CPAC/utils/typing.py
+++ b/CPAC/utils/typing.py
@@ -41,11 +41,11 @@ else:
     from typing import Iterable, List
     LIST = List
 if sys.version_info >= (3, 10):
-    LIST_OR_STR = list | str  # pylint: disable=invalid-name
+    LIST_OR_STR = LIST[str] | str  # pylint: disable=invalid-name
     TUPLE = tuple
 else:
     from typing import Tuple
-    LIST_OR_STR = Union[list, str]  # pylint: disable=invalid-name
+    LIST_OR_STR = Union[LIST[str], str]  # pylint: disable=invalid-name
     TUPLE = Tuple
 ITERABLE = Iterable
 ConfigKeyType = Union[str, LIST[str]]


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #2011 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
Simplified https://github.com/FCP-INDI/C-PAC/blob/dd95a760b8e237bf4274e8e356197498bc28ea96/CPAC/pipeline/engine.py#L335-L378 into https://github.com/FCP-INDI/C-PAC/blob/330f317e72b9bc187badb804ee7aeeff72318c5e/CPAC/pipeline/engine.py#L339-L370 and adds typehints to the method's signature

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* This changes one bit of logic here. Before this PR, if a list is passed as `resource` to `ResourcePool.get`, any `pipe_idx` passed to the method is ignored, but if a string is passed, `pipe_idx` is used. I.e.,

  | `ResourcePool.get(resource=resource, pipe_idx=pipe_idx)` returns | before | after |
  |---|---|---|
  | `if isinstance(resource, list)` | `self.rpool[label]` | `self.rpool[label][pipe_idx]`  |
  | `if isinstance(resource, str)` | `self.rpool[label][pipe_idx]` | `self.rpool[label][pipe_idx]` |

  Otherwise the behavior should be identical before and after this code change
* If #2011 is merged before this PR, this PR's target should change to `develop`

## Tests
Smoke tests behave the same [before](https://github.com/FCP-INDI/C-PAC/actions/runs/6674617016) and [after](https://github.com/FCP-INDI/C-PAC/actions/runs/6698352708) these changes

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `fix/smoke-1.8.6-dev` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
