### PR TITLE
👔 Make CCS & fMRIPrep BOLD masking steps interchangeable

### DIFF
--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1369,7 +1369,7 @@ def bold_mask_anatomical_resampled(wf, cfg, strat_pool, pipe_num, opt=None):
     option_val='CCS_Anatomical_Refined',
     inputs=[['desc-motion_bold', 'desc-preproc_bold', 'bold'], 'desc-brain_T1w',
             ['desc-preproc_T1w', 'desc-reorient_T1w', 'T1w']],
-    outputs=['space-bold_desc-brain_mask', 'desc-ROIbrain_bold']
+    outputs=['space-bold_desc-brain_mask', 'desc-ref_bold']
 )
 def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
     '''Generate the BOLD mask by basing it off of the anatomical brain.
@@ -1496,7 +1496,7 @@ def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
 
     outputs = {
         'space-bold_desc-brain_mask': (intersect_mask, 'out_file'),
-        'desc-ROIbrain_bold': (example_func_brain, 'out_file')
+        'desc-ref_bold': (example_func_brain, 'out_file')
     }
 
     return (wf, outputs)


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes 
> ```Python
> LookupError: When trying to connect node block 'coregistration_prep_fmriprep' to workflow 'cpac_sub-NDARINV2VY7YYNW_ses-baselineYear1Arm1' after node block 'func_normalize': 
> 
> [!] C-PAC says: None of the listed resources in the node block being connected exist in the resource pool.
> 
> Resources:
> ['desc-ref_bold']
> ```

for

```YAML
functional_preproc:
  func_masking:
    using:
      - CCS_Anatomical_Refined
registration_workflows:
  functional_registration:
    coregistration:
      func_input_prep:
        input:
          - fmriprep_reference
```

by @nx10 & @e-kenneally on Slack
## Description
<!-- Concisely describe what the pull request does. -->
Updates the BOLD resource coming out of the `bold_mask_ccs` NodeBlock to be interchangeable with the BOLD resource coming out of the `bold_mask_fsl_afni` NodeBlock. (The BOLD resource coming out of `bold_mask_ccs` is not being used elsewhere as far as I can tell)

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* <span id='design-question' name='design-question'>Of the options for `func_masking.using` https://github.com/FCP-INDI/C-PAC/blob/1d195412665cacceb575cf8dd3b0eeb812dbd326/CPAC/pipeline/schema.py#L834-L836, before this PR, only `FSL_AFNI` was compatible with `coregistration_prep_fmriprep`, and after 1d195412665cacceb575cf8dd3b0eeb812dbd326 only `FSL_AFNI` and `CCS_Anatomical_Refined` are. I imagine we should make the others compatible as well?</span>
* Like #2012, this PR is targeting the branch for #2011. If #2011 is merged before this one, this branch's target should be updated to `develop`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `fix/smoke-1.8.6-dev` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
