### PR TITLE
🐛 Fix parsing `FROM: /filepath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handling of `3dECM` outputs for AFNI ≥ 21.1.1.
 - Fixed a bug where sparsity thresholds were not being scaled for network centrality.
 - Fixed a bug where `calculate_motion_first` would not calculate motion at all.
+- Fixed a bug in parsing `FROM: /file/path` syntax
 
 ### Changed
 

--- a/CPAC/utils/configuration/configuration.py
+++ b/CPAC/utils/configuration/configuration.py
@@ -118,8 +118,8 @@ class Configuration:
             config_map = update_nested_dict(base_config.dict(), config_map)
         else:
             # base everything on blank pipeline for unspecified keys
-            with open(preconfig_yaml('blank'), 'r', encoding='utf-8') as _f:
-                config_map = update_nested_dict(yaml.safe_load(_f), config_map)
+            config_map = update_nested_dict(
+                preconfig_yaml('blank', load=True), config_map)
 
         config_map = self._nonestr_to_None(config_map)
 
@@ -636,9 +636,9 @@ def preconfig_yaml(preconfig_name='default', load=False):
     from CPAC.pipeline import ALL_PIPELINE_CONFIGS, AVAILABLE_PIPELINE_CONFIGS
     if preconfig_name not in ALL_PIPELINE_CONFIGS:
         raise BadParameter(
-            "The pre-configured pipeline name '{0}' you provided is not one "
-            "of the available pipelines.\n\nAvailable pipelines:\n"
-            f"{1}\n".format(preconfig_name, str(AVAILABLE_PIPELINE_CONFIGS)),
+            f"The pre-configured pipeline name '{preconfig_name}' you "
+            "provided is not one of the available pipelines.\n\nAvailable "
+            f"pipelines:\n{str(AVAILABLE_PIPELINE_CONFIGS)}\n",
             param='preconfig')
     if load:
         with open(preconfig_yaml(preconfig_name), 'r', encoding='utf-8') as _f:

--- a/CPAC/utils/configuration/yaml_template.py
+++ b/CPAC/utils/configuration/yaml_template.py
@@ -20,6 +20,7 @@ import os
 import re
 from datetime import datetime
 from hashlib import sha1
+from click import BadParameter
 import yaml
 
 from CPAC.utils.configuration import Configuration, Preconfiguration, \
@@ -58,16 +59,20 @@ class YamlTemplate():  # pylint: disable=too-few-public-methods
 
         base_config : Configuration, optional
         """
-        preconfig_path = preconfig_yaml(original_yaml)
-        if os.path.exists(preconfig_path):
-            original_yaml = preconfig_path
+        try:
+            original_yaml = preconfig_yaml(original_yaml)
+        except BadParameter:
+            pass
         if os.path.exists(original_yaml):
             with open(original_yaml, 'r', encoding='utf-8') as _f:
                 original_yaml = _f.read()
         self.comments = {}
         self.template = original_yaml
         if base_config is None:
-            self._dict = yaml.safe_load(self.template)
+            if isinstance(self.template, dict):
+                self._dict = self.template
+            if isinstance(self.template, str):
+                self._dict = yaml.safe_load(self.template)
         else:
             self._dict = base_config.dict()
         self._parse_comments()

--- a/CPAC/utils/tests/configs/__init__.py
+++ b/CPAC/utils/tests/configs/__init__.py
@@ -1,14 +1,22 @@
 """Configs for testing"""
-import os
+from pathlib import Path
 from pkg_resources import resource_filename
-with open(resource_filename("CPAC",
-                            os.path.join('utils', 'tests', 'configs',
-                                         'neurostars_23786.yml')),
-          'r', encoding='utf-8') as _f:
+import yaml
+
+_TEST_CONFIGS_PATH = Path(resource_filename("CPAC", "utils/tests/configs"))
+with open(_TEST_CONFIGS_PATH / "neurostars_23786.yml", "r", encoding="utf-8"
+          ) as _f:
+    # A loaded YAML file to test https://tinyurl.com/neurostars23786
     NEUROSTARS_23786 = _f.read()
-with open(resource_filename("CPAC",
-                            os.path.join('utils', 'tests', 'configs',
-                                         'neurostars_24035.yml')),
-          'r', encoding='utf-8') as _f:
+with open(_TEST_CONFIGS_PATH / "neurostars_24035.yml", "r", encoding="utf-8"
+          ) as _f:
+    # A loaded YAML file to test https://tinyurl.com/neurostars24035
     NEUROSTARS_24035 = _f.read()
-__all__ = ['NEUROSTARS_23786', 'NEUROSTARS_24035']
+# A loaded YAML file to test https://tinyurl.com/cmicnlslack420349
+SLACK_420349 = {
+    "filepath": yaml.dump({
+        "FROM": str(_TEST_CONFIGS_PATH / "neurostars_23786.yml"),
+        "pipeline_setup": {"pipeline_name": "slack_420349_filepath"}}),
+    "preconfig": yaml.dump({"FROM": "preproc",
+        "pipeline_setup": {"pipeline_name": "slack_420349_preconfig"}})}
+__all__ = ["NEUROSTARS_23786", "NEUROSTARS_24035", "SLACK_420349"]

--- a/CPAC/utils/tests/test_yaml.py
+++ b/CPAC/utils/tests/test_yaml.py
@@ -50,8 +50,7 @@ def test_yaml_template():
     # Create a new YAML configuration file based on the default pipeline
     # YAML file.
     pipeline_file = preconfig_yaml('default')
-    with open(pipeline_file, 'r', encoding='utf-8') as f:
-        config = yaml.safe_load(f)
+    config = preconfig_yaml('default', load=True)
     new_config = create_yaml_from_template(config, pipeline_file)
     with open(config_file, 'w', encoding='utf-8') as f:
         f.write(new_config)

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -25,11 +25,9 @@ import pickle
 import numpy as np
 import yaml
 
-from click import BadParameter
 from copy import deepcopy
 from itertools import repeat
 from voluptuous.error import Invalid
-from CPAC.pipeline import ALL_PIPELINE_CONFIGS, AVAILABLE_PIPELINE_CONFIGS
 
 CONFIGS_DIR = os.path.abspath(os.path.join(
     __file__, *repeat(os.path.pardir, 2), 'resources/configs/'))
@@ -1513,33 +1511,6 @@ def delete_nested_value(d, keys):
         return d
     d[keys[0]] = delete_nested_value(d.get(keys[0], {}), keys[1:])
     return d
-
-
-def load_preconfig(pipeline_label):
-    import os
-    import pkg_resources as p
-
-    if pipeline_label not in ALL_PIPELINE_CONFIGS:
-        raise BadParameter(
-            "The pre-configured pipeline name '{0}' you provided is not one "
-            "of the available pipelines.\n\nAvailable pipelines:\n"
-            "{1}\n".format(pipeline_label, str(AVAILABLE_PIPELINE_CONFIGS)),
-            param='preconfig')
-
-    pipeline_file = \
-        p.resource_filename(
-            "CPAC",
-            os.path.join(
-                "resources",
-                "configs",
-                "pipeline_config_{0}.yml".format(pipeline_label)
-            )
-        )
-
-    print(f"Loading the '{pipeline_label}' pre-configured pipeline.",
-          file=sys.stderr)
-
-    return pipeline_file
 
 
 def ordereddict_to_dict(value):

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -40,7 +40,7 @@ from CPAC.utils.monitoring import failed_to_start, log_nodes_cb
 from CPAC.utils.configuration.yaml_template import create_yaml_from_template, \
                                                    hash_data_config, \
                                                    upgrade_pipeline_to_1_8
-from CPAC.utils.utils import load_preconfig, update_nested_dict
+from CPAC.utils.utils import update_nested_dict
 simplefilter(action='ignore', category=FutureWarning)
 logger = logging.getLogger('nipype.workflow')
 DEFAULT_TMP_DIR = "/tmp"
@@ -460,7 +460,7 @@ def run_main():
                 run(f"bids-validator {bids_dir}")
 
         if args.preconfig:
-            args.pipeline_file = load_preconfig(args.preconfig)
+            args.pipeline_file = preconfig_yaml(args.preconfig, load=True)
 
         # otherwise, if we are running group, participant, or dry run we
         # begin by conforming the configuration

--- a/dev/docker_data/run.py
+++ b/dev/docker_data/run.py
@@ -460,11 +460,14 @@ def run_main():
                 run(f"bids-validator {bids_dir}")
 
         if args.preconfig:
-            args.pipeline_file = preconfig_yaml(args.preconfig, load=True)
+            args.pipeline_file = preconfig_yaml(args.preconfig)
 
         # otherwise, if we are running group, participant, or dry run we
         # begin by conforming the configuration
-        c = load_yaml_config(args.pipeline_file, args.aws_input_creds)
+        if isinstance(args.pipeline_file, dict):
+            c = args.pipeline_file
+        else:
+            c = load_yaml_config(args.pipeline_file, args.aws_input_creds)
 
         if 'pipeline_setup' not in c:
             _url = (f'{DOCS_URL_PREFIX}/user/pipelines/'


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes [`FileNotFoundError: [Errno 2] No such file or directory: '/code/CPAC/resources/configs/pipeline_config_/configs/pipeline_config_cpac_1.8.5_fromPhoebeNoDeriviativesNative.yml.yml'`](https://tinyurl.com/cmicnlslack420349) by [@Shinwon Park](https://cmi-cnl.slack.com/team/U05CG6L2RB3)

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Consolidates https://github.com/FCP-INDI/C-PAC/blob/ecfc583ac03a57fed185fd5028c27d378d08fa8f/CPAC/utils/utils.py#L1518-L1542 and https://github.com/FCP-INDI/C-PAC/blob/ecfc583ac03a57fed185fd5028c27d378d08fa8f/CPAC/utils/configuration/configuration.py#L606-L625 into https://github.com/FCP-INDI/C-PAC/blob/907fab5e0e6e4efda0046ee04ddc4a74d07b170b/CPAC/utils/configuration/configuration.py#L620-L647 so preconfiguration loading is handled consistently everywhere and updates the relevant function calls.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
https://github.com/FCP-INDI/C-PAC/blob/907fab5e0e6e4efda0046ee04ddc4a74d07b170b/CPAC/utils/tests/configs/__init__.py#L15-L21
https://github.com/FCP-INDI/C-PAC/blob/907fab5e0e6e4efda0046ee04ddc4a74d07b170b/CPAC/utils/configuration/configuration.py#L88-L100

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
