### PR TITLE
👔 Make nuisance regression space non-forkable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uses highest resolution available locally as reference when resampling a template to a non-packaged resolution (was always using 1mm reference before)
 - Updates config boolean validation from anything-truthy-is-True (e.g., `[True, False]`, or `[False]`, or a typo like `Offf`) to only accepting bools, ints, and YAML boolean strings like "On" and "Off" as boolean
 - When applying a filter to motion parameters, now C-PAC reports both the original and the filtered motion parameters and uses the original parameters for qc. Previous versions only reported the filtered parameters and used the filtered parameters for qc.
+- Makes nuisance regression space non-forkable. In v1.8.5, nuisance regression forking was broken, so this change should not cause backwards-compatibility issues.
 
 ### Added dependencies
 

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -94,11 +94,11 @@ def choose_nuisance_blocks(cfg, rpool, generate_only=False):
             nuisance.append((nuisance_regressors_generation_EPItemplate,
                              input_interface))
 
-        if not generate_only and 'native' in cfg['nuisance_corrections',
-                                                 '2-nuisance_regression',
-                                                 'space']:
+        if not generate_only and cfg['nuisance_corrections',
+                                     '2-nuisance_regression',
+                                     'space'] == 'native':
             nuisance.append((nuisance_regression_native, input_interface))
-    
+
     return nuisance
 
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1356,7 +1356,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
 
     pipeline_blocks += [func_despike_template]
 
-    if 'Template' in target_space_alff and 'Native' in target_space_nuis:
+    if 'Template' in target_space_alff and target_space_nuis == 'native':
         pipeline_blocks += [warp_denoiseNofilt_to_T1template]
 
     template = cfg.registration_workflows['functional_registration'][
@@ -1392,9 +1392,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None,
                             warp_deriv_mask_to_EPItemplate]
 
     # Template-space nuisance regression
-    nuisance_template = 'template' in cfg[
-        'nuisance_corrections', '2-nuisance_regression', 'space'
-    ] and not generate_only
+    nuisance_template = (cfg['nuisance_corrections', '2-nuisance_regression',
+                             'space'] == 'template') and (not generate_only)
     if nuisance_template:
         pipeline_blocks += [nuisance_regression_template]
         # pipeline_blocks += [(nuisance_regression_template,

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -22,11 +22,11 @@ from itertools import chain, permutations
 import numpy as np
 from pathvalidate import sanitize_filename
 from voluptuous import All, ALLOW_EXTRA, Any, BooleanInvalid, Capitalize, \
-                       Coerce, ExclusiveInvalid, In, Length, LengthInvalid, \
-                       Lower, Match, Maybe, Optional, Range, Required, \
-                       Schema, Title
+                       Coerce, CoerceInvalid, ExclusiveInvalid, In, Length, \
+                       LengthInvalid, Lower, Match, Maybe, MultipleInvalid, \
+                       Optional, Range, Required, Schema, Title
 from CPAC import docs_prefix
-from CPAC.utils.datatypes import ListFromItem
+from CPAC.utils.datatypes import ItemFromList, ListFromItem
 from CPAC.utils.utils import YAML_BOOLS
 
 # 1 or more digits, optional decimal, 'e', optional '-', 1 or more digits
@@ -134,6 +134,8 @@ valid_options = {
     },
     'target_space': ['Native', 'Template']
 }
+valid_options['space'] = list({option.lower() for option in
+                               valid_options['target_space']})
 mutex = {  # mutually exclusive booleans
     'FSL-BET': {
         # exactly zero or one of each of the following can be True for FSL-BET
@@ -886,8 +888,8 @@ latest_schema = Schema({
         },
         '2-nuisance_regression': {
             'run': forkable,
-            'space': All(Coerce(ListFromItem),
-                         [All(Lower, In({'native', 'template'}))]),
+            'space': All(Coerce(ItemFromList),
+                         Lower, In({'native', 'template'})),
             'create_regressors': bool1_1,
             'ingress_regressors': {
                 'run': bool1_1,
@@ -1096,7 +1098,17 @@ def schema(config_dict):
     dict
     '''
     from CPAC.utils.utils import _changes_1_8_0_to_1_8_1
-    partially_validated = latest_schema(_changes_1_8_0_to_1_8_1(config_dict))
+    try:
+        partially_validated = latest_schema(
+            _changes_1_8_0_to_1_8_1(config_dict))
+    except MultipleInvalid as multiple_invalid:
+        if (multiple_invalid.path == ['nuisance_corrections',
+                                      '2-nuisance_regression', 'space'] and
+                isinstance(multiple_invalid.errors[0], CoerceInvalid)):
+            raise CoerceInvalid(
+                'Nusiance regression space is not forkable. Please choose '
+                f'only one of {valid_options["space"]}',
+                path=multiple_invalid.path) from multiple_invalid
     try:
         if (partially_validated['registration_workflows'][
             'functional_registration'
@@ -1110,7 +1122,7 @@ def schema(config_dict):
             if True in partially_validated['nuisance_corrections'][
                 '2-nuisance_regression']['run'] and partially_validated[
                 'nuisance_corrections'
-            ]['2-nuisance_regression']['space'] != ['template']:
+            ]['2-nuisance_regression']['space'] != 'template':
                 raise ExclusiveInvalid(
                     '``single_step_resampling_from_stc`` requires '
                     'template-space nuisance regression. Either set '

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1109,6 +1109,7 @@ def schema(config_dict):
                 'Nusiance regression space is not forkable. Please choose '
                 f'only one of {valid_options["space"]}',
                 path=multiple_invalid.path) from multiple_invalid
+        raise multiple_invalid
     try:
         if (partially_validated['registration_workflows'][
             'functional_registration'

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -1267,13 +1267,12 @@ nuisance_corrections:
         # Erode binarized gray matter mask in millimeters
         gm_erosion_mm:
 
-    # this is a fork point
+    # this is not a fork point
     # Run nuisance regression in native or template space
-    #   - If set to [native, template], the number of outputs will be double what it would be if only one space were chosen. Nuisance regression will only be run once per fork.
     #   - If set to template, will use the brain mask configured in
     #     ``functional_preproc: func_masking: FSL_AFNI: brain_mask``
-    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must only be set to template
-    space: [native]
+    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must be set to template
+    space: native
     ingress_regressors:
       run: Off
       Regressors:

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -1367,13 +1367,12 @@ nuisance_corrections:
     #   run: [On, Off] - this will run both and fork the pipeline
     run: [On]
 
-    # this is a fork point
+    # this is not a fork point
     # Run nuisance regression in native or template space
-    #   - If set to [native, template], the number of outputs will be double what it would be if only one space were chosen. Nuisance regression will only be run once per fork.
     #   - If set to template, will use the brain mask configured in
     #     ``functional_preproc: func_masking: FSL_AFNI: brain_mask``
-    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must only be set to template
-    space: [native]
+    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must be set to template
+    space: native
 
     # switch to Off if nuisance regression is off and you don't want to write out the regressors
     create_regressors: On

--- a/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
@@ -113,13 +113,12 @@ nuisance_corrections:
         # If using erosion, using both proportion and millimeters is not recommended.
         gm_erosion_prop: 0.6
 
-    # this is a fork point
+    # this is not a fork point
     # Run nuisance regression in native or template space
-    #   - If set to [native, template], the number of outputs will be double what it would be if only one space were chosen. Nuisance regression will only be run once per fork.
     #   - If set to template, will use the brain mask configured in
     #     ``functional_preproc: func_masking: FSL_AFNI: brain_mask``
-    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must only be set to template
-    space: [template]
+    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must be set to template
+    space: template
     ingress_regressors:
       run: On
       Regressors:

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -476,13 +476,12 @@ nuisance_corrections:
         # If using erosion, using both proportion and millimeters is not recommended.
         gm_erosion_prop: 0.6
 
-    # this is a fork point
+    # this is not a fork point
     # Run nuisance regression in native or template space
-    #   - If set to [native, template], the number of outputs will be double what it would be if only one space were chosen. Nuisance regression will only be run once per fork.
     #   - If set to template, will use the brain mask configured in
     #     ``functional_preproc: func_masking: FSL_AFNI: brain_mask``
-    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must only be set to template
-    space: [template]
+    #   - If ``registration_workflows: functional_registration: func_registration_to_template: apply_trasnform: using: single_step_resampling_from_stc``, this must be set to template
+    space: template
 
     # Standard Lateral Ventricles Binary Mask
     # used in CSF mask refinement for CSF signal-related regressions

--- a/CPAC/utils/datatypes.py
+++ b/CPAC/utils/datatypes.py
@@ -1,4 +1,32 @@
 """Custom datatypes for C-PAC"""
+class ItemFromList:  # pylint: disable=too-few-public-methods
+    """Coerce single-item lists into just the only item in the list.
+    Returns item if item is not a list, set, or tuple.
+    Raises CoerceInvalid if impossible.
+
+    Examples
+    --------
+    >>> ItemFromList(['seagull'])
+    'seagull'
+    >>> ItemFromList(['two', 'seagulls'])
+    Traceback (most recent call last):
+        ...
+    voluptuous.error.CoerceInvalid: Cannot coerce list of length 2 to item
+    >>> ItemFromList('string')
+    'string'
+    """
+    def __new__(cls, list_of_one, msg=None):
+        """Initialize item from list"""
+        from voluptuous import CoerceInvalid, Length, LengthInvalid
+        if not isinstance(list_of_one, (list, set, tuple)):
+            return list_of_one
+        try:
+            Length(max=1)(list_of_one)
+        except LengthInvalid as length_invalid:
+            raise CoerceInvalid(
+                f'Cannot coerce list of length {len(list_of_one)} to item'
+                if msg is None else msg) from length_invalid
+        return list_of_one[0]
 
 
 class ListFromItem(list):


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2018 by @shnizzedy & [@Shinwon Park](https://cmi-cnl.slack.com/team/U05CG6L2RB3)

## Description
<!-- Concisely describe what the pull request does. -->
Makes nuisance regression space non-forkable.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
At schema validation, ensures only one space is chosen.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
- Ran `test_config` with each of
   - ```YAML
     space: ['native', 'template']
     ```
   - ```YAML
     space: ['native']
     ```
   - ```YAML
     space: ['template']
     ```
  and got expected results (validation error, success, success, respectively)
- https://github.com/FCP-INDI/C-PAC/blob/3eae380c875d587e38359dbbb75c719e91ffdc70/CPAC/utils/datatypes.py#L9-L16

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![`CoerceInvalid: Nusiance regression space is not forkable. Please choose only one of ['template', 'native'] @ data['nuisance_corrections']['2-nuisance_regression']['space']`](https://github.com/FCP-INDI/C-PAC/assets/5974438/7c6b9eb6-7a37-41dd-91ce-d1b6467ad24d)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
