### PR TITLE
🐛 Install `torch` dynamically in a read-only container

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -800,16 +800,28 @@ CPAC run error:
                 # Remove working directory when done
                 if c.pipeline_setup['working_directory'][
                     'remove_working_dir']:
-                    try:
-                        if os.path.exists(working_dir):
-                            logger.info("Removing working dir: %s",
-                                        working_dir)
-                            shutil.rmtree(working_dir)
-                    except (FileNotFoundError, PermissionError):
-                        logger.warning(
-                            'Could not remove working directory %s',
-                            working_dir
-                        )
+                    remove_workdir(working_dir)
+                # Remove just .local from working directory
+                else:
+                    remove_workdir(os.path.join(os.environ["CPAC_WORKDIR"],
+                                                '.local'))
+
+
+def remove_workdir(wdpath: str) -> None:
+    """Remove a given working directory if possible, warn if impossible
+
+    Parameters
+    ----------
+    wdpath : str
+        path to working directory to remove
+    """
+    try:
+        if os.path.exists(wdpath):
+            logger.info("Removing working dir: %s", wdpath)
+            shutil.rmtree(wdpath)
+    except (FileNotFoundError, PermissionError):
+        logger.warning(
+            'Could not remove working directory %s', wdpath)
 
 
 def initialize_nipype_wf(cfg, sub_data_dct, name=""):

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -1182,6 +1182,23 @@ def schema(config_dict):
                 " Try turning one option off.\n ")
     except KeyError:
         pass
+    try:
+        if 'unet' in [using.lower() for using in
+                      partially_validated['anatomical_preproc'][
+                          'brain_extraction']['using']]:
+            try:
+                from importlib import import_module
+                import_module('CPAC.unet')
+            except (ImportError, ModuleNotFoundError, OSError) as error:
+                import site
+                raise OSError(
+                    'U-Net brain extraction requires torch to be installed, '
+                    'but the installation path in this container is '
+                    'read-only. Please bind a local writable path to '
+                    f'"{site.USER_BASE}" in the container to use U-Net.'
+                ) from error
+    except KeyError:
+        pass
     return partially_validated
 
 

--- a/CPAC/unet/_torch.py
+++ b/CPAC/unet/_torch.py
@@ -56,6 +56,7 @@ def _custom_pip_install(env_var: Optional[str] = None) -> None:
 try:
     import torch  # just import if it's available
 except (ImportError, ModuleNotFoundError):
+    torch = NotImplemented
     try:
         _custom_pip_install()  # pip install in default user directory
     except (CalledProcessError, FileNotFoundError, ImportError,
@@ -65,4 +66,5 @@ except (ImportError, ModuleNotFoundError):
         except (CalledProcessError, FileNotFoundError, ImportError,
                 ModuleNotFoundError, OSError):
             _custom_pip_install('PWD')  # pip install in $PWD
-__all__ = ['torch']
+if torch is not NotImplemented:
+    __all__ = ['torch']

--- a/CPAC/unet/_torch.py
+++ b/CPAC/unet/_torch.py
@@ -30,12 +30,18 @@ except (ImportError, ModuleNotFoundError):
         # try to install under the working directory if in a
         # read-only container
         import os
-        os.environ['PYTHONUSERBASE'] = os.path.join(
+        import site
+        import sys
+        if 'CPAC_WORKDIR' not in os.environ:
+            os.environ['CPAC_WORKDIR'] = os.environ['PWD']
+        site.USER_BASE = os.environ['PYTHONUSERBASE'] = os.path.join(
             os.environ['CPAC_WORKDIR'], '.local')
-        os.environ['PATH'] = ':'.join([os.environ['PATH'],
-                                       f'{os.environ["PYTHONUSERBASE"]}/bin'])
+        PY_VERSION = '.'.join(str(getattr(sys.version_info, attr)) for
+                              attr in ['major', 'minor'])
+        PYTHONPATH = f'{site.USER_BASE}/lib/python{PY_VERSION}/site-packages'
+        sys.path.append(PYTHONPATH)
         os.environ['PYTHONPATH'] = ':'.join([os.environ['PYTHONPATH'],
-            f'{os.environ["PYTHONUSERBASE"]}/lib/python3.10/site-packages'])
+                                             PYTHONPATH]).replace('::', ':')
         log_subprocess(['pip', 'install', '--user', *UNET_REQUIREMENTS])
     invalidate_caches()
     import torch

--- a/CPAC/unet/_torch.py
+++ b/CPAC/unet/_torch.py
@@ -20,10 +20,23 @@ try:
     import torch
 except (ImportError, ModuleNotFoundError):
     from importlib import invalidate_caches
+    from subprocess import CalledProcessError
     from CPAC.info import UNET_REQUIREMENTS
     from CPAC.utils.monitoring.custom_logging import log_subprocess
     invalidate_caches()
-    log_subprocess(['pip', 'install', '--user', *UNET_REQUIREMENTS])
+    try:
+        log_subprocess(['pip', 'install', '--user', *UNET_REQUIREMENTS])
+    except (CalledProcessError, OSError):
+        # try to install under the working directory if in a
+        # read-only container
+        import os
+        os.environ['PYTHONUSERBASE'] = os.path.join(
+            os.environ['CPAC_WORKDIR'], '.local')
+        os.environ['PATH'] = ':'.join([os.environ['PATH'],
+                                       f'{os.environ["PYTHONUSERBASE"]}/bin'])
+        os.environ['PYTHONPATH'] = ':'.join([os.environ['PYTHONPATH'],
+            f'{os.environ["PYTHONUSERBASE"]}/lib/python3.10/site-packages'])
+        log_subprocess(['pip', 'install', '--user', *UNET_REQUIREMENTS])
     invalidate_caches()
     import torch
 

--- a/CPAC/unet/tests/test_torch.py
+++ b/CPAC/unet/tests/test_torch.py
@@ -33,7 +33,7 @@ def test_import_torch(monkeypatch, readonly, tmp_path, workdir):
         os.chmod(tmp_path, 0o444)
         monkeypatch.setenv('PYTHONUSERBASE', tmp_path)
     if workdir:
-        os.environ['CPAC_WORKDIR'] = tmp_path
+        os.environ['CPAC_WORKDIR'] = str(tmp_path)
     else:
         if 'CPAC_WORKDIR' in os.environ:
             del os.environ['CPAC_WORKDIR']

--- a/CPAC/unet/tests/test_torch.py
+++ b/CPAC/unet/tests/test_torch.py
@@ -15,13 +15,23 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Test torch installation"""
-def test_import_torch():
+import pytest
+
+
+@pytest.mark.parametrize('readonly', [False, True])
+def test_import_torch(monkeypatch, readonly, tmp_path):
     """
     Test that ``torch`` successfully imports after being installed dynamically.
 
     This test is necessarily slow because it involves dynamically
     installing ``torch``.
     """
+    if readonly:
+        # set PYTHONUSERBASE to a readonly directory
+        import os
+        os.chmod(tmp_path, 0o444)
+        monkeypatch.setenv('PYTHONUSERBASE', tmp_path)
+
     # pylint: disable=import-error,unused-import,wrong-import-order
     from CPAC import unet
     import torch

--- a/CPAC/unet/tests/test_torch.py
+++ b/CPAC/unet/tests/test_torch.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Test torch installation"""
+import os
 import pytest
 
 
@@ -29,7 +30,6 @@ def test_import_torch(monkeypatch, readonly, tmp_path, workdir):
     """
     if readonly:
         # set PYTHONUSERBASE to a readonly directory
-        import os
         os.chmod(tmp_path, 0o444)
         monkeypatch.setenv('PYTHONUSERBASE', tmp_path)
     if workdir:

--- a/CPAC/unet/tests/test_torch.py
+++ b/CPAC/unet/tests/test_torch.py
@@ -19,7 +19,8 @@ import pytest
 
 
 @pytest.mark.parametrize('readonly', [False, True])
-def test_import_torch(monkeypatch, readonly, tmp_path):
+@pytest.mark.parametrize('workdir', [False, True])
+def test_import_torch(monkeypatch, readonly, tmp_path, workdir):
     """
     Test that ``torch`` successfully imports after being installed dynamically.
 
@@ -31,6 +32,11 @@ def test_import_torch(monkeypatch, readonly, tmp_path):
         import os
         os.chmod(tmp_path, 0o444)
         monkeypatch.setenv('PYTHONUSERBASE', tmp_path)
+    if workdir:
+        os.environ['CPAC_WORKDIR'] = tmp_path
+    else:
+        if 'CPAC_WORKDIR' in os.environ:
+            del os.environ['CPAC_WORKDIR']
 
     # pylint: disable=import-error,unused-import,wrong-import-order
     from CPAC import unet

--- a/CPAC/utils/configuration/configuration.py
+++ b/CPAC/utils/configuration/configuration.py
@@ -156,6 +156,10 @@ class Configuration:
 
         self._update_attr()
 
+        # set working directory as an environment variable
+        os.environ['CPAC_WORKDIR'] = self[
+            'pipeline_setup', 'working_directory', 'path']
+
     def __str__(self):
         return ('C-PAC Configuration '
                 f"('{self['pipeline_setup', 'pipeline_name']}')")


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes 
```Python
Installing collected packages: nvidia-cuda-runtime-cu11, nvidia-cuda-nvrtc-cu11, nvidia-cublas-cu11, nvidia-cudnn-cu11, torch, torchvision
ERROR: Could not install packages due to an OSError: [Errno 30] Read-only file system: '/home/c-pac_user/.local'
```

by @e-kenneally [on Slack](https://cmi-cnl.slack.com/archives/C065W7YJ4V9/p1700146457157509)

## Description
<!-- Concisely describe what the pull request does. -->

- Nothing different if the container is writable
```mermaid
graph TD;
  P[set '$CPAC_WORKDIR' when loading pipeline config] --> A
  A{container writable?} -->|yes| B[nothing different] --> Y
  A -->|no| C[try to install torch in '$CPAC_WORKDIR/.local'] --> D{success} -->|yes| Y[torch installed]
  D -->|no| E[set 'CPAC_WORKDIR = $PWD'] --> F[install torch in '$CPAC_WORKDIR/.local'] --> Y
  Y --> R[run to end of workflow or graceful crash] --> G{ '$CPAC_WORKDIR/.local' exists?} -->|yes| H[rm -r '$CPAC_WORKDIR/.local']
```

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Updated the torch installation tests with some parameterization to simulate readonly conditions https://github.com/FCP-INDI/C-PAC/blob/7565c0fd8c965c0a2ecd353cb50598b76f7e20eb/CPAC/unet/tests/test_torch.py#L22-L43

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
