### PR TITLE
Fix nuisance regression file naming issue

### DIFF
--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -265,7 +265,7 @@ class ResourcePool:
                              "Try turning on create_regressors or "
                              "ingress_regressors.")
         _nr = cfg['nuisance_corrections', '2-nuisance_regression']
-        if not hasattr(self, 'regressors'):
+        if not hasattr(self, 'timeseries'):
             self.regressors = {reg["Name"]: reg for reg in _nr['Regressors']}
         if self.check_rpool('parsed_regressors'):  # ingressed regressor
             # name regressor workflow without regressor_prov

--- a/CPAC/pipeline/utils.py
+++ b/CPAC/pipeline/utils.py
@@ -16,6 +16,7 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """C-PAC pipeline engine utilities"""
 from typing import Union
+from itertools import chain
 from CPAC.func_preproc.func_motion import motion_estimate_filter
 from CPAC.utils.bids_utils import insert_entity
 
@@ -65,15 +66,13 @@ def name_fork(resource_idx, cfg, json_info, out_dct):
                                                      'filt', filt_value)
     if cfg.switch_is_on(['nuisance_corrections',
                          '2-nuisance_regression', 'run']):
-        reg_value = None
-        if ('regressors' in json_info.get('CpacVariant', {})
-                and json_info['CpacVariant']['regressors']):
-            reg_value = json_info['CpacVariant'][
-                'regressors'
-            ][0].replace('nuisance_regressors_generation_', '')
-        elif cfg.switch_is_off(['nuisance_corrections',
-                                '2-nuisance_regression', 'run']):
-            reg_value = 'Off'
+        variants = [variant.split('_')[-1] for variant in
+                    chain.from_iterable(json_info['CpacVariant'].values()) if
+                    variant.startswith('nuisance_regressors_generation')]
+        if cfg.switch_is_off(['nuisance_corrections', '2-nuisance_regression',
+                              'run']):
+            variants.append['Off']
+        reg_value = variants[0] if variants else None
         resource_idx, out_dct = _update_resource_idx(resource_idx, out_dct,
                                                      'reg', reg_value)
     return resource_idx, out_dct


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Co-Authored by: jon.clucas@childmind.org 

## Description
<img width="1219" alt="Screenshot 2023-12-06 at 4 13 06 PM" src="https://github.com/FCP-INDI/C-PAC/assets/113037677/3326a5c4-4318-4ca6-aa02-8dd66714fc9f">

The name of the regressor strategy used wasn't showing up in the output directory filenames because the method used to grab the regressor strategy name wasn't consistently effective. @shnizzedy proposed this new method to grab the last segment of the value under `CpacVariant` in the JSON sidecar. 

<img width="523" alt="Screenshot 2023-12-06 at 4 08 03 PM" src="https://github.com/FCP-INDI/C-PAC/assets/113037677/324645ec-0447-4141-975d-c9d769bc98cf">

 After the naming was fixed, the C-PAC engine was still registering the different nuisance regressor strategies as forks in the pipeline and adding numbers to the filenames. The problem stemmed from when we re-named 'regressors' to 'desc-confounds_timeseries' but forgot to update the wording in this section.

## Tests
I ran the full regression testing suite on these changes and everything went smoothly.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
