### PR TITLE
Option-forked nodeblock missing resource name reporting

### DIFF
--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1130,10 +1130,20 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
                 f"after node block '{previous_nb.get_name()}':"
             ) if previous_nb else 'at beginning:'
             # Alert user to block that raises error
-            e.args = (
-                'When trying to connect node block '
-                f"'{NodeBlock(block).get_name()}' "
-                f"to workflow '{wf}' {previous_nb_str} {e.args[0]}",)
+            if isinstance(block, list):
+                node_block_names = str([NodeBlock(b).get_name() for b in block])
+                e.args = (
+                    f'When trying to {e.args} connect one of the node blocks '
+                    f"'{node_block_names}' "
+                    f"to workflow '{wf}' {previous_nb_str} {e.args[0]}",
+                )
+            else:
+                node_block_names = NodeBlock(block).get_name()
+                e.args = (
+                    f'When trying to {e.args} connect node block '
+                    f"'{node_block_names}' "
+                    f"to workflow '{wf}' {previous_nb_str} {e.args[0]}",
+                )
             if cfg.pipeline_setup['Debugging']['verbose']:
                 verbose_logger = getLogger('engine')
                 verbose_logger.debug(e.args[0])

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1133,14 +1133,14 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
             if isinstance(block, list):
                 node_block_names = str([NodeBlock(b).get_name() for b in block])
                 e.args = (
-                    f'When trying to {e.args} connect one of the node blocks '
+                    f'When trying to connect one of the node blocks '
                     f"'{node_block_names}' "
                     f"to workflow '{wf}' {previous_nb_str} {e.args[0]}",
                 )
             else:
                 node_block_names = NodeBlock(block).get_name()
                 e.args = (
-                    f'When trying to {e.args} connect node block '
+                    f'When trying to connect node block '
                     f"'{node_block_names}' "
                     f"to workflow '{wf}' {previous_nb_str} {e.args[0]}",
                 )

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1134,7 +1134,7 @@ def connect_pipeline(wf, cfg, rpool, pipeline_blocks):
                 node_block_names = str([NodeBlock(b).get_name() for b in block])
                 e.args = (
                     f'When trying to connect one of the node blocks '
-                    f"'{node_block_names}' "
+                    f"{node_block_names} "
                     f"to workflow '{wf}' {previous_nb_str} {e.args[0]}",
                 )
             else:


### PR DESCRIPTION
## Description & Technical details

<!-- Concisely describe what the pull request does. -->

Option-forked nodeblock lists only report the name of the last nodeblock in the list when a missing resource is reported.

E.g.:

Users will see

```sh
LookupError: When trying to connect one of the node blocks 'bold_mask_ccs' to workflow 'cpac_sub-01_ses-1' after node block 'motion_estimate_filter': 

[!] C-PAC says: None of the listed resources are in the resource pool:

['space-template_desc-T1w_mask']
```

while the nodeblock not necessarily has anything to do with the missing resource.

Now they will see:

```sh
LookupError: When trying to connect one of the node blocks ['bold_mask_afni', 'bold_mask_fsl', 'bold_mask_fsl_afni', 'bold_mask_anatomical_refined', 'bold_mask_anatomical_based', 'bold_mask_anatomical_resampled', 'bold_mask_ccs'] to workflow 'cpac_sub-01_ses-1' after node block 'motion_estimate_filter': 

[!] C-PAC says: None of the listed resources are in the resource pool:

['space-template_desc-T1w_mask']
```

Which is also not ideal, as it also does not point to the specific nodeblock that causes the problem, but at least it will contain it.

To properly point the issue-causing one out bigger engine modifications are necessary (such as appending nodeblock information to the `LookupError` as it happens).

Generally the mechanism by which some NodeBlock instances can be lists of nodeblocks while others are single ones might be worth to restructure a bit as in [this loop](https://github.com/FCP-INDI/C-PAC/blob/456052c041dc18d0cce0cbef6c296cd7c47563f6/CPAC/pipeline/engine.py#L1251) every time a local field like `name` is set it will end up being the name of the last nodeblock in that list which could cause similar unexpected behavior throughout the codebase. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
