### PR TITLE
Prevent Nipype from emitting .proc-* files to user working dir Fix #1955 

### DIFF
--- a/CPAC/pipeline/__init__.py
+++ b/CPAC/pipeline/__init__.py
@@ -19,6 +19,10 @@ License along with C-PAC. If not, see <https://www.gnu.org/licenses/>."""
 import os
 import pkg_resources as p
 
+from CPAC.pipeline.nipype_pipeline_engine.monkeypatch import patch_base_interface
+
+patch_base_interface()  # Monkeypatch Nipypes BaseInterface class
+
 ALL_PIPELINE_CONFIGS = os.listdir(
     p.resource_filename("CPAC", os.path.join("resources", "configs")))
 ALL_PIPELINE_CONFIGS = [x.split('_')[2].replace('.yml', '') for
@@ -28,6 +32,5 @@ AVAILABLE_PIPELINE_CONFIGS = [preconfig for preconfig in ALL_PIPELINE_CONFIGS
                               if preconfig not in
                               ['benchmark-ANTS', 'monkey-ABCD'] and
                               not preconfig.startswith('regtest-')]
-
 
 __all__ = ['ALL_PIPELINE_CONFIGS', 'AVAILABLE_PIPELINE_CONFIGS']

--- a/CPAC/pipeline/nipype_pipeline_engine/monkeypatch.py
+++ b/CPAC/pipeline/nipype_pipeline_engine/monkeypatch.py
@@ -1,0 +1,65 @@
+def patch_base_interface():
+    """
+    Monkey-patch nipype.interfaces.base.core.BaseInterface.run().
+
+    This is a temporary workaround to prevent nipype from emitting
+    .proc-* files in the current working directory.
+    """
+    from nipype.interfaces.base.core import (
+        BaseInterface,
+        config,
+        indirectory,
+        InterfaceResult,
+        os,
+        RuntimeContext,
+        str2bool,
+        write_provenance,
+    )
+
+    class PatchedBaseInterface(BaseInterface):
+        def run(self, cwd=None, ignore_exception=None, **inputs):
+            with indirectory(cwd or os.getcwd()):  # This is the only line that changed
+                rtc = RuntimeContext(
+                    resource_monitor=config.resource_monitor and self.resource_monitor,
+                    ignore_exception=ignore_exception
+                    if ignore_exception is not None
+                    else self.ignore_exception,
+                )
+
+            with indirectory(cwd or os.getcwd()):
+                self.inputs.trait_set(**inputs)
+            self._check_mandatory_inputs()
+            self._check_version_requirements(self.inputs)
+
+            with rtc(self, cwd=cwd, redirect_x=self._redirect_x) as runtime:
+                # Grab inputs now, as they should not change during execution
+                inputs = self.inputs.get_traitsfree()
+                outputs = None
+                # Run interface
+                runtime = self._pre_run_hook(runtime)
+                runtime = self._run_interface(runtime)
+                runtime = self._post_run_hook(runtime)
+                # Collect outputs
+                outputs = self.aggregate_outputs(runtime)
+
+            results = InterfaceResult(
+                self.__class__,
+                rtc.runtime,
+                inputs=inputs,
+                outputs=outputs,
+                provenance=None,
+            )
+
+            # Add provenance (if required)
+            if str2bool(config.get("execution", "write_provenance", "false")):
+                # Provenance will only throw a warning if something went wrong
+                results.provenance = write_provenance(results)
+
+            self._duecredit_cite()
+
+            return results
+
+    # Apply patch
+    import nipype.interfaces.base.core as base_core
+    base_core.BaseInterface.run = PatchedBaseInterface.run
+


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1955 by @amygutierrez

## Description
<!-- Concisely describe what the pull request does. -->

- Since Nipype version ~1.8.x Nipype emits many (!) `.proc-*` to the _user_ working directory (wherever the user started nipype from, instead of _nipype_ working directory node subdirectories)

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

@shnizzedy 's exhaustive internal writedown 🕵️
> C-PAC and fMRIPrep both hit the issue upgrading from nipype 1.5.x to 1.8.x; I think [this](https://github.com/nipy/nipype/blob/071523a5069b52689ed27f995f1e2bea5b6e0402/nipype/interfaces/base/core.py#L370) chdir that used to be before [initializing the ResourceMonitor](https://github.com/nipy/nipype/blob/071523a5069b52689ed27f995f1e2bea5b6e0402/nipype/interfaces/base/core.py#L410) led to [this relative path](https://github.com/nipy/nipype/blob/3b505327f412a2c4215d0763f932d0eac6e3a11b/nipype/utils/profiler.py#L59) being inside the relevant subdirectory of the working directory, but now [it's initialized](https://github.com/nipy/nipype/blob/3b505327f412a2c4215d0763f932d0eac6e3a11b/nipype/interfaces/base/core.py#L379-L384) without changing directories first

- The relevant nipype `BaseInterface` is now monkey patched to use the individual node workdir to emit `.proc-*` files to
- This means they will automatically be cleaned if the working dir is not retained (no `--save-work-dir`)

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
