### PR TITLE
fslrobustfov with padding inorder to remove neck regions in the fsl-bet skull stripped image

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -33,7 +33,8 @@ from CPAC.anat_preproc.utils import create_3dskullstrip_arg_string, \
     wb_command, \
     fslmaths_command, \
     VolumeRemoveIslands, \
-    normalize_wmparc
+    normalize_wmparc, \
+    pad, get_shape
 from CPAC.utils.interfaces.fsl import Merge as fslMerge
 
 
@@ -647,16 +648,34 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
             'FSL-BET']['vertical_gradient'],
     )
     
+    anat_nifti_shape= pe.Node(util.Function(input_names=['nifti_image'],
+                                            output_names=['shape'],
+                                            function=get_shape),
+                            name=f'anat_nifti_shape_{pipe_num}'
+                            )
+
     anat_robustfov = pe.Node(
         interface=fsl.RobustFOV(), name=f'anat_RobustFOV_{pipe_num}')
+    #anat_robustfov.brainsize = '%d'
     anat_robustfov.inputs.output_type = 'NIFTI_GZ'
+
+    pad_mask = pe.Node(util.Function(input_names=['cropped_image', 'target_shape'],
+                                    output_names=['padded_mask'],
+                                    function=pad),
+                        name=f'pad_mask_{pipe_num}'
+                        )
 
     if strat_pool.check_rpool('desc-preproc_T1w'): 
         node, out = strat_pool.get_data('desc-preproc_T1w')
         
+        wf.connect(anat_nifti_shape, 'dim3', anat_robustfov, 'brainsize')
+        
         if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov']:
            wf.connect(node, out, anat_robustfov, 'in_file')
-           wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
+           wf.connect(node, out, anat_nifti_shape, 'nifti_image')
+           wf.connect(anat_robustfov, 'out_roi', pad_mask, 'cropped_image')
+           wf.connect(anat_nifti_shape,'shape', pad_mask, 'target_shape')
+           wf.connect(pad_mask, 'padded_image', anat_skullstrip,'in_file')
         else :
            wf.connect(node, out, anat_skullstrip, 'in_file')
 
@@ -664,10 +683,13 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
         node, out = strat_pool.get_data('desc-preproc_T2w')
         if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov']:
            wf.connect(node, out, anat_robustfov, 'in_file')
-           wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
+           wf.connect(node, out, anat_nifti_shape, 'nifti_image')
+           wf.connect(anat_robustfov, 'out_roi', pad_mask, 'cropped_image')
+           wf.connect(anat_nifti_shape,'shape', pad_mask, 'target_shape')
+           wf.connect(pad_mask, 'padded_image', anat_skullstrip,'in_file')
         else :
            wf.connect(node, out, anat_skullstrip, 'in_file')
-
+    
     wf.connect([
         (inputnode_bet, anat_skullstrip, [
             ('frac', 'frac'),

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -650,7 +650,7 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
             'FSL-BET']['vertical_gradient'],
     )
 
-  if strat_pool.check_rpool('desc-preproc_T1w'): 
+    if strat_pool.check_rpool('desc-preproc_T1w'): 
         node, out = strat_pool.get_data('desc-preproc_T1w')
         wf.connect(node, out, anat_robustfov, 'in_file')
         wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -608,6 +608,10 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
                                        'vertical_gradient']),
         name=f'BET_options_{pipe_num}')
 
+    anat_robustfov = pe.Node(
+        interface=fsl.RobustFOV(), name=f'anat_RobustFOV_{pipe_num}')
+    anat_robustfov.inputs.output_type = 'NIFTI_GZ'
+    
     anat_skullstrip = pe.Node(
         interface=fsl.BET(), name=f'anat_BET_skullstrip_{pipe_num}')
     anat_skullstrip.inputs.output_type = 'NIFTI_GZ'
@@ -646,13 +650,15 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
             'FSL-BET']['vertical_gradient'],
     )
 
-    if strat_pool.check_rpool('desc-preproc_T1w'): 
+  if strat_pool.check_rpool('desc-preproc_T1w'): 
         node, out = strat_pool.get_data('desc-preproc_T1w')
-        wf.connect(node, out, anat_skullstrip, 'in_file')
+        wf.connect(node, out, anat_robustfov, 'in_file')
+        wf.connect(anat_robustfov, 'out_file', anat_skullstrip,'in_file')
 
     elif strat_pool.check_rpool('desc-preproc_T2w'):
         node, out = strat_pool.get_data('desc-preproc_T2w')
-        wf.connect(node, out, anat_skullstrip, 'in_file')
+        wf.connect(node, out, anat_robustfov, 'in_file')
+        wf.connect(anat_robustfov, 'out_file', anat_skullstrip,'in_file')
 
     wf.connect([
         (inputnode_bet, anat_skullstrip, [

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -652,13 +652,19 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     if strat_pool.check_rpool('desc-preproc_T1w'): 
         node, out = strat_pool.get_data('desc-preproc_T1w')
-        wf.connect(node, out, anat_robustfov, 'in_file')
-        wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
+        if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov'] == 'True':
+           wf.connect(node, out, anat_robustfov, 'in_file')
+           wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
+        else :
+           wf.connect(node, out, anat_skullstrip, 'in_file')
 
     elif strat_pool.check_rpool('desc-preproc_T2w'):
         node, out = strat_pool.get_data('desc-preproc_T2w')
-        wf.connect(node, out, anat_robustfov, 'in_file')
-        wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
+        if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov'] == 'True':
+           wf.connect(node, out, anat_robustfov, 'in_file')
+           wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
+        else :
+           wf.connect(node, out, anat_skullstrip, 'in_file')
 
     wf.connect([
         (inputnode_bet, anat_skullstrip, [

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -653,7 +653,7 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     anat_robustfov.inputs.output_type = 'NIFTI_GZ'
 
-    anat_pad_mask = pe.Node(util.Function(input_names=['cropped_image_path', 'target_image_path'],
+    anat_pad_RobustFOV_cropped = pe.Node(util.Function(input_names=['cropped_image_path', 'target_image_path'],
                                     output_names=['padded_image_path'],
                                     function=pad),
                         name=f'anat_pad_mask_{pipe_num}'
@@ -663,9 +663,9 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
         node, out = strat_pool.get_data('desc-preproc_T1w')
         if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov']:
            wf.connect(node, out, anat_robustfov, 'in_file')
-           wf.connect(node, out, anat_pad_mask, 'target_image_path')
-           wf.connect(anat_robustfov, 'out_roi', anat_pad_mask, 'cropped_image_path')
-           wf.connect(anat_pad_mask, 'padded_image_path', anat_skullstrip,'in_file')
+           wf.connect(node, out, anat_pad_RobustFOV_cropped, 'target_image_path')
+           wf.connect(anat_robustfov, 'out_roi', anat_pad_RobustFOV_cropped, 'cropped_image_path')
+           wf.connect(anat_pad_RobustFOV_cropped, 'padded_image_path', anat_skullstrip,'in_file')
         else :
            wf.connect(node, out, anat_skullstrip, 'in_file')
 
@@ -673,9 +673,9 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
         node, out = strat_pool.get_data('desc-preproc_T2w')
         if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov']:
            wf.connect(node, out, anat_robustfov, 'in_file')
-           wf.connect(node, out, anat_pad_mask, 'target_image_path')
-           wf.connect(anat_robustfov, 'out_roi', anat_pad_mask, 'cropped_image_path')
-           wf.connect(anat_pad_mask, 'padded_image_path', anat_skullstrip,'in_file')
+           wf.connect(node, out, anat_pad_RobustFOV_cropped, 'target_image_path')
+           wf.connect(anat_robustfov, 'out_roi', anat_pad_RobustFOV_cropped, 'cropped_image_path')
+           wf.connect(anat_pad_RobustFOV_cropped, 'padded_image_path', anat_skullstrip,'in_file')
         else :
            wf.connect(node, out, anat_skullstrip, 'in_file')
     

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -653,12 +653,12 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
   if strat_pool.check_rpool('desc-preproc_T1w'): 
         node, out = strat_pool.get_data('desc-preproc_T1w')
         wf.connect(node, out, anat_robustfov, 'in_file')
-        wf.connect(anat_robustfov, 'out_file', anat_skullstrip,'in_file')
+        wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
 
     elif strat_pool.check_rpool('desc-preproc_T2w'):
         node, out = strat_pool.get_data('desc-preproc_T2w')
         wf.connect(node, out, anat_robustfov, 'in_file')
-        wf.connect(anat_robustfov, 'out_file', anat_skullstrip,'in_file')
+        wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
 
     wf.connect([
         (inputnode_bet, anat_skullstrip, [

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -608,9 +608,6 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
                                        'vertical_gradient']),
         name=f'BET_options_{pipe_num}')
 
-    anat_robustfov = pe.Node(
-        interface=fsl.RobustFOV(), name=f'anat_RobustFOV_{pipe_num}')
-    anat_robustfov.inputs.output_type = 'NIFTI_GZ'
     
     anat_skullstrip = pe.Node(
         interface=fsl.BET(), name=f'anat_BET_skullstrip_{pipe_num}')
@@ -649,10 +646,15 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
         cfg.anatomical_preproc['brain_extraction'][
             'FSL-BET']['vertical_gradient'],
     )
+    
+    anat_robustfov = pe.Node(
+        interface=fsl.RobustFOV(), name=f'anat_RobustFOV_{pipe_num}')
+    anat_robustfov.inputs.output_type = 'NIFTI_GZ'
 
     if strat_pool.check_rpool('desc-preproc_T1w'): 
         node, out = strat_pool.get_data('desc-preproc_T1w')
-        if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov'] == 'True':
+        
+        if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov']:
            wf.connect(node, out, anat_robustfov, 'in_file')
            wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
         else :
@@ -660,7 +662,7 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     elif strat_pool.check_rpool('desc-preproc_T2w'):
         node, out = strat_pool.get_data('desc-preproc_T2w')
-        if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov'] == 'True':
+        if cfg.anatomical_preproc['brain_extraction']['FSL-BET']['Robustfov']:
            wf.connect(node, out, anat_robustfov, 'in_file')
            wf.connect(anat_robustfov, 'out_roi', anat_skullstrip,'in_file')
         else :

--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -3,16 +3,6 @@ import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
 
-def find_sublist(a, b):
-    len_a = len(a)
-    len_b = len(b)
-
-    for f in range(len_b - len_a + 1):
-        b[f:f+len_a]
-        if (b[f:f+len_a] == a).all():
-            return f
-    return None
-
 def pad(cropped_image_path, target_image_path):
     import numpy as np
     from nibabel import load, save, Nifti1Image
@@ -23,13 +13,21 @@ def pad(cropped_image_path, target_image_path):
 
     r =20
     c= 20
-    f = find_sublist(cropped_image[r, c, :], target_image[r, c, :])
+    a = cropped_image[r, c, :]
+    b = target_image[r, c, :]
+    len_a = len(a)
+    len_b = len(b)
+
+    for f in range(len_b - len_a + 1):
+        b[f:f+len_a]
+        if (b[f:f+len_a] == a).all():
+            break
+    print(f)
     
     padded_image_matrix = np.zeros_like(target_image)
-    print(padded_image_matrix.shape)
-    cropped_image = load(cropped_image_path)
     padded_image_matrix[:, :, f:cropped_image.shape[2]+f] = cropped_image
     padded_image_path = path.join(getcwd(),"padded_image_T1w.nii.gz")
+    cropped_image = load(cropped_image_path)
     save(Nifti1Image(padded_image_matrix, affine=cropped_image.affine), padded_image_path)
     return padded_image_path
 

--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -4,28 +4,25 @@ import nipype.interfaces.utility as util
 from CPAC.pipeline import nipype_pipeline_engine as pe
 
 def pad(cropped_image_path, target_image_path):
-    import numpy as np
+    from numpy import asanyarray, zeros_like
     from nibabel import load, save, Nifti1Image
     from os import path, getcwd
 
-    cropped_image = np.asanyarray(load(cropped_image_path).dataobj)
-    target_image = np.asanyarray(load(target_image_path).dataobj)
+    cropped_image = asanyarray(load(cropped_image_path).dataobj)
+    target_image = asanyarray(load(target_image_path).dataobj)
 
-    r =20
-    c= 20
-    a = cropped_image[r, c, :]
-    b = target_image[r, c, :]
-    len_a = len(a)
-    len_b = len(b)
+    # Taking 1 slice to calculate the z dimension shift from top
+    row =target_image.shape[0]//2
+    column= target_image.shape[1]//2
+    a = cropped_image[row, column, :]
+    b = target_image[row, column, :]
 
-    for f in range(len_b - len_a + 1):
-        b[f:f+len_a]
-        if (b[f:f+len_a] == a).all():
+    for z_shift in range(len(b) - len(a) + 1):
+        if (b[z_shift:z_shift+len(a)] == a).all():
             break
-    print(f)
     
-    padded_image_matrix = np.zeros_like(target_image)
-    padded_image_matrix[:, :, f:cropped_image.shape[2]+f] = cropped_image
+    padded_image_matrix = zeros_like(target_image)
+    padded_image_matrix[:, :, z_shift:cropped_image.shape[2]+z_shift] = cropped_image
     padded_image_path = path.join(getcwd(),"padded_image_T1w.nii.gz")
     cropped_image = load(cropped_image_path)
     save(Nifti1Image(padded_image_matrix, affine=cropped_image.affine), padded_image_path)

--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -2,7 +2,16 @@
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from nibabel import load as nib_load, Nifti1Image
+from numpy import zeros
 
+def get_shape(nifti_image):
+    return nib_load(nifti_image).shape
+
+def pad(cropped_image, target_shape):
+    padded_image = zeros(target_shape)
+    padded_image[:, :, :cropped_image.shape[2]] = cropped_image.get_data()
+    return Nifti1Image(padded_image, affine=cropped_image.affine)
 
 def fsl_aff_to_rigid(in_xfm, out_name):
 

--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -2,16 +2,36 @@
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
-from nibabel import load as nib_load, Nifti1Image
-from numpy import zeros
 
-def get_shape(nifti_image):
-    return nib_load(nifti_image).shape
+def find_sublist(a, b):
+    len_a = len(a)
+    len_b = len(b)
 
-def pad(cropped_image, target_shape):
-    padded_image = zeros(target_shape)
-    padded_image[:, :, :cropped_image.shape[2]] = cropped_image.get_data()
-    return Nifti1Image(padded_image, affine=cropped_image.affine)
+    for f in range(len_b - len_a + 1):
+        b[f:f+len_a]
+        if (b[f:f+len_a] == a).all():
+            return f
+    return None
+
+def pad(cropped_image_path, target_image_path):
+    import numpy as np
+    from nibabel import load, save, Nifti1Image
+    from os import path, getcwd
+
+    cropped_image = np.asanyarray(load(cropped_image_path).dataobj)
+    target_image = np.asanyarray(load(target_image_path).dataobj)
+
+    r =20
+    c= 20
+    f = find_sublist(cropped_image[r, c, :], target_image[r, c, :])
+    
+    padded_image_matrix = np.zeros_like(target_image)
+    print(padded_image_matrix.shape)
+    cropped_image = load(cropped_image_path)
+    padded_image_matrix[:, :, f:cropped_image.shape[2]+f] = cropped_image
+    padded_image_path = path.join(getcwd(),"padded_image_T1w.nii.gz")
+    save(Nifti1Image(padded_image_matrix, affine=cropped_image.affine), padded_image_path)
+    return padded_image_path
 
 def fsl_aff_to_rigid(in_xfm, out_name):
 

--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -4,26 +4,45 @@ import nipype.interfaces.utility as util
 from CPAC.pipeline import nipype_pipeline_engine as pe
 
 def pad(cropped_image_path, target_image_path):
-    from numpy import asanyarray, zeros_like
+    """
+    Pad a cropped image to match the dimensions of a target image along the z-axis, 
+    while keeping padded image aligned with target_image.
+
+    Parameters:
+    - cropped_image_path (str): The file path to the cropped image (NIfTI format).
+    - target_image_path (str): The file path to the target image (NIfTI format).
+
+    Returns:
+    - str: The file path to the saved padded image (NIfTI format).
+
+    The function loads cropped and target iamges, calculates the z-dimension shift required for alignment such 
+    that the mask generated from padded image will work correctly on the target image. The result padded image is
+    saved as an NIfTI file in the working directory/node and file path is returned as output.
+
+    Note: The function assumes that the input images are in NIfTI format and have compatible dimensions. The cropped
+    and target image should only differ in z-axis dimension.
+    """
+    from numpy import asanyarray, zeros_like, ndarray
     from nibabel import load, save, Nifti1Image
     from os import path, getcwd
+    from typing import Optional
 
-    cropped_image = asanyarray(load(cropped_image_path).dataobj)
-    target_image = asanyarray(load(target_image_path).dataobj)
+    cropped_image: Optional[ndarray] = asanyarray(load(cropped_image_path).dataobj)
+    target_image: Optional[ndarray] = asanyarray(load(target_image_path).dataobj)
 
     # Taking 1 slice to calculate the z dimension shift from top
-    row =target_image.shape[0]//2
-    column= target_image.shape[1]//2
-    a = cropped_image[row, column, :]
-    b = target_image[row, column, :]
+    center_row:int =target_image.shape[0]//2
+    center_column:int = target_image.shape[1]//2
+    z_slice_cropped_image: Optional[ndarray] = cropped_image[center_row, center_column, :]
+    z_slice_target_image: Optional[ndarray] = target_image[center_row, center_column, :]
 
-    for z_shift in range(len(b) - len(a) + 1):
-        if (b[z_shift:z_shift+len(a)] == a).all():
+    for z_shift in range(len(z_slice_target_image) - len(z_slice_cropped_image) + 1):
+        if (z_slice_target_image[z_shift:z_shift+len(z_slice_cropped_image)] == z_slice_cropped_image).all():
             break
-    
-    padded_image_matrix = zeros_like(target_image)
+
+    padded_image_matrix: Optional[ndarray] = zeros_like(target_image)
     padded_image_matrix[:, :, z_shift:cropped_image.shape[2]+z_shift] = cropped_image
-    padded_image_path = path.join(getcwd(),"padded_image_T1w.nii.gz")
+    padded_image_path:str = path.join(getcwd(),"padded_image_T1w.nii.gz")
     cropped_image = load(cropped_image_path)
     save(Nifti1Image(padded_image_matrix, affine=cropped_image.affine), padded_image_path)
     return padded_image_path

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -524,6 +524,7 @@ latest_schema = Schema({
             },
             'FSL-BET': {
                 'frac': Number,
+                'Robustfov': bool1_1,
                 'mask_boolean': bool1_1,
                 'mesh_boolean': bool1_1,
                 'outline': bool1_1,

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -342,7 +342,7 @@ anatomical_preproc:
       monkey: Off
 
     FSL-BET:
-
+      Robustfov : On
       # Set the threshold value controling the brain vs non-brain voxels, default is 0.5
       frac: 0.5
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -342,6 +342,7 @@ anatomical_preproc:
       monkey: Off
 
     FSL-BET:
+
       # Set Robustfov on to crop neck regions before generating the mask for skull stripping.
       Robustfov: On
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -342,6 +342,8 @@ anatomical_preproc:
       monkey: Off
 
     FSL-BET:
+
+      # Set Robustfov on to crop neck regions before generating the mask for skull stripping.
       Robustfov: On
 
       # Set the threshold value controling the brain vs non-brain voxels, default is 0.5

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -342,7 +342,8 @@ anatomical_preproc:
       monkey: Off
 
     FSL-BET:
-      Robustfov : On
+      Robustfov: On
+
       # Set the threshold value controling the brain vs non-brain voxels, default is 0.5
       frac: 0.5
 

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -409,7 +409,7 @@ anatomical_preproc:
       monkey: False
 
     FSL-BET:
-
+      Robustfov : On
       # Set the threshold value controling the brain vs non-brain voxels, default is 0.5
       frac: 0.5
 

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -409,7 +409,9 @@ anatomical_preproc:
       monkey: False
 
     FSL-BET:
+      # Set Robustfov on to crop neck regions before generating the mask for skull stripping.
       Robustfov : On
+
       # Set the threshold value controling the brain vs non-brain voxels, default is 0.5
       frac: 0.5
 

--- a/CPAC/resources/cpac_outputs.tsv
+++ b/CPAC/resources/cpac_outputs.tsv
@@ -100,6 +100,7 @@ space-template_desc-bold_mask	mask	template	func	NIfTI
 space-template_res-derivative_desc-bold_mask	mask	template	func	NIfTI					
 motion	motion		func	TSV					
 desc-summary_motion	motion		func	TSV					
+dvars	motion		func	TSV				Yes
 motion-filter-plot	motion		func	png					
 desc-movementParameters_motion	motion		func	TSV					
 desc-movementParametersUnfiltered_motion	motion		func	TSV					


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes #1928
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #1928 by @birajstha 

## Description
<!-- Concisely describe what the pull request does. -->
This PR further expands the work of former cpac developer @tergeorge, by addressing the bug on implementation of RobustFOV.
RobustFOV crops the Nifti Image and hence when BET generates the mask, the mask doesnot match the dimension of the original resampled image thus giving error in "3Dcalc" down the pipeline.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Tested on few (4-5) sample datasets with and without neck regions in the image where it performed as expected.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `add_fslrobustfov` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
