### PR TITLE
🧑‍💻 Move YAML comment updater to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,14 @@ repos:
         entry: .github/scripts/autoversioning.sh
         language: script
         files: '.*Dockerfile$|.*\.yaml$|^CPAC/info\.py$'
+      - id: update-yaml-comments
+        name: Update YAML comments
+        entry: CPAC/utils/configuration/yaml_template.py
+        language: python
+        files: '^CPAC/resources/configs/pipeline_config_.*\.ya?ml'
+        additional_dependencies:
+          - "click"
+          - "nipype"
+          - "pathvalidate"
+          - "pyyaml"
+          - "voluptuous"

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -99,7 +99,6 @@ anatomical_preproc:
       # Perform final surface smoothing after all iterations. Default is 20.
       smooth_final: 22
 
-
   # Non-local means filtering via ANTs DenoiseImage
   non_local_means_filtering:
 

--- a/CPAC/utils/configuration/yaml_template.py
+++ b/CPAC/utils/configuration/yaml_template.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (C) 2022  C-PAC Developers
 
 # This file is part of C-PAC.
@@ -18,6 +19,7 @@
 from copy import deepcopy
 import os
 import re
+from typing import Optional, Union
 from datetime import datetime
 from hashlib import sha1
 from click import BadParameter
@@ -226,8 +228,10 @@ def _count_indent(line):
     return (len(line) - len(line.lstrip())) // 2
 
 
-def create_yaml_from_template(d,  # pylint: disable=invalid-name
-                              template='default', import_from=None):
+def create_yaml_from_template(
+        d: Union[Configuration, dict],  # pylint: disable=invalid-name
+        template: str = 'default', import_from: Optional[str] = None,
+        skip_env_check: Optional[bool] = False) -> str:
     """Save dictionary to a YAML file, keeping the structure
     (such as first level comments and ordering) from the template
 
@@ -243,6 +247,9 @@ def create_yaml_from_template(d,  # pylint: disable=invalid-name
 
     import_from : str, optional
         name of a preconfig. Full config is generated if omitted
+
+    skip_env_check : bool, optional
+        skip environment check (for validating a config without running)
 
     Examples
     --------
@@ -284,7 +291,7 @@ def create_yaml_from_template(d,  # pylint: disable=invalid-name
         base_config = None
     else:  # config based on preconfig
         d = Configuration(d) if not isinstance(d, Configuration) else d
-        base_config = Preconfiguration(import_from)
+        base_config = Preconfiguration(import_from, skip_env_check=skip_env_check)
         d = (d - base_config).left
         d.update({'FROM': import_from})
     yaml_template = YamlTemplate(template, base_config)
@@ -466,8 +473,9 @@ def update_a_preconfig(preconfig, import_from):
     """
     import sys
     print(f'Updating {preconfig} preconfig…', file=sys.stderr)
-    updated = create_yaml_from_template(Preconfiguration(preconfig),
-                                        import_from=import_from)
+    updated = create_yaml_from_template(Preconfiguration(preconfig,
+                                                         skip_env_check=True),
+                                        import_from=import_from, skip_env_check=True)
     with open(preconfig_yaml(preconfig), 'w', encoding='utf-8') as _f:
         _f.write(updated)
 


### PR DESCRIPTION
## Fixes
Fixes #2046 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
In reviewing https://github.com/FCP-INDI/C-PAC/pull/1933#discussion_r1496169967, I noticed we (I) lost the YAML comment autoupdates in #2046. This PR restores that functionality, but also moves it from the CI to a pre-commit hook.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
A couple changes were necessary here:

1. With `torch` moved out of the pre-installed packages, the pipeline config validator checks that we have it or can install it if `unet` is selected https://github.com/FCP-INDI/C-PAC/blob/16320b95f67dbbcb8eb4a1e73cc99182d5e769c0/CPAC/pipeline/schema.py#L1191-L1201
2. `$FSLDIR` wasn't/isn't set in the CI images, but likely will be on developers' machines.

To get over both of these hurdles, this PR adds https://github.com/FCP-INDI/C-PAC/blob/16320b95f67dbbcb8eb4a1e73cc99182d5e769c0/CPAC/utils/configuration/configuration.py#L117-L118 a `"skip env check"` flag that skips checking for `torch` and skips resolving environment variables in the config, and deletes the flag from the config after validation https://github.com/FCP-INDI/C-PAC/blob/16320b95f67dbbcb8eb4a1e73cc99182d5e769c0/CPAC/utils/configuration/configuration.py#L155-L157 

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/16320b95f67dbbcb8eb4a1e73cc99182d5e769c0/CPAC/utils/configuration/configuration.py#L351-L356

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
