### PR TITLE
🥅 Raise an error instead of returning `None` where a dict is expected

### DIFF
--- a/CPAC/nuisance/utils/utils.py
+++ b/CPAC/nuisance/utils/utils.py
@@ -637,7 +637,8 @@ def generate_summarize_tissue_mask_ventricles_masking(
                 ]
 
         return pipeline_resource_pool
-    return None
+    msg = f"`{mask_key}_Unmasked` already in resource pool"
+    raise LookupError(msg)
 
 
 class NuisanceRegressor(object):


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes https://github.com/FCP-INDI/C-PAC/pull/2059#discussion_r1472295222 by @shnizzedy with https://github.com/FCP-INDI/C-PAC/pull/2059#discussion_r1483106483 by @nx10 

## Description
<!-- Concisely describe what the pull request does. -->
> https://github.com/FCP-INDI/C-PAC/blob/85737a19957a212586de173fb18d5ffe0ad6ed40/CPAC/nuisance/utils/utils.py#L639-L640
> It hasn't seemed to cause a problem, but I don't understand why this case would return None instead of pipeline_resource_pool or {}

> If no one knows you could turn it into an error? Maybe it just never happens?

This just changes that `return None` into a `raise LookupError`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `intial-run/ruff` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
