### PR TITLE
🐛 For uploading logs, look for S3 encryption setting in pipeline config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## Changed
+### Fixed
+
+- A bug in which AWS S3 encryption was looked for in Nipype config instead of pipeline config (only affected uploading logs)
+
+### Changed
 
 - Moved autoversioning from CI to pre-commit
 - Updated `FSL-BET` config to default `-mask-boolean` flag as on, and removed all removed `mask-boolean` keys from configs.
@@ -24,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.6] - 2024-01-15
 
-## Added
+### Added
 
 - Some automatic handling of user-provided BIDSy atlas names.
 - `sig_imports` static method decorator for `Function` nodes, to accommodate type hinting in signatures of `Function` node functions.

--- a/CPAC/longitudinal_pipeline/longitudinal_workflow.py
+++ b/CPAC/longitudinal_pipeline/longitudinal_workflow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2022  C-PAC Developers
+# Copyright (C) 2020-2024  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -92,10 +92,7 @@ def create_datasink(
     -------
 
     """
-    try:
-        encrypt_data = bool(config.pipeline_setup["Amazon-AWS"]["s3_encryption"])
-    except:
-        encrypt_data = False
+    encrypt_data = config.pipeline_setup["Amazon-AWS"]["s3_encryption"]
 
     # TODO Enforce value with schema validation
     # Extract credentials path for output if it exists

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -363,7 +363,7 @@ def run_workflow(
 
     # TODO enforce value with schema validation
     try:
-        encrypt_data = bool(config.pipeline_setup["Amazon-AWS"]["s3_encryption"])
+        encrypt_data = bool(c.pipeline_setup["Amazon-AWS"]["s3_encryption"])
     except (KeyError, TypeError, ValueError):
         encrypt_data = False
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -361,12 +361,6 @@ def run_workflow(
     except KeyError:
         input_creds_path = None
 
-    # TODO enforce value with schema validation
-    try:
-        encrypt_data = bool(c.pipeline_setup["Amazon-AWS"]["s3_encryption"])
-    except (KeyError, TypeError, ValueError):
-        encrypt_data = False
-
     information = """
     Environment
     ===========
@@ -766,7 +760,9 @@ Please, make yourself aware of how it works and its assumptions:
                     ]
                     # Upload logs
                     aws_utils.s3_upload(
-                        bucket, (local_log_files, s3_log_files), encrypt=encrypt_data
+                        bucket,
+                        (local_log_files, s3_log_files),
+                        encrypt=c["pipeline_setup", "Amazon-AWS", "s3_encryption"],
                     )
                     # Delete local log files
                     for log_f in local_log_files:
@@ -1622,13 +1618,6 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None):
                 "your data and pipeline configurations."
             ) from lookup_error
         raise lookup_error
-
-    # Write out the data
-    # TODO enforce value with schema validation
-    try:
-        bool(cfg.pipeline_setup["Amazon-AWS"]["s3_encryption"])
-    except (KeyError, TypeError, ValueError):
-        pass
 
     # TODO enforce value with schema validation
     # Extract credentials path for output if it exists


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes [preliminary smoke test failures](https://github.com/FCP-INDI/C-PAC/actions/runs/8255413491) by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
In https://github.com/FCP-INDI/C-PAC/blob/1fe21e19af34c058ac7455f546be948f7e5ed225/CPAC/pipeline/cpac_pipeline.py#L361-L366 `config` is the Nipype configuration, not the pipeline configuration, so the broad exception was catching an `AttributeError`, failing silently and always setting `encrypt_data` to `False`.

Upon the linted change listing expected exceptions https://github.com/FCP-INDI/C-PAC/blob/7aaf4393efc7bf24da3c455ca171fdf329d503cb/CPAC/pipeline/cpac_pipeline.py#L364-L368 `AttributeError` isn't caught, so the rule-excepted broad exception in https://github.com/FCP-INDI/C-PAC/blob/7aaf4393efc7bf24da3c455ca171fdf329d503cb/CPAC/pipeline/cpac_runner.py#L652-L665 catches the error and exits with an exit code 1.

The schema validation _does_ handle validating the value in the config (I guess it didn't when this code was written), and `encrypt_data` isn't used anywhere besides in setting the `encrypt` parameter in uploading the logs to S3, so I just cut out the variable assignment altogether and just directly plug the value from the pipeline config into the S3 call https://github.com/FCP-INDI/C-PAC/blob/d463fd3d095687bfbfae5c5cf99effb10a2d50ef/CPAC/pipeline/cpac_pipeline.py#L765

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
I was going to write tests for this, but I don't think we need any:
* The schema validator already tests for a valid value for `s3_encryption` and will have a default imported if one isn't set.
* If the config somehow gets switched back from `c` (the pipeline config) to `config` (the Nipype config), the `AttributeError` will raise, but only if the pipeline config is uploading to S3 (otherwise it doesn't matter).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `initial-run/ruff` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the smoke tests and verified that they now succeed.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
