### PR TITLE
📦️ PEP 518: Set `[build-system]` in `pyproject.toml`

### DIFF
--- a/.github/Dockerfiles/C-PAC.develop-ABCD-HCP-bionic.Dockerfile
+++ b/.github/Dockerfiles/C-PAC.develop-ABCD-HCP-bionic.Dockerfile
@@ -16,7 +16,7 @@ USER root
 # install C-PAC
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/.github/Dockerfiles/C-PAC.develop-fMRIPrep-LTS-xenial.Dockerfile
+++ b/.github/Dockerfiles/C-PAC.develop-fMRIPrep-LTS-xenial.Dockerfile
@@ -16,7 +16,7 @@ USER root
 # install C-PAC & set up runscript
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/.github/Dockerfiles/C-PAC.develop-jammy.Dockerfile
+++ b/.github/Dockerfiles/C-PAC.develop-jammy.Dockerfile
@@ -22,7 +22,7 @@ USER root
 # install C-PAC
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/.github/Dockerfiles/C-PAC.develop-lite-jammy.Dockerfile
+++ b/.github/Dockerfiles/C-PAC.develop-lite-jammy.Dockerfile
@@ -23,7 +23,7 @@ USER root
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
 COPY --from=ghcr.io/fcp-indi/c-pac_templates:latest /cpac_templates /cpac_templates
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- `pyproject.toml` file with `[build-system]` defined.
+
 ### Fixed
 
-- A bug in which AWS S3 encryption was looked for in Nipype config instead of pipeline config (only affected uploading logs)
+- A bug in which AWS S3 encryption was looked for in Nipype config instead of pipeline config (only affected uploading logs).
 
 ## [1.8.7] - 2024-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pyproject.toml` file with `[build-system]` defined.
 
+### Changed
+
+- Moved `pygraphviz` from requirements to `graphviz` optional dependencies group.
+
 ### Fixed
 
 - A bug in which AWS S3 encryption was looked for in Nipype config instead of pipeline config (only affected uploading logs).

--- a/CPAC/info.py
+++ b/CPAC/info.py
@@ -198,7 +198,7 @@ REQUIREMENTS = [
     "PyBASC",
     "pybids",
     "pygraphviz",
-    "PyPEER @ git+https://git@github.com/ChildMindInstitute/PyPEER.git@6965d2b2bea0fef824e885fec33a8e0e6bd50a97#egg=PyPEER",
+    "PyPEER @ https://github.com/shnizzedy/PyPEER/archive/6965d2b2bea0fef824e885fec33a8e0e6bd50a97.zip",
     "python-dateutil",
     "pyyaml",
     "scikit-learn",

--- a/CPAC/info.py
+++ b/CPAC/info.py
@@ -197,7 +197,6 @@ REQUIREMENTS = [
     "psutil",
     "PyBASC",
     "pybids",
-    "pygraphviz",
     "PyPEER @ https://github.com/shnizzedy/PyPEER/archive/6965d2b2bea0fef824e885fec33a8e0e6bd50a97.zip",
     "python-dateutil",
     "pyyaml",

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ USER root
 # install C-PAC
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/dev/docker_data/unpinned_requirements.txt
+++ b/dev/docker_data/unpinned_requirements.txt
@@ -20,7 +20,7 @@ prov
 psutil
 PyBASC
 pybids
-PyPEER @ git+https://git@github.com/ChildMindInstitute/PyPEER.git@6965d2b2bea0fef824e885fec33a8e0e6bd50a97
+PyPEER @ https://github.com/shnizzedy/PyPEER/archive/6965d2b2bea0fef824e885fec33a8e0e6bd50a97.zip
 python-dateutil
 PyYAML
 requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+# Copyright (C) 2024  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+[build-system]
+requires = ["nipype", "numpy", "pyyaml", "setuptools", "voluptuous"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ prov==2.0.0
 psutil==5.9.5
 PyBASC==0.6.1
 pybids==0.15.6
-PyPEER @ git+https://git@github.com/ChildMindInstitute/PyPEER.git@6965d2b2bea0fef824e885fec33a8e0e6bd50a97
+PyPEER @ https://github.com/shnizzedy/PyPEER/archive/6965d2b2bea0fef824e885fec33a8e0e6bd50a97.zip
 python-dateutil==2.8.2
 PyYAML==6.0
 requests==2.31.0

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ def main(**extra_args):
         platforms=PLATFORMS,
         version=VERSION,
         install_requires=REQUIREMENTS,
+        extras_require={"graphviz": ["pygraphviz"]},
         configuration=configuration,
         scripts=glob("scripts/*"),
         entry_points={"console_scripts": ["cpac = CPAC.__main__:main"]},

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022  C-PAC Developers
+# Copyright (C) 2022-2024  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -43,9 +43,12 @@ def configuration(parent_package="", top_path=None):
 
 def main(**extra_args):
     from glob import glob
+    import sys
 
     from numpy.distutils.core import setup
 
+    # prepend this file's parent directory to sys.path to find CPAC when building
+    sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
     from CPAC.info import (
         AUTHOR,
         AUTHOR_EMAIL,

--- a/variant-ABCD-HCP.Dockerfile
+++ b/variant-ABCD-HCP.Dockerfile
@@ -16,7 +16,7 @@ USER root
 # install C-PAC
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/variant-fMRIPrep-LTS.Dockerfile
+++ b/variant-fMRIPrep-LTS.Dockerfile
@@ -16,7 +16,7 @@ USER root
 # install C-PAC & set up runscript
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \

--- a/variant-lite.Dockerfile
+++ b/variant-lite.Dockerfile
@@ -23,7 +23,7 @@ USER root
 COPY dev/circleci_data/pipe-test_ci.yml /cpac_resources/pipe-test_ci.yml
 COPY . /code
 COPY --from=ghcr.io/fcp-indi/c-pac_templates:latest /cpac_templates /cpac_templates
-RUN pip cache purge && pip install -e /code
+RUN pip cache purge && pip install -e "/code[graphviz]"
 # set up runscript
 COPY dev/docker_data /code/docker_data
 RUN rm -Rf /code/docker_data/checksum && \


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to [:snake: PEP 518 – Specifying Minimum Build System Requirements for Python Projects](https://peps.python.org/pep-0518/)
Related to [:octocat:/childmindresearch/nodeblock-testing](https://github.com/childmindresearch/nodeblock-testing)

## Description
<!-- Concisely describe what the pull request does. -->
1. Adds a `pyproject.toml` file with just a license and build system requirements https://github.com/FCP-INDI/C-PAC/blob/3f23711275ebcb5de6ca99ed338c26d6ea230f42/pyproject.toml#L17-L19
2. Prepends the source path to `sys.path` https://github.com/FCP-INDI/C-PAC/blob/3f23711275ebcb5de6ca99ed338c26d6ea230f42/setup.py#L50-L51 to be able to import from `CPAC.info` at build-time https://github.com/FCP-INDI/C-PAC/blob/3f23711275ebcb5de6ca99ed338c26d6ea230f42/setup.py#L52-L67
3. Switches the PyPEER dependency from https://github.com/ChildMindInstitute/PyPEER/commit/6965d2b2bea0fef824e885fec33a8e0e6bd50a97 (<img alt="⚠️ This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository." title="⚠️ This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository." src="https://github.com/FCP-INDI/C-PAC/assets/5974438/742443d1-c59e-4ab0-8fea-e083ed7de012" height="44px">) to https://github.com/shnizzedy/PyPEER/commit/6965d2b2bea0fef824e885fec33a8e0e6bd50a97
4. Moves `pygraphviz` from requirements to optional requirements in the "graphviz" extras, and updates all the Dockerfiles to install with the "graphviz" extras.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
1. C-PAC was created long before the current Python packaging standards were formalized (e.g., the current standard uses a `pyproject.toml` file, and the initial release of TOML hadn't come out when this project started). The build system in C-PAC is pretty idiosyncratic, using Python 3 and setuptools but with style remnants from Python 2 and distutils, with some nipype and numpy flavor sprinkled in. I think we'll eventually want to migrate most-to-all of the build info to pyproject.toml, but for the prototype of [:octocat:/childmindresearch/nodeblock-testing](https://github.com/childmindresearch/nodeblock-testing), defining the build system is all we need.

<ol start="3"><li>PyPEER is pretty stale (ChildMindInstitute/PyPEER#28), and none of us except @js545 have write access to that repo. In the current build style, GitHub finds the commit in its global tree, but some builders (at least poetry) are more careful and won't grab the commit if it's not in the specified fork.</li><li>Some dev or testing environments don't have graphviz installed, and don't necessarily need it. With this packaging change, we'll still always have it in the image, but for things like <a href="https://github.com/childmindresearch/nodeblock-testing">:octocat:/childmindresearch/nodeblock-testing</a> we don't have to install graphviz just to import some CPAC functions.</li></ol>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
