### PR TITLE
📦️ Restore `bids-validator` installation in containerized C-PAC images

### DIFF
--- a/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
+++ b/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
@@ -29,7 +29,8 @@ FROM neurodebian:jammy-non-free
 LABEL org.opencontainers.image.description "NOT INTENDED FOR USE OTHER THAN AS A STAGE IMAGE IN A MULTI-STAGE BUILD \
 Ubuntu Jammy base image"
 LABEL org.opencontainers.image.source https://github.com/FCP-INDI/C-PAC
-ARG DEBIAN_FRONTEND=noninteractive
+ARG BIDS_VALIDATOR_VERSION=1.14.6 \
+    DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York \
     PATH=$PATH:/.local/bin \
     PYTHONPATH=$PYTHONPATH:/.local/lib/python3.10/site-packages
@@ -61,7 +62,11 @@ RUN groupadd -r c-pac \
     && echo $TZ > /etc/timezone \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
-    && update-locale LANG="en_US.UTF-8"
+    && update-locale LANG="en_US.UTF-8" \
+    # # install bids-validator
+    && curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts \
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    npm install -g "bids-validator@${BIDS_VALIDATOR_VERSION}"
 
 COPY --from=c-pac_templates /cpac_templates /cpac_templates
 COPY --from=dcan-hcp /opt/dcan-tools/pipeline/global /opt/dcan-tools/pipeline/global

--- a/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
+++ b/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
@@ -65,8 +65,7 @@ RUN groupadd -r c-pac \
     && update-locale LANG="en_US.UTF-8" \
     # # install bids-validator
     && curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    npm install -g "bids-validator@${BIDS_VALIDATOR_VERSION}"
+    && npm install -g "bids-validator@${BIDS_VALIDATOR_VERSION}"
 
 COPY --from=c-pac_templates /cpac_templates /cpac_templates
 COPY --from=dcan-hcp /opt/dcan-tools/pipeline/global /opt/dcan-tools/pipeline/global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A bug in which AWS S3 encryption was looked for in Nipype config instead of pipeline config (only affected uploading logs).
+- Restored `bids-validator` functionality.
 
 ### Removed
 

--- a/CPAC/utils/tests/test_bids_utils.py
+++ b/CPAC/utils/tests/test_bids_utils.py
@@ -18,6 +18,7 @@
 
 from logging import basicConfig, INFO
 import os
+from subprocess import run
 
 import pytest
 import yaml
@@ -71,6 +72,11 @@ def create_sample_bids_structure(root_dir):
                 os.path.join(path, "_".join([_prefix_entities(paths, path), suffix])),
                 "w",
             )
+
+
+def test_bids_validator() -> None:
+    """Test subprocess call to `bids-validator`."""
+    run(["bids-validator", "--version"], check=True)
 
 
 @pytest.mark.parametrize("only_one_anat", [True, False])

--- a/CPAC/utils/versioning/dependencies.py
+++ b/CPAC/utils/versioning/dependencies.py
@@ -136,6 +136,12 @@ def requirements() -> dict:
 
 REPORTED = sorted_versions(
     {
+        **cli_version(
+            "bids-validator --version",
+            dependency="bids-validator",
+            in_result=False,
+            formatting=first_line,
+        ),
         **cli_version("ldd --version", formatting=first_line),
         "Python": sys.version.replace("\n", " ").replace("  ", " "),
         **cli_version(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 
 [build-system]
-requires = ["nipype==1.8.6", "numpy==1.25.1", "pyyaml==6.0", "setuptools==68.0.0", "voluptuous==0.13.1"]
+requires = ["nipype==1.8.6", "numpy==1.25.1", "pyyaml==6.0", "setuptools<60.0", "voluptuous==0.13.1"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,20 @@
 # Copyright (C) 2024  C-PAC Developers
-
+#
 # This file is part of C-PAC.
-
+#
 # C-PAC is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the
 # Free Software Foundation, either version 3 of the License, or (at your
 # option) any later version.
-
+#
 # C-PAC is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
 # License for more details.
-
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+
 [build-system]
-requires = ["nipype", "numpy", "pyyaml", "setuptools", "voluptuous"]
+requires = ["nipype==1.8.6", "numpy==1.25.1", "pyyaml==6.0", "setuptools==68.0.0", "voluptuous==0.13.1"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ h5py==3.8.0
 importlib-metadata==6.8.0
 lxml==4.9.2
 pip==23.3
-setuptools==68.0.0
+setuptools<60.0
 urllib3==1.26.18
 wheel==0.40.0
 zipp==3.16.0


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2110 by @shnizzedy
Related to [[comment]](https://neurostars.org/t/running-an-older-version-of-c-pac-v1-3-0/29178/4?u=shnizzedy) by @shnizzedy (response to [<img src="https://neurostars.org/uploads/default/optimized/1X/eadd889a719a1e6370fbe086d518eafd6cd4586c_2_32x32.png" alt="Neurostars" width="14px"/> Running an older version of C-PAC (V1.3.0)](https://neurostars.org/t/running-an-older-version-of-c-pac-v1-3-0/29178) by [@Ammar_Ibrahim](https://neurostars.org/u/Ammar_Ibrahim))

## Description
<!-- Concisely describe what the pull request does. -->
> In looking into the issue, I discovered that we inadvertently removed the bids-validator CLI, so trying to run with the BIDS validator in versions 1.8.6 and 1.8.7 will fail as well.

― [<img src="https://neurostars.org/uploads/default/optimized/1X/eadd889a719a1e6370fbe086d518eafd6cd4586c_2_32x32.png" alt="Neurostars" width="14px"/> Re: Running an older version of C-PAC (V1.3.0)](https://neurostars.org/t/running-an-older-version-of-c-pac-v1-3-0/29178/4?u=shnizzedy)

This PR

1. installs [`n`](https://www.npmjs.com/package/n) https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile#L67 and the Node.js version of [`bids-validator`](https://github.com/bids-standard/bids-validator) https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile#L32 https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile#L68
2. Adds `bids-validator` to the list of dependencies to log the version of https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/CPAC/utils/versioning/dependencies.py#L139-L144

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

* Pinned buildtime dependencies and bounded `setuptools` version to https://github.com/FCP-INDI/C-PAC/blob/12cf540a0466876a87a791fc87b145a6efed9070/pyproject.toml#L19 for
  ```
  `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
  of the deprecation of `distutils` itself. It will be removed for
  Python >= 3.12. For older Python versions it will remain present.
  It is recommended to use `setuptools < 60.0` for those Python versions.
  For more details, see:
  https://numpy.org/devdocs/reference/distutils_status_migration.html
  ```

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/CPAC/utils/tests/test_bids_utils.py#L77-L79 ([fails when `bids-validator` CLI is not installed](https://app.circleci.com/pipelines/github/FCP-INDI/C-PAC/7023/workflows/cb8440db-8427-45a3-8539-dcdbeb20f837/jobs/30863))

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### `python /code/CPAC/__main__.py version`
![`bids-validator: 1.14.6`](https://github.com/FCP-INDI/C-PAC/assets/5974438/df500ebf-c5ae-40b2-8bfc-3ed511f39789)

### `bids-validator --help`

![`Usage: bids-validator <dataset_directory> [options]`](https://github.com/FCP-INDI/C-PAC/assets/5974438/8ac20c50-d8d0-42db-9fe5-104667c95fa3)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (FCP-INDI/fcp-indi.github.io#324).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
