### PR TITLE
🐛 Fix `get_scan_params`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -11,6 +11,7 @@ external = ["T20"]  # Don't autoremove 'noqa` comments for these rules
 [lint.per-file-ignores]
 "CPAC/func_preproc/func_preproc.py" = ["E402"]
 "CPAC/utils/sklearn.py" = ["RUF003"]
+"CPAC/utils/tests/old_functions.py" = ["C", "D", "E", "EM", "PLW", "RET"]
 "CPAC/utils/utils.py" = ["T201"]  # until `repickle` is removed
 "setup.py" = ["D1"]
 

--- a/CPAC/alff/alff.py
+++ b/CPAC/alff/alff.py
@@ -1,5 +1,20 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2012-2024  C-PAC Developers
 
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import os
 
 from nipype.interfaces.afni import preprocess
@@ -9,6 +24,7 @@ from CPAC.alff.utils import get_opt_string
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.pipeline.nodeblock import nodeblock
 from CPAC.registration.registration import apply_transform
+from CPAC.utils.interfaces import Function
 from CPAC.utils.utils import check_prov_for_regtool
 
 
@@ -177,7 +193,7 @@ def create_alff(wf_name="alff_workflow"):
     wf.connect(input_node, "rest_res", bandpass, "in_file")
 
     get_option_string = pe.Node(
-        util.Function(
+        Function(
             input_names=["mask"],
             output_names=["option_string"],
             function=get_opt_string,

--- a/CPAC/alff/utils.py
+++ b/CPAC/alff/utils.py
@@ -3,7 +3,10 @@
 
 from pathlib import Path
 
+from CPAC.utils.interfaces.function import Function
 
+
+@Function.sig_imports(["from pathlib import Path"])
 def get_opt_string(mask: Path | str) -> str:
     """
     Return option string for 3dTstat.

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -15,7 +15,6 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
-# from copy import deepcopy
 import os
 
 from nipype.interfaces import afni, ants, freesurfer, fsl
@@ -36,6 +35,7 @@ from CPAC.anat_preproc.utils import (
 )
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.pipeline.nodeblock import nodeblock
+from CPAC.utils.interfaces import Function
 from CPAC.utils.interfaces.fsl import Merge as fslMerge
 
 
@@ -138,7 +138,7 @@ def acpc_alignment(
 
     aff_to_rig_imports = ["import os", "from numpy import *"]
     aff_to_rig = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_xfm", "out_name"],
             output_names=["out_mat"],
             function=fsl_aff_to_rigid,
@@ -319,7 +319,7 @@ def BiasFieldCorrection_sqrtT1wXT1w(config=None, wf_name="biasfield_correction_t
         return "-s %f -div %s" % (sigma, in_file)
 
     T1wmulT2w_brain_norm_s_string = pe.Node(
-        util.Function(
+        Function(
             input_names=["sigma", "in_file"],
             output_names=["out_str"],
             function=T1wmulT2w_brain_norm_s_string,
@@ -378,7 +378,7 @@ def BiasFieldCorrection_sqrtT1wXT1w(config=None, wf_name="biasfield_correction_t
         return "-thr %s -bin -ero -mul 255" % (lower)
 
     form_lower_string = pe.Node(
-        util.Function(
+        Function(
             input_names=["mean", "std"],
             output_names=["out_str"],
             function=form_lower_string,
@@ -444,7 +444,7 @@ def BiasFieldCorrection_sqrtT1wXT1w(config=None, wf_name="biasfield_correction_t
         return [infile_1, infile_2]
 
     file_to_a_list = pe.Node(
-        util.Function(
+        Function(
             input_names=["infile_1", "infile_2"],
             output_names=["out_list"],
             function=file_to_a_list,
@@ -544,7 +544,7 @@ def afni_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     )
 
     skullstrip_args = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "spat_norm",
                 "spat_norm_dxyz",
@@ -762,7 +762,7 @@ def fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     anat_robustfov.inputs.output_type = "NIFTI_GZ"
 
     anat_pad_RobustFOV_cropped = pe.Node(
-        util.Function(
+        Function(
             input_names=["cropped_image_path", "target_image_path"],
             output_names=["padded_image_path"],
             function=pad,
@@ -902,7 +902,7 @@ def unet_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     from CPAC.unet.function import predict_volumes
 
     unet_mask = pe.Node(
-        util.Function(
+        Function(
             input_names=["model_path", "cimg_in"],
             output_names=["out_path"],
             function=predict_volumes,
@@ -1083,7 +1083,7 @@ def freesurfer_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     # convert brain mask file from .mgz to .nii.gz
     fs_brain_mask_to_nifti = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file"], output_names=["out_file"], function=mri_convert
         ),
         name=f"fs_brainmask_to_nifti_{pipe_num}",
@@ -1119,7 +1119,7 @@ def freesurfer_abcd_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     Ref: https://github.com/DCAN-Labs/DCAN-HCP/blob/7927754/PostFreeSurfer/PostFreeSurferPipeline.sh#L151-L156
     """
     wmparc_to_nifti = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file", "reslice_like", "args"],
             output_names=["out_file"],
             function=mri_convert,
@@ -1130,7 +1130,7 @@ def freesurfer_abcd_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     # Register wmparc file if ingressing FreeSurfer data
     if strat_pool.check_rpool("pipeline-fs_xfm"):
         wmparc_to_native = pe.Node(
-            util.Function(
+            Function(
                 input_names=["source_file", "target_file", "xfm", "out_file"],
                 output_names=["transformed_file"],
                 function=normalize_wmparc,
@@ -1168,7 +1168,7 @@ def freesurfer_abcd_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     wf.connect(wmparc_to_nifti, "out_file", binary_mask, "in_file")
 
     wb_command_fill_holes = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file"], output_names=["out_file"], function=wb_command
         ),
         name=f"wb_command_fill_holes_{pipe_num}",
@@ -1206,7 +1206,7 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     # mri_convert -it mgz ${SUBJECTS_DIR}/${subject}/mri/brainmask.mgz -ot nii brainmask.nii.gz
     convert_fs_brainmask_to_nifti = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file"], output_names=["out_file"], function=mri_convert
         ),
         name=f"convert_fs_brainmask_to_nifti_{node_id}",
@@ -1217,7 +1217,7 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     # mri_convert -it mgz ${SUBJECTS_DIR}/${subject}/mri/T1.mgz -ot nii T1.nii.gz
     convert_fs_T1_to_nifti = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file"], output_names=["out_file"], function=mri_convert
         ),
         name=f"convert_fs_T1_to_nifti_{node_id}",
@@ -2888,7 +2888,7 @@ def freesurfer_abcd_preproc(wf, cfg, strat_pool, pipe_num, opt=None):
 
     # fslmaths "$T1wImageFile"_1mm.nii.gz -div $Mean -mul 150 -abs "$T1wImageFile"_1mm.nii.gz
     normalize_head = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file", "number", "out_file_suffix"],
             output_names=["out_file"],
             function=fslmaths_command,

--- a/CPAC/anat_preproc/lesion_preproc.py
+++ b/CPAC/anat_preproc/lesion_preproc.py
@@ -1,13 +1,30 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2019-2023  C-PAC Developers
 
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 from nipype.interfaces import afni
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 
 
 def inverse_lesion(lesion_path):
-    """
+    """Replace non-zeroes with zeroes and zeroes with ones.
+
     Check if the image contains more zeros than non-zeros, if so,
     replaces non-zeros by zeros and zeros by ones.
 
@@ -38,13 +55,12 @@ def inverse_lesion(lesion_path):
         nii = nu.inverse_nifti_values(image=lesion_path)
         nib.save(nii, lesion_out)
         return lesion_out
-    else:
-        return lesion_out
+    return lesion_out
 
 
 def create_lesion_preproc(wf_name="lesion_preproc"):
-    """
-    The main purpose of this workflow is to process lesions masks.
+    """Process lesions masks.
+
     Lesion mask file is deobliqued and reoriented in the same way as the T1 in
     the anat_preproc function.
 
@@ -95,7 +111,7 @@ def create_lesion_preproc(wf_name="lesion_preproc"):
     lesion_deoblique.inputs.deoblique = True
 
     lesion_inverted = pe.Node(
-        interface=util.Function(
+        interface=Function(
             input_names=["lesion_path"],
             output_names=["lesion_out"],
             function=inverse_lesion,

--- a/CPAC/distortion_correction/distortion_correction.py
+++ b/CPAC/distortion_correction/distortion_correction.py
@@ -131,7 +131,7 @@ def distcor_phasediff_fsl_fugue(wf, cfg, strat_pool, pipe_num, opt=None):
         == "AFNI"
     ):
         skullstrip_args = pe.Node(
-            util.Function(
+            Function(
                 input_names=["shrink_fac"],
                 output_names=["expr"],
                 function=create_afni_arg,
@@ -667,7 +667,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
         "import sys",
     ]
     phase_encoding = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "unwarp_dir",
                 "phase_one",
@@ -710,7 +710,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
 
     topup_imports = ["import os", "import subprocess"]
     run_topup = pe.Node(
-        util.Function(
+        Function(
             input_names=["merged_file", "acqparams"],
             output_names=[
                 "out_fieldcoef",
@@ -732,7 +732,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(phase_encoding, "acq_params", run_topup, "acqparams")
 
     choose_phase = pe.Node(
-        util.Function(
+        Function(
             input_names=["phase_imgs", "unwarp_dir"],
             output_names=["out_phase_image", "vnum"],
             function=choose_phase_image,
@@ -746,7 +746,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, choose_phase, "unwarp_dir")
 
     vnum_base = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "vnum",
                 "motion_mat_list",
@@ -797,7 +797,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
     name = "PhaseTwo_aw"
 
     vnum_base_two = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "vnum",
                 "motion_mat_list",
@@ -840,7 +840,7 @@ def distcor_blip_fsl_topup(wf, cfg, strat_pool, pipe_num, opt=None):
     name = "PhaseOne_aw"
 
     vnum_base_one = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "vnum",
                 "motion_mat_list",

--- a/CPAC/distortion_correction/distortion_correction.py
+++ b/CPAC/distortion_correction/distortion_correction.py
@@ -165,7 +165,7 @@ def distcor_phasediff_fsl_fugue(wf, cfg, strat_pool, pipe_num, opt=None):
         == "BET"
     ):
         bet = pe.Node(
-            interface=fsl.BET(), name="distcor_phasediff_bet_skullstrip_{pipe_num}"
+            interface=fsl.BET(), name=f"distcor_phasediff_bet_skullstrip_{pipe_num}"
         )
         bet.inputs.output_type = "NIFTI_GZ"
         bet.inputs.frac = cfg.functional_preproc["distortion_correction"]["PhaseDiff"][

--- a/CPAC/easy_thresh/easy_thresh.py
+++ b/CPAC/easy_thresh/easy_thresh.py
@@ -1,3 +1,19 @@
+# Copyright (C) 2012-2023  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import os
 import re
 import subprocess
@@ -7,12 +23,11 @@ from nipype.interfaces import fsl
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 
 
 def easy_thresh(wf_name):
-    """
-    Workflow for carrying out cluster-based thresholding
-    and colour activation overlaying.
+    """Carry out cluster-based thresholding and colour activation overlaying.
 
     Parameters
     ----------
@@ -213,7 +228,7 @@ def easy_thresh(wf_name):
     # or qform/sform info) from one image to another
     geo_imports = ["import subprocess"]
     copy_geometry = pe.MapNode(
-        util.Function(
+        Function(
             input_names=["infile_a", "infile_b"],
             output_names=["out_file"],
             function=copy_geom,
@@ -246,7 +261,7 @@ def easy_thresh(wf_name):
 
     cluster_imports = ["import os", "import re", "import subprocess"]
     cluster = pe.MapNode(
-        util.Function(
+        Function(
             input_names=[
                 "in_file",
                 "volume",
@@ -271,7 +286,7 @@ def easy_thresh(wf_name):
 
     # create tuple of z_threshold and max intensity value of threshold file
     create_tuple = pe.MapNode(
-        util.Function(
+        Function(
             input_names=["infile_a", "infile_b"],
             output_names=["out_file"],
             function=get_tuple,
@@ -299,7 +314,7 @@ def easy_thresh(wf_name):
     # as FSLDIR,MNI and voxel size
     get_bg_imports = ["import os", "import nibabel as nib"]
     get_backgroundimage = pe.MapNode(
-        util.Function(
+        Function(
             input_names=["in_file", "file_parameters"],
             output_names=["out_file"],
             function=get_standard_background_img,
@@ -312,7 +327,7 @@ def easy_thresh(wf_name):
     # function node to get the standard fsl brain image
     # outputs single file
     get_backgroundimage2 = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file", "file_parameters"],
             output_names=["out_file"],
             function=get_standard_background_img,
@@ -412,10 +427,9 @@ def call_cluster(in_file, volume, dlh, threshold, pthreshold, parameters):
 
 
 def copy_geom(infile_a, infile_b):
-    """
-    Method to call fsl fslcpgeom command to copy
-    certain parts of the header information (image dimensions,
-    voxel dimensions, voxel dimensions units string, image
+    """Call fsl fslcpgeom command to copy certain parts of the header information.
+
+    Copy (image dimensions, voxel dimensions, voxel dimensions units string, image
     orientation/origin or qform/sform info) from one image to another.
 
     Parameters
@@ -449,9 +463,7 @@ def copy_geom(infile_a, infile_b):
 
 
 def get_standard_background_img(in_file, file_parameters):
-    """
-    Method to get the standard brain image from FSL
-    standard data directory.
+    """Get the standard brain image from FSL standard data directory.
 
     Parameters
     ----------
@@ -487,10 +499,7 @@ def get_standard_background_img(in_file, file_parameters):
 
 
 def get_tuple(infile_a, infile_b):
-    """
-    Simple method to return tuple of z_threhsold
-    maximum intensity values of Zstatistic image
-    for input to the overlay.
+    """Return tuple of z_threhsold maximum intensity values of Zstatistic image for input to the overlay.
 
     Parameters
     ----------

--- a/CPAC/func_preproc/func_motion.py
+++ b/CPAC/func_preproc/func_motion.py
@@ -423,7 +423,7 @@ def get_motion_ref(wf, cfg, strat_pool, pipe_num, opt=None):
 
     elif opt == "fmriprep_reference":
         func_get_RPI = pe.Node(
-            util.Function(
+            Function(
                 input_names=["in_file"],
                 output_names=["out_file"],
                 function=estimate_reference_image,

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -23,6 +23,7 @@ from nipype.interfaces.afni import preprocess, utils as afni_utils
 from CPAC.func_preproc.utils import nullify
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.pipeline.nodeblock import nodeblock
+from CPAC.utils.interfaces import Function
 from CPAC.utils.interfaces.ants import (
     AI,  # niworkflows
     PrintHeader,
@@ -343,7 +344,7 @@ def create_wf_edit_func(wf_name="edit_func"):
     # allocate a node to check that the requested edits are
     # reasonable given the data
     func_get_idx = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_files", "stop_idx", "start_idx"],
             output_names=["stopidx", "startidx"],
             function=get_idx,
@@ -877,7 +878,7 @@ def bold_mask_fsl(wf, cfg, strat_pool, pipe_num, opt=None):
                 return "-thr %s" % (threshold_z)
 
             form_thr_string = pe.Node(
-                util.Function(
+                Function(
                     input_names=["thr"],
                     output_names=["out_str"],
                     function=form_thr_string,

--- a/CPAC/group_analysis/group_analysis.py
+++ b/CPAC/group_analysis/group_analysis.py
@@ -1,14 +1,29 @@
+# Copyright (C) 2012-2023  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 from nipype.interfaces import fsl
 import nipype.interfaces.utility as util
 
 from CPAC.easy_thresh import easy_thresh
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 
 
 def get_operation(in_file):
-    """
-    Method to create operation string
-    for fslmaths.
+    """Create operation string for fslmaths.
 
     Parameters
     ----------
@@ -39,7 +54,9 @@ def get_operation(in_file):
 
 
 def label_zstat_files(zstat_list, con_file):
-    """Take in the z-stat file outputs of FSL FLAME and rename them after the
+    """Rename z-stat file outputs from FSL FLAME using contrast labels.
+
+    Take in the z-stat file outputs of FSL FLAME and rename them after the
     contrast labels of the contrasts provided.
     """
     cons = []
@@ -64,9 +81,7 @@ def label_zstat_files(zstat_list, con_file):
 
 
 def create_fsl_flame_wf(ftest=False, wf_name="groupAnalysis"):
-    """
-    FSL `FEAT <http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT>`_
-    BASED Group Analysis.
+    """Run FSL `FEAT <http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT>`_ BASED Group Analysis.
 
     Parameters
     ----------
@@ -313,7 +328,7 @@ def create_fsl_flame_wf(ftest=False, wf_name="groupAnalysis"):
     # easier interpretation
     label_zstat_imports = ["import os"]
     label_zstat = pe.Node(
-        util.Function(
+        Function(
             input_names=["zstat_list", "con_file"],
             output_names=["new_zstat_list"],
             function=label_zstat_files,
@@ -341,7 +356,7 @@ def create_fsl_flame_wf(ftest=False, wf_name="groupAnalysis"):
 
     # function node to get the operation string for fslmaths command
     get_opstring = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file"], output_names=["out_file"], function=get_operation
         ),
         name="get_opstring",

--- a/CPAC/longitudinal_pipeline/longitudinal_preproc.py
+++ b/CPAC/longitudinal_pipeline/longitudinal_preproc.py
@@ -24,9 +24,9 @@ import os
 import numpy as np
 import nibabel as nib
 from nipype.interfaces import fsl
-import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 from CPAC.utils.monitoring import IFLOGGER
 from CPAC.utils.nifti_utils import nifti_image_input
 
@@ -617,7 +617,7 @@ def subject_specific_template(
     ]
     if method == "flirt":
         template_gen_node = pe.Node(
-            util.Function(
+            Function(
                 input_names=[
                     "input_brain_list",
                     "input_skull_list",

--- a/CPAC/median_angle/median_angle.py
+++ b/CPAC/median_angle/median_angle.py
@@ -1,12 +1,29 @@
+# Copyright (C) 2012-2023  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 
 
 def median_angle_correct(target_angle_deg, realigned_file):
-    """
-    Performs median angle correction on fMRI data.  Median angle correction algorithm
-    based on [1]_.
+    """Perform median angle correction on fMRI data.
+
+    Median angle correction algorithm based on [1]_.
 
     Parameters
     ----------
@@ -89,8 +106,7 @@ def median_angle_correct(target_angle_deg, realigned_file):
 
 
 def calc_median_angle_params(subject):
-    """
-    Calculates median angle parameters of a subject.
+    """Calculate median angle parameters of a subject.
 
     Parameters
     ----------
@@ -133,8 +149,7 @@ def calc_median_angle_params(subject):
 
 def calc_target_angle(mean_bolds, median_angles):
     """
-    Calculates a target angle based on median angle parameters of
-    the group.
+    Calculate a target angle based on median angle parameters of the group.
 
     Parameters
     ----------
@@ -229,7 +244,7 @@ def create_median_angle_correction(name="median_angle_correction"):
     )
 
     mac = pe.Node(
-        util.Function(
+        Function(
             input_names=["target_angle_deg", "realigned_file"],
             output_names=["corrected_file", "angles_file"],
             function=median_angle_correct,
@@ -305,7 +320,7 @@ def create_target_angle(name="target_angle"):
     )
 
     cmap = pe.MapNode(
-        util.Function(
+        Function(
             input_names=["subject"],
             output_names=["mean_bold", "median_angle"],
             function=calc_median_angle_params,
@@ -315,7 +330,7 @@ def create_target_angle(name="target_angle"):
     )
 
     cta = pe.Node(
-        util.Function(
+        Function(
             input_names=["mean_bolds", "median_angles"],
             output_names=["target_angle"],
             function=calc_target_angle,

--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -125,7 +125,7 @@ def erode_mask(name, segmentmap=True):
     ]
 
     eroded_mask = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "roi_mask",
                 "skullstrip_mask",
@@ -156,7 +156,7 @@ def erode_mask(name, segmentmap=True):
         wf.connect(eroded_mask, "output_roi_mask", outputspec, "eroded_mask")
     if segmentmap:
         erosion_segmentmap = pe.Node(
-            util.Function(
+            Function(
                 input_names=["roi_mask", "erosion_mm", "erosion_prop"],
                 output_names=["eroded_roi_mask"],
                 function=erosion,
@@ -1357,7 +1357,7 @@ def create_regressor_workflow(
                         ]
 
                         cosfilter_node = pe.Node(
-                            util.Function(
+                            Function(
                                 input_names=["input_image_path", "timestep"],
                                 output_names=["cosfiltered_img"],
                                 function=cosine_filter,
@@ -1374,7 +1374,7 @@ def create_regressor_workflow(
                             "input_image_path",
                         )
                         tr_string2float_node = pe.Node(
-                            util.Function(
+                            Function(
                                 input_names=["tr"],
                                 output_names=["tr_float"],
                                 function=TR_string_to_float,
@@ -1887,7 +1887,7 @@ def filtering_bold_and_regressors(
         bandpass_ts.inputs.outputtype = "NIFTI_GZ"
 
         tr_string2float_node = pe.Node(
-            util.Function(
+            Function(
                 input_names=["tr"],
                 output_names=["tr_float"],
                 function=TR_string_to_float,
@@ -2418,7 +2418,8 @@ def nuisance_regressors_generation(
     opt: dict,
     space: Literal["T1w", "bold"],
 ) -> tuple[Workflow, dict]:
-    """
+    """Generate nuisance regressors.
+
     Parameters
     ----------
     wf : ~nipype.pipeline.engine.workflows.Workflow

--- a/CPAC/nuisance/utils/utils.py
+++ b/CPAC/nuisance/utils/utils.py
@@ -499,7 +499,7 @@ def generate_summarize_tissue_mask_ventricles_masking(
 
                     # generate inverse transform flags, which depends on the number of transforms
                     inverse_transform_flags = pe.Node(
-                        util.Function(
+                        Function(
                             input_names=["transform_list"],
                             output_names=["inverse_transform_flags"],
                             function=generate_inverse_transform_flags,

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -19,13 +19,12 @@ import copy
 import hashlib
 from itertools import chain
 import json
-import logging
 import os
 import re
 from typing import Optional
 import warnings
 
-from nipype import config
+from nipype import config, logging
 from nipype.interfaces.utility import Rename
 
 from CPAC.image_utils.spatial_smoothing import spatial_smoothing

--- a/CPAC/randomise/randomise.py
+++ b/CPAC/randomise/randomise.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 from CPAC.utils.monitoring import IFLOGGER
 
 
@@ -53,7 +54,6 @@ def prep_randomise_workflow(
 ):
     from nipype.interfaces import fsl
     import nipype.interfaces.io as nio
-    import nipype.interfaces.utility as util
 
     wf = pe.Workflow(name="randomise_workflow")
     wf.base_dir = c.work_dir
@@ -74,7 +74,7 @@ def prep_randomise_workflow(
         randomise.inputs.fcon = fts_file
 
     select_tcorrp_files = pe.Node(
-        util.Function(
+        Function(
             input_names=["input_list"], output_names=["out_file"], function=select
         ),
         name="select_t_corrp",
@@ -83,7 +83,7 @@ def prep_randomise_workflow(
     wf.connect(randomise, "t_corrected_p_files", select_tcorrp_files, "input_list")
 
     select_tstat_files = pe.Node(
-        util.Function(
+        Function(
             input_names=["input_list"], output_names=["out_file"], function=select
         ),
         name="select_t_stat",
@@ -147,6 +147,10 @@ def run(group_config_path):
     import os
 
     from CPAC.pipeline.cpac_group_runner import load_config_yml
+    from CPAC.pipeline.cpac_randomise_pipeline import (
+        randomise_merged_file,
+        randomise_merged_mask,
+    )
 
     group_config_obj = load_config_yml(group_config_path)
     pipeline_output_folder = group_config_obj.pipeline_dir

--- a/CPAC/registration/output_func_to_standard.py
+++ b/CPAC/registration/output_func_to_standard.py
@@ -374,7 +374,7 @@ def ants_apply_warps_func_mni(
 
         itk_imports = ["import os"]
         change_transform = pe.Node(
-            util.Function(
+            Function(
                 input_names=["input_affine_file"],
                 output_names=["updated_affine_file"],
                 function=change_itk_transform_type,
@@ -534,7 +534,7 @@ def ants_apply_warps_func_mni(
 
         # check transform list (if missing any init/rig/affine) and exclude Nonetype
         check_transform = pe.Node(
-            util.Function(
+            Function(
                 input_names=["transform_list"],
                 output_names=["checked_transform_list", "list_length"],
                 function=check_transforms,
@@ -546,7 +546,7 @@ def ants_apply_warps_func_mni(
 
         # generate inverse transform flags, which depends on the number of transforms
         inverse_transform_flags = pe.Node(
-            util.Function(
+            Function(
                 input_names=["transform_list"],
                 output_names=["inverse_transform_flags"],
                 function=generate_inverse_transform_flags,

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -39,6 +39,7 @@ from CPAC.registration.utils import (
     seperate_warps_list,
     single_ants_xfm_to_list,
 )
+from CPAC.utils.interfaces import Function
 from CPAC.utils.interfaces.fsl import Merge as fslMerge
 from CPAC.utils.utils import check_prov_for_motion_tool, check_prov_for_regtool
 
@@ -104,7 +105,7 @@ def apply_transform(
         wf.connect(inputNode, "reference", apply_warp, "reference_image")
 
         interp_string = pe.Node(
-            util.Function(
+            Function(
                 input_names=["interpolation", "reg_tool"],
                 output_names=["interpolation"],
                 function=interpolation_string,
@@ -118,7 +119,7 @@ def apply_transform(
         wf.connect(interp_string, "interpolation", apply_warp, "interpolation")
 
         ants_xfm_list = pe.Node(
-            util.Function(
+            Function(
                 input_names=["transform"],
                 output_names=["transform_list"],
                 function=single_ants_xfm_to_list,
@@ -135,7 +136,7 @@ def apply_transform(
         if int(num_cpus) > 1 and time_series:
             chunk_imports = ["import nibabel as nib"]
             chunk = pe.Node(
-                util.Function(
+                Function(
                     input_names=["func_file", "n_chunks", "chunk_size"],
                     output_names=["TR_ranges"],
                     function=chunk_ts,
@@ -154,7 +155,7 @@ def apply_transform(
 
             split_imports = ["import os", "import subprocess"]
             split = pe.Node(
-                util.Function(
+                Function(
                     input_names=["func_file", "tr_ranges"],
                     output_names=["split_funcs"],
                     function=split_ts_chunks,
@@ -196,7 +197,7 @@ def apply_transform(
             )
 
         interp_string = pe.Node(
-            util.Function(
+            Function(
                 input_names=["interpolation", "reg_tool"],
                 output_names=["interpolation"],
                 function=interpolation_string,
@@ -222,7 +223,7 @@ def apply_transform(
         if int(num_cpus) > 1 and time_series:
             chunk_imports = ["import nibabel as nib"]
             chunk = pe.Node(
-                util.Function(
+                Function(
                     input_names=["func_file", "n_chunks", "chunk_size"],
                     output_names=["TR_ranges"],
                     function=chunk_ts,
@@ -241,7 +242,7 @@ def apply_transform(
 
             split_imports = ["import os", "import subprocess"]
             split = pe.Node(
-                util.Function(
+                Function(
                     input_names=["func_file", "tr_ranges"],
                     output_names=["split_funcs"],
                     function=split_ts_chunks,
@@ -761,7 +762,7 @@ def create_register_func_to_anat(
 
     if phase_diff_distcor:
         conv_pedir = pe.Node(
-            interface=util.Function(
+            interface=Function(
                 input_names=["pedir", "convert"],
                 output_names=["pedir"],
                 function=convert_pedir,
@@ -1067,7 +1068,7 @@ def create_bbregister_func_to_anat(
 
     if phase_diff_distcor:
         conv_pedir = pe.Node(
-            interface=util.Function(
+            interface=Function(
                 input_names=["pedir", "convert"],
                 output_names=["pedir"],
                 function=convert_pedir,
@@ -1276,7 +1277,7 @@ def create_wf_calculate_ants_warp(
     """
     reg_imports = ["import os", "import subprocess"]
     calculate_ants_warp = pe.Node(
-        interface=util.Function(
+        interface=Function(
             input_names=[
                 "moving_brain",
                 "reference_brain",
@@ -1302,7 +1303,7 @@ def create_wf_calculate_ants_warp(
     calculate_ants_warp.interface.num_threads = num_threads
 
     select_forward_initial = pe.Node(
-        util.Function(
+        Function(
             input_names=["warp_list", "selection"],
             output_names=["selected_warp"],
             function=seperate_warps_list,
@@ -1313,7 +1314,7 @@ def create_wf_calculate_ants_warp(
     select_forward_initial.inputs.selection = "Initial"
 
     select_forward_rigid = pe.Node(
-        util.Function(
+        Function(
             input_names=["warp_list", "selection"],
             output_names=["selected_warp"],
             function=seperate_warps_list,
@@ -1324,7 +1325,7 @@ def create_wf_calculate_ants_warp(
     select_forward_rigid.inputs.selection = "Rigid"
 
     select_forward_affine = pe.Node(
-        util.Function(
+        Function(
             input_names=["warp_list", "selection"],
             output_names=["selected_warp"],
             function=seperate_warps_list,
@@ -1335,7 +1336,7 @@ def create_wf_calculate_ants_warp(
     select_forward_affine.inputs.selection = "Affine"
 
     select_forward_warp = pe.Node(
-        util.Function(
+        Function(
             input_names=["warp_list", "selection"],
             output_names=["selected_warp"],
             function=seperate_warps_list,
@@ -1346,7 +1347,7 @@ def create_wf_calculate_ants_warp(
     select_forward_warp.inputs.selection = "Warp"
 
     select_inverse_warp = pe.Node(
-        util.Function(
+        Function(
             input_names=["warp_list", "selection"],
             output_names=["selected_warp"],
             function=seperate_warps_list,
@@ -1788,7 +1789,7 @@ def ANTs_registration_connector(
 
     # check transform list to exclude Nonetype (missing) init/rig/affine
     check_transform = pe.Node(
-        util.Function(
+        Function(
             input_names=["transform_list"],
             output_names=["checked_transform_list", "list_length"],
             function=check_transforms,
@@ -1851,7 +1852,7 @@ def ANTs_registration_connector(
 
     # check transform list to exclude Nonetype (missing) init/rig/affine
     check_invlinear_transform = pe.Node(
-        util.Function(
+        Function(
             input_names=["transform_list"],
             output_names=["checked_transform_list", "list_length"],
             function=check_transforms,
@@ -1873,7 +1874,7 @@ def ANTs_registration_connector(
     # generate inverse transform flags, which depends on the
     # number of transforms
     inverse_transform_flags = pe.Node(
-        util.Function(
+        Function(
             input_names=["transform_list"],
             output_names=["inverse_transform_flags"],
             function=generate_inverse_transform_flags,
@@ -1935,7 +1936,7 @@ def ANTs_registration_connector(
 
     # check transform list to exclude Nonetype (missing) init/rig/affine
     check_all_transform = pe.Node(
-        util.Function(
+        Function(
             input_names=["transform_list"],
             output_names=["checked_transform_list", "list_length"],
             function=check_transforms,
@@ -2004,7 +2005,7 @@ def ANTs_registration_connector(
 
     # check transform list to exclude Nonetype (missing) init/rig/affine
     check_all_inv_transform = pe.Node(
-        util.Function(
+        Function(
             input_names=["transform_list"],
             output_names=["checked_transform_list", "list_length"],
             function=check_transforms,
@@ -2026,7 +2027,7 @@ def ANTs_registration_connector(
     # generate inverse transform flags, which depends on the
     # number of transforms
     inverse_all_transform_flags = pe.Node(
-        util.Function(
+        Function(
             input_names=["transform_list"],
             output_names=["inverse_transform_flags"],
             function=generate_inverse_transform_flags,
@@ -2122,7 +2123,7 @@ def bold_to_T1template_xfm_connector(
 
         itk_imports = ["import os"]
         change_transform = pe.Node(
-            util.Function(
+            Function(
                 input_names=["input_affine_file"],
                 output_names=["updated_affine_file"],
                 function=change_itk_transform_type,
@@ -2964,7 +2965,7 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
         # c4d -mcs ${WD}/xfms/ANTs_CombinedWarp.nii.gz -oo ${WD}/xfms/e1.nii.gz ${WD}/xfms/e2.nii.gz ${WD}/xfms/e3.nii.gz
         # -mcs: -multicomponent-split, -oo: -output-multiple
         split_combined_warp = pe.Node(
-            util.Function(
+            Function(
                 input_names=["input_name", "output_name"],
                 output_names=["output1", "output2", "output3"],
                 function=run_c4d,
@@ -2982,7 +2983,7 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
 
         # c4d -mcs ${WD}/xfms/ANTs_CombinedInvWarp.nii.gz -oo ${WD}/xfms/e1inv.nii.gz ${WD}/xfms/e2inv.nii.gz ${WD}/xfms/e3inv.nii.gz
         split_combined_inv_warp = pe.Node(
-            util.Function(
+            Function(
                 input_names=["input_name", "output_name"],
                 output_names=["output1", "output2", "output3"],
                 function=run_c4d,
@@ -3678,7 +3679,7 @@ def apply_phasediff_to_timeseries_separately(wf, cfg, strat_pool, pipe_num, opt=
     wf.connect(warp_fmap, "out_file", mask_fmap, "in_file")
 
     conv_pedir = pe.Node(
-        interface=util.Function(
+        interface=Function(
             input_names=["pedir", "convert"],
             output_names=["pedir"],
             function=convert_pedir,
@@ -4819,7 +4820,7 @@ def single_step_resample_timeseries_to_T1template(
     reg_tool = check_prov_for_regtool(xfm_prov)
 
     bbr2itk = pe.Node(
-        util.Function(
+        Function(
             input_names=["reference_file", "source_file", "transform_file"],
             output_names=["itk_transform"],
             function=run_c3d,
@@ -4860,7 +4861,7 @@ def single_step_resample_timeseries_to_T1template(
 
     ### Loop starts! ###
     motionxfm2itk = pe.MapNode(
-        util.Function(
+        Function(
             input_names=["reference_file", "source_file", "transform_file"],
             output_names=["itk_transform"],
             function=run_c3d,
@@ -4881,7 +4882,7 @@ def single_step_resample_timeseries_to_T1template(
         wf.connect(node, out, motionxfm2itk, "transform_file")
     elif motion_correct_tool == "3dvolreg":
         convert_transform = pe.Node(
-            util.Function(
+            Function(
                 input_names=["one_d_filename"],
                 output_names=["transform_directory"],
                 function=one_d_to_mat,

--- a/CPAC/reho/reho.py
+++ b/CPAC/reho/reho.py
@@ -1,9 +1,26 @@
 # coding: utf-8
+# Copyright (C) 2012-2024  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.pipeline.nodeblock import nodeblock
 from CPAC.reho.utils import *
+from CPAC.utils.interfaces import Function
 
 
 def create_reho(wf_name):
@@ -99,7 +116,7 @@ def create_reho(wf_name):
         "from CPAC.reho.utils import f_kendall",
     ]
     raw_reho_map = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file", "mask_file", "cluster_size"],
             output_names=["out_file"],
             function=compute_reho,

--- a/CPAC/sca/sca.py
+++ b/CPAC/sca/sca.py
@@ -30,11 +30,15 @@ from CPAC.utils.datasource import (
     create_spatial_map_dataflow,
     resample_func_roi,
 )
+from CPAC.utils.interfaces import Function
 
 
 def create_sca(name_sca="sca"):
     """
-    Map of the correlations of the Region of Interest(Seed in native or MNI space) with the rest of brain voxels.
+    Create map of the correlations of the Region of Interest with the rest of brain voxels.
+
+    (Seed in native or MNI space)
+
     The map is normalized to contain Z-scores, mapped in standard space and treated with spatial smoothing.
 
     Parameters
@@ -150,8 +154,8 @@ def create_sca(name_sca="sca"):
 
 
 def create_temporal_reg(wflow_name="temporal_reg", which="SR"):
-    r"""
-    Temporal multiple regression workflow
+    r"""Create temporal multiple regression workflow.
+
     Provides a spatial map of parameter estimates corresponding to each
     provided timeseries in a timeseries.txt file as regressors.
 
@@ -280,9 +284,7 @@ def create_temporal_reg(wflow_name="temporal_reg", which="SR"):
     )
 
     check_timeseries = pe.Node(
-        util.Function(
-            input_names=["in_file"], output_names=["out_file"], function=check_ts
-        ),
+        Function(input_names=["in_file"], output_names=["out_file"], function=check_ts),
         name="check_timeseries",
     )
 
@@ -325,7 +327,7 @@ def create_temporal_reg(wflow_name="temporal_reg", which="SR"):
         map_roi_imports = ['import os', 'import numpy as np']
 
         # get roi order and send to output node for raw outputs
-        get_roi_order = pe.Node(util.Function(input_names=['maps',
+        get_roi_order = pe.Node(Function(input_names=['maps',
                                                            'timeseries'],
                                               output_names=['labels',
                                                             'maps'],
@@ -350,7 +352,7 @@ def create_temporal_reg(wflow_name="temporal_reg", which="SR"):
                       outputNode, 'temp_reg_map_files')
 
         # get roi order and send to output node for z-stat outputs
-        get_roi_order_zstat = pe.Node(util.Function(input_names=['maps',
+        get_roi_order_zstat = pe.Node(Function(input_names=['maps',
                                                            'timeseries'],
                                                     output_names=['labels',
                                                                   'maps'],
@@ -396,7 +398,7 @@ def SCA_AVG(wf, cfg, strat_pool, pipe_num, opt=None):
     # same workflow, except to run TSE and send it to the resource
     # pool so that it will not get sent to SCA
     resample_functional_roi_for_sca = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_func", "in_roi", "realignment", "identity_matrix"],
             output_names=["out_func", "out_roi"],
             function=resample_func_roi,

--- a/CPAC/scrubbing/scrubbing.py
+++ b/CPAC/scrubbing/scrubbing.py
@@ -1,13 +1,29 @@
+# Copyright (C) 2012-2023  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
+from CPAC.utils.interfaces import Function
 
 
 def create_scrubbing_preproc(wf_name="scrubbing"):
-    """
-    This workflow essentially takes the list of offending timepoints that are to be removed
-    and removes it from the motion corrected input image. Also, it removes the information
-    of discarded time points from the movement parameters file obtained during motion correction.
+    """Take the list of offending timepoints that are to be removed and remove it from the motion corrected input image.
+
+    Also remove the information of discarded time points from the movement parameters file obtained during motion correction.
 
     Parameters
     ----------
@@ -94,7 +110,7 @@ def create_scrubbing_preproc(wf_name="scrubbing"):
     )
 
     craft_scrub_input = pe.Node(
-        util.Function(
+        Function(
             input_names=["scrub_input", "frames_in_1D_file"],
             output_names=["scrub_input_string"],
             function=get_indx,
@@ -103,7 +119,7 @@ def create_scrubbing_preproc(wf_name="scrubbing"):
     )
 
     scrubbed_movement_parameters = pe.Node(
-        util.Function(
+        Function(
             input_names=["infile_a", "infile_b"],
             output_names=["out_file"],
             function=get_mov_parameters,
@@ -120,7 +136,7 @@ def create_scrubbing_preproc(wf_name="scrubbing"):
     # scrubbed_preprocessed.inputs.outputtype = 'NIFTI_GZ'
 
     scrubbed_preprocessed = pe.Node(
-        util.Function(
+        Function(
             input_names=["scrub_input"],
             output_names=["scrubbed_image"],
             function=scrub_image,
@@ -152,9 +168,8 @@ def create_scrubbing_preproc(wf_name="scrubbing"):
 
 
 def get_mov_parameters(infile_a, infile_b):
-    """
-    Method to get the new movement parameters
-    file after removing the offending time frames
+    """Get the new movement parameters file after removing the offending time frames.
+
     (i.e., those exceeding FD 0.5mm/0.2mm threshold).
 
     Parameters
@@ -192,7 +207,7 @@ def get_mov_parameters(infile_a, infile_b):
         raise Exception(msg)
 
     f = open(out_file, "a")
-    for l in l1:
+    for l in l1:  # noqa: E741
         data = l2[int(l.strip())]
         f.write(data)
     f.close()
@@ -200,9 +215,7 @@ def get_mov_parameters(infile_a, infile_b):
 
 
 def get_indx(scrub_input, frames_in_1D_file):
-    """
-    Method to get the list of time
-    frames that are to be included.
+    """Get the list of time frames that are to be included.
 
     Parameters
     ----------
@@ -230,10 +243,10 @@ def get_indx(scrub_input, frames_in_1D_file):
 
 
 def scrub_image(scrub_input):
-    """
-    Method to run 3dcalc in order to scrub the image. This is used instead of
-    the Nipype interface for 3dcalc because functionality is needed for
-    specifying an input file with specifically-selected volumes. For example:
+    """Run 3dcalc in order to scrub the image.
+
+    This is used instead of the Nipype interface for 3dcalc because functionality is
+    needed for specifying an input file with specifically-selected volumes. For example:
         input.nii.gz[2,3,4,..98], etc.
 
     Parameters

--- a/CPAC/seg_preproc/seg_preproc.py
+++ b/CPAC/seg_preproc/seg_preproc.py
@@ -1,3 +1,19 @@
+# Copyright (C) 2012-2023  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 from nipype.interfaces import ants, freesurfer, fsl, utility as util
 from nipype.interfaces.utility import Function
 
@@ -23,10 +39,10 @@ from CPAC.utils.utils import check_prov_for_regtool
 
 
 def process_segment_map(wf_name, use_priors, use_custom_threshold, reg_tool):
-    """This is a sub workflow used inside segmentation workflow to process
-    probability maps obtained in segmentation. Steps include overlapping
-    of the prior tissue with probability maps, thresholding and binarizing
-    it and creating a mask that is used in further analysis.
+    """Create a sub workflow used inside segmentation workflow to process probability maps obtained in segmentation.
+
+    Steps include overlapping of the prior tissue with probability maps, thresholding
+    and binarizing it and creating a mask that is used in further analysis.
 
     Parameters
     ----------
@@ -274,7 +290,7 @@ def tissue_mask_template_to_t1(wf_name, use_ants):
 
         # check transform list to exclude Nonetype (missing) init/rig/affine
         check_transform = pe.Node(
-            util.Function(
+            Function(
                 input_names=["transform_list"],
                 output_names=["checked_transform_list", "list_length"],
                 function=check_transforms,
@@ -289,7 +305,7 @@ def tissue_mask_template_to_t1(wf_name, use_ants):
         # generate inverse transform flags, which depends on the
         # number of transforms
         inverse_transform_flags = pe.Node(
-            util.Function(
+            Function(
                 input_names=["transform_list"],
                 output_names=["inverse_transform_flags"],
                 function=generate_inverse_transform_flags,
@@ -356,9 +372,7 @@ def tissue_mask_template_to_t1(wf_name, use_ants):
 
 
 def create_seg_preproc_antsJointLabel_method(wf_name="seg_preproc_templated_based"):
-    """
-    Generate the subject's cerebral spinal fluids,
-    white matter and gray matter mask based on provided template, if selected to do so.
+    """Generate the subject's cerebral spinal fluids, white matter and gray matter mask based on provided template, if selected to do so.
 
     Parameters
     ----------
@@ -417,7 +431,7 @@ def create_seg_preproc_antsJointLabel_method(wf_name="seg_preproc_templated_base
     )
 
     seg_preproc_antsJointLabel = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "anatomical_brain",
                 "anatomical_brain_mask",
@@ -700,7 +714,7 @@ def tissue_seg_fsl_fast(wf, cfg, strat_pool, pipe_num, opt=None):
     )
 
     get_csf = pe.Node(
-        util.Function(
+        Function(
             input_names=["probability_maps"],
             output_names=["filename"],
             function=pick_wm_prob_0,
@@ -945,7 +959,7 @@ def tissue_seg_freesurfer(wf, cfg, strat_pool, pipe_num, opt=None):
     wf.connect(node, out, fs_aseg_to_native, "target_file")
 
     fs_aseg_to_nifti = pe.Node(
-        util.Function(
+        Function(
             input_names=["in_file"], output_names=["out_file"], function=mri_convert
         ),
         name=f"fs_aseg_to_nifti_{pipe_num}",

--- a/CPAC/surface/surf_preproc.py
+++ b/CPAC/surface/surf_preproc.py
@@ -1,10 +1,25 @@
-import os
+# Copyright (C) 2021-2023  C-PAC Developers
 
-import nipype.interfaces.utility as util
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+import os
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.pipeline.nodeblock import nodeblock
 from CPAC.surface.PostFreeSurfer.surf_reho import run_surf_reho
+from CPAC.utils.interfaces import Function
 
 
 def run_surface(
@@ -1026,7 +1041,7 @@ def run_surface(
 )
 def surface_postproc(wf, cfg, strat_pool, pipe_num, opt=None):
     surf = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "post_freesurfer_folder",
                 "freesurfer_folder",
@@ -1369,7 +1384,7 @@ def surface_postproc(wf, cfg, strat_pool, pipe_num, opt=None):
 )
 def surface_falff(wf, cfg, strat_pool, pipe_num, opt):
     falff = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "dtseries"],
             output_names=["surf_falff"],
             function=run_surf_falff,
@@ -1394,7 +1409,7 @@ def surface_falff(wf, cfg, strat_pool, pipe_num, opt):
 )
 def surface_alff(wf, cfg, strat_pool, pipe_num, opt):
     alff = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "dtseries"],
             output_names=["surf_alff"],
             function=run_surf_alff,
@@ -1427,7 +1442,7 @@ def surface_alff(wf, cfg, strat_pool, pipe_num, opt):
 )
 def surface_reho(wf, cfg, strat_pool, pipe_num, opt):
     L_cortex_file = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "dtseries", "structure", "cortex_filename"],
             output_names=["L_cortex_file"],
             function=run_get_cortex,
@@ -1442,7 +1457,7 @@ def surface_reho(wf, cfg, strat_pool, pipe_num, opt):
     wf.connect(node, out, L_cortex_file, "dtseries")
 
     R_cortex_file = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "dtseries", "structure", "cortex_filename"],
             output_names=["R_cortex_file"],
             function=run_get_cortex,
@@ -1456,7 +1471,7 @@ def surface_reho(wf, cfg, strat_pool, pipe_num, opt):
     wf.connect(node, out, R_cortex_file, "dtseries")
 
     mean_timeseries = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "dtseries"],
             output_names=["mean_timeseries"],
             function=run_mean_timeseries,
@@ -1468,7 +1483,7 @@ def surface_reho(wf, cfg, strat_pool, pipe_num, opt):
     wf.connect(node, out, mean_timeseries, "dtseries")
 
     L_reho = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "subject",
                 "dtseries",
@@ -1499,7 +1514,7 @@ def surface_reho(wf, cfg, strat_pool, pipe_num, opt):
     wf.connect(node, out, L_reho, "dtseries")
 
     R_reho = pe.Node(
-        util.Function(
+        Function(
             input_names=[
                 "subject",
                 "dtseries",
@@ -1545,7 +1560,7 @@ def surface_reho(wf, cfg, strat_pool, pipe_num, opt):
 )
 def surface_connectivity_matrix(wf, cfg, strat_pool, pipe_num, opt):
     connectivity_parcellation = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "dtseries", "surf_atlaslabel"],
             output_names=["parcellation_file"],
             function=run_ciftiparcellate,
@@ -1561,7 +1576,7 @@ def surface_connectivity_matrix(wf, cfg, strat_pool, pipe_num, opt):
     ]["surface_parcellation_template"]
 
     correlation_matrix = pe.Node(
-        util.Function(
+        Function(
             input_names=["subject", "ptseries"],
             output_names=["correlation_matrix"],
             function=run_cifticorrelation,

--- a/CPAC/timeseries/timeseries_analysis.py
+++ b/CPAC/timeseries/timeseries_analysis.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 from nipype.interfaces import afni, fsl, utility as util
-from nipype.interfaces.utility import Function
 
 from CPAC.connectome.connectivity_matrix import (
     create_connectome_afni,
@@ -29,6 +28,7 @@ from CPAC.utils.datasource import (
     create_spatial_map_dataflow,
     resample_func_roi,
 )
+from CPAC.utils.interfaces import Function
 from CPAC.utils.monitoring import FMLOGGER
 
 
@@ -86,7 +86,7 @@ def get_voxel_timeseries(wf_name: str = "voxel_timeseries") -> pe.Workflow:
     )
 
     timeseries_voxel = pe.Node(
-        util.Function(
+        Function(
             input_names=["data_file", "template"],
             output_names=["oneD_file"],
             function=gen_voxel_timeseries,
@@ -241,7 +241,7 @@ def get_roi_timeseries(wf_name: str = "roi_timeseries") -> pe.Workflow:
 
     clean_csv_imports = ["import os"]
     clean_csv = pe.Node(
-        util.Function(
+        Function(
             input_names=["roi_csv"],
             output_names=["roi_array", "edited_roi_csv"],
             function=clean_roi_csv,
@@ -382,7 +382,7 @@ def get_vertices_timeseries(wf_name="vertices_timeseries"):
     )
 
     timeseries_surface = pe.Node(
-        util.Function(
+        Function(
             input_names=["rh_surface_file", "lh_surface_file"],
             output_names=["out_file"],
             function=gen_vertices_timeseries,

--- a/CPAC/utils/datasource.py
+++ b/CPAC/utils/datasource.py
@@ -730,7 +730,6 @@ def ingress_func_metadata(
                 "effective_echo_spacing",
             ],
             function=get_scan_params,
-            imports=["from CPAC.utils.utils import check, try_fetch_parameter"],
         ),
         name=f"bold_scan_params_{subject_id}{name_suffix}",
     )

--- a/CPAC/utils/interfaces/__init__.py
+++ b/CPAC/utils/interfaces/__init__.py
@@ -1,7 +1,27 @@
+# Copyright (C) 2010-2024  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""Custom interfaces for C-PAC."""
+
 from . import brickstat, datasink, function, pc
+from .function import Function
 
 __all__ = [
     "function",
+    "Function",
     "pc",
     "brickstat",
     "datasink",

--- a/CPAC/utils/interfaces/function/seg_preproc.py
+++ b/CPAC/utils/interfaces/function/seg_preproc.py
@@ -1,11 +1,26 @@
+# Copyright (C) 2022-2023  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Function interfaces for seg_preproc."""
 
-from nipype.interfaces import utility as util
+from CPAC.utils.interfaces import Function
 
 
 def pick_tissue_from_labels_file_interface(input_names=None):
-    """Function to create a Function interface for
-    CPAC.seg_preproc.utils.pick_tissue_from_labels_file.
+    """Create a Function interface for ~CPAC.seg_preproc.utils.pick_tissue_from_labels_file.
 
     Parameters
     ----------
@@ -20,7 +35,7 @@ def pick_tissue_from_labels_file_interface(input_names=None):
 
     if input_names is None:
         input_names = ["multiatlas_Labels", "csf_label", "gm_label", "wm_label"]
-    return util.Function(
+    return Function(
         input_names=input_names,
         output_names=["csf_mask", "gm_mask", "wm_mask"],
         function=pick_tissue_from_labels_file,

--- a/CPAC/utils/interfaces/function/seg_preproc.py
+++ b/CPAC/utils/interfaces/function/seg_preproc.py
@@ -16,7 +16,7 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Function interfaces for seg_preproc."""
 
-from CPAC.utils.interfaces import Function
+from CPAC.utils.interfaces.function.function import Function
 
 
 def pick_tissue_from_labels_file_interface(input_names=None):

--- a/CPAC/utils/tests/old_functions.py
+++ b/CPAC/utils/tests/old_functions.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2012-2024  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""Functions from before refactoring."""
+
+
+def check(params_dct, subject_id, scan_id, val_to_check, throw_exception):
+    """https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L630-L653"""
+    if val_to_check not in params_dct:
+        if throw_exception:
+            raise Exception(
+                f"Missing Value for {val_to_check} for participant " f"{subject_id}"
+            )
+        return None
+    if isinstance(params_dct[val_to_check], dict):
+        ret_val = params_dct[val_to_check][scan_id]
+    else:
+        ret_val = params_dct[val_to_check]
+    if ret_val == "None":
+        if throw_exception:
+            raise Exception(
+                f"'None' Parameter Value for {val_to_check} for participant "
+                f"{subject_id}"
+            )
+        else:
+            ret_val = None
+    if ret_val == "" and throw_exception:
+        raise Exception(
+            f"Missing Value for {val_to_check} for participant " f"{subject_id}"
+        )
+    return ret_val
+
+
+def check2(val):
+    """https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L745-L746"""
+    return val if val == None or val == "" or isinstance(val, str) else int(val)
+
+
+def try_fetch_parameter(scan_parameters, subject, scan, keys):
+    """https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L679-L703"""
+    scan_parameters = dict((k.lower(), v) for k, v in scan_parameters.items())
+    for key in keys:
+        key = key.lower()
+        if key not in scan_parameters:
+            continue
+        if isinstance(scan_parameters[key], dict):
+            value = scan_parameters[key][scan]
+        else:
+            value = scan_parameters[key]
+        if value == "None":
+            return None
+        if value is not None:
+            return value
+    return None

--- a/CPAC/utils/tests/test_datasource.py
+++ b/CPAC/utils/tests/test_datasource.py
@@ -1,10 +1,26 @@
+# Copyright (C) 2019-2024  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 import json
 
 import pytest
-import nipype.interfaces.utility as util
 
 from CPAC.pipeline import nipype_pipeline_engine as pe
 from CPAC.utils.datasource import match_epi_fmaps
+from CPAC.utils.interfaces import Function
 from CPAC.utils.test_resources import setup_test_wf
 
 
@@ -48,7 +64,7 @@ def test_match_epi_fmaps():
     }
 
     match_fmaps = pe.Node(
-        util.Function(
+        Function(
             input_names=["fmap_dct", "bold_pedir"],
             output_names=["opposite_pe_epi", "same_pe_epi"],
             function=match_epi_fmaps,

--- a/CPAC/utils/tests/test_utils.py
+++ b/CPAC/utils/tests/test_utils.py
@@ -13,7 +13,7 @@ from CPAC.utils.monitoring.custom_logging import log_subprocess
 from CPAC.utils.utils import (
     check_config_resources,
     check_system_deps,
-    fetch_and_convert,
+    ScanParameters,
 )
 
 SCAN_PARAMS = {
@@ -84,10 +84,8 @@ def test_fetch_and_convert(
     caplog: LogCaptureFixture, scan_params: str, convert_to: type
 ) -> None:
     """Test functionality to fetch and convert scan parameters."""
-    params = SCAN_PARAMS[scan_params]["params"]
-    TR = fetch_and_convert(
-        scan_parameters=params,
-        scan="scan",
+    params = ScanParameters(SCAN_PARAMS[scan_params]["params"], "subject", "scan")
+    TR = params.fetch_and_convert(
         keys=["TR", "RepetitionTime"],
         convert_to=convert_to,
     )
@@ -98,9 +96,7 @@ def test_fetch_and_convert(
         assert "Using case-insenitive match: 'TR' ≅ 'tr'." in caplog.text
     else:
         assert "Using case-insenitive match: 'TR' ≅ 'tr'." not in caplog.text
-    not_TR = fetch_and_convert(
-        scan_parameters=params,
-        scan="scan",
+    not_TR = params.fetch_and_convert(
         keys=["NotTR", "NotRepetitionTime"],
         convert_to=convert_to,
     )

--- a/CPAC/utils/tests/test_utils.py
+++ b/CPAC/utils/tests/test_utils.py
@@ -3,6 +3,7 @@
 import multiprocessing
 from unittest import mock
 
+from _pytest.logging import LogCaptureFixture
 import pytest
 
 from CPAC.func_preproc import get_motion_ref
@@ -12,26 +13,33 @@ from CPAC.utils.monitoring.custom_logging import log_subprocess
 from CPAC.utils.utils import (
     check_config_resources,
     check_system_deps,
-    try_fetch_parameter,
+    fetch_and_convert,
 )
 
-scan_params_bids = {
-    "RepetitionTime": 2.0,
-    "ScanOptions": "FS",
-    "SliceAcquisitionOrder": "Interleaved Ascending",
-}
-scan_params_cpac = {
-    "tr": 2.5,
-    "acquisition": "seq+z",
-    "reference": "24",
-    "first_tr": "",
-    "last_tr": "",
+SCAN_PARAMS = {
+    "BIDS": {
+        "params": {
+            "RepetitionTime": 2.0,
+            "ScanOptions": "FS",
+            "SliceAcquisitionOrder": "Interleaved Ascending",
+        },
+        "expected_TR": 2.0,
+    },
+    "C-PAC": {
+        "params": {
+            "tr": 2.5,
+            "acquisition": "seq+z",
+            "reference": "24",
+            "first_tr": "",
+            "last_tr": "",
+        },
+        "expected_TR": 2.5,
+    },
 }
 
 
 def _installation_check(command: str, flag: str) -> None:
-    """Test that command is installed by running specified version or
-    help flag.
+    """Test that command is installed by running specified version or help flag.
 
     Parameters
     ----------
@@ -56,9 +64,10 @@ def _installation_check(command: str, flag: str) -> None:
 
 def test_check_config_resources():
     """Test check_config_resources function."""
-    with mock.patch.object(multiprocessing, "cpu_count", return_value=2), pytest.raises(
-        SystemError
-    ) as system_error:
+    with (
+        mock.patch.object(multiprocessing, "cpu_count", return_value=2),
+        pytest.raises(SystemError) as system_error,
+    ):
         check_config_resources(
             Configuration(
                 {"pipeline_setup": {"system_config": {"max_cores_per_participant": 10}}}
@@ -69,12 +78,33 @@ def test_check_config_resources():
     assert "threads available (2)" in error_string
 
 
-def test_function():
-    TR = try_fetch_parameter(scan_params_bids, "0001", "scan", ["TR", "RepetitionTime"])
-    assert TR == 2.0
-
-    TR = try_fetch_parameter(scan_params_cpac, "0001", "scan", ["TR", "RepetitionTime"])
-    assert TR == 2.5
+@pytest.mark.parametrize("scan_params", ["BIDS", "C-PAC"])
+@pytest.mark.parametrize("convert_to", [int, float, str])
+def test_fetch_and_convert(
+    caplog: LogCaptureFixture, scan_params: str, convert_to: type
+) -> None:
+    """Test functionality to fetch and convert scan parameters."""
+    params = SCAN_PARAMS[scan_params]["params"]
+    TR = fetch_and_convert(
+        scan_parameters=params,
+        scan="scan",
+        keys=["TR", "RepetitionTime"],
+        convert_to=convert_to,
+    )
+    assert (TR == convert_to(SCAN_PARAMS[scan_params]["expected_TR"])) and isinstance(
+        TR, convert_to
+    )
+    if scan_params == "C-PAC":
+        assert "Using case-insenitive match: 'TR' ≅ 'tr'." in caplog.text
+    else:
+        assert "Using case-insenitive match: 'TR' ≅ 'tr'." not in caplog.text
+    not_TR = fetch_and_convert(
+        scan_parameters=params,
+        scan="scan",
+        keys=["NotTR", "NotRepetitionTime"],
+        convert_to=convert_to,
+    )
+    assert not_TR is None
 
 
 @pytest.mark.parametrize("executable", ["Xvfb"])
@@ -96,6 +126,7 @@ def test_NodeBlock_option_SSOT():  # pylint: disable=invalid-name
 
 def test_system_deps():
     """Test system dependencies.
+
     Raises an exception if dependencies are not met.
     """
     check_system_deps(*([True] * 4))

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -808,10 +808,7 @@ def get_scan_params(
     effective_echo_spacing
         https://bids-specification.readthedocs.io/en/stable/glossary.html#effectiveechospacing-metadata
     """
-    # initialize vars to empty
-    tr = pattern = ref_slice = first_tr = last_tr = pe_direction = ""
     unit: Literal["ms", "s"] = "s"
-    effective_echo_spacing = template = None
 
     if isinstance(pipeconfig_stop_indx, str):
         if "End" in pipeconfig_stop_indx or "end" in pipeconfig_stop_indx:

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -921,18 +921,18 @@ def get_scan_params(
         # if slice timing in ms convert tr to ms as well
         if tr and max_slice_offset > tr:
             WFLOGGER.warning(
-                "tr is in seconds and slice timings are in "
-                "milliseconds. Converting tr into milliseconds"
+                "TR is in seconds and slice timings are in "
+                "milliseconds. Converting TR into milliseconds"
             )
             tr = tr * 1000
             WFLOGGER.info("New tr value %s ms", tr)
             unit = "ms"
 
     elif tr and tr > 10:  # noqa: PLR2004
-        # check to see, if tr is in milliseconds, convert it into seconds
-        WFLOGGER.warning("tr is in milliseconds, Converting it into seconds")
+        # check to see, if TR is in milliseconds, convert it into seconds
+        WFLOGGER.warning("TR is in milliseconds, Converting it into seconds")
         tr = tr / 1000.0
-        WFLOGGER.info("New tr value %s s", tr)
+        WFLOGGER.info("New TR value %s s", tr)
         unit = "s"
 
     # swap back in

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -689,6 +689,13 @@ def get_scan_params(
     import os
     import warnings
 
+    from CPAC.utils.utils import (
+        check,
+        fetch_and_convert,
+        try_fetch_parameter,
+        VALID_PATTERNS,
+    )
+
     def check2(val):
         return val if val is None or val == "" or isinstance(val, str) else int(val)
 

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -33,6 +33,7 @@ import yaml
 
 from CPAC.utils.configuration import Configuration
 from CPAC.utils.docs import deprecated
+from CPAC.utils.interfaces.function import Function
 from CPAC.utils.monitoring import FMLOGGER, WFLOGGER
 
 CONFIGS_DIR = os.path.abspath(
@@ -648,6 +649,14 @@ def try_fetch_parameter(scan_parameters, subject, scan, keys):
     return None
 
 
+@Function.sig_imports(
+    [
+        "import json",
+        "import os",
+        "from CPAC.utils.utils import check, fetch_and_convert,"
+        " try_fetch_parameter, VALID_PATTERNS",
+    ]
+)
 def get_scan_params(
     subject_id,
     scan,
@@ -685,16 +694,6 @@ def get_scan_params(
     pe_direction : str
     effective_echo_spacing : float
     """
-    import json
-    import os
-    import warnings
-
-    from CPAC.utils.utils import (
-        check,
-        fetch_and_convert,
-        try_fetch_parameter,
-        VALID_PATTERNS,
-    )
 
     def check2(val):
         return val if val is None or val == "" or isinstance(val, str) else int(val)
@@ -875,7 +874,7 @@ def get_scan_params(
         # checking if the unit of TR and slice timing match or not
         # if slice timing in ms convert TR to ms as well
         if TR and max_slice_offset > TR:
-            warnings.warn(
+            WFLOGGER.warn(
                 "TR is in seconds and slice timings are in "
                 "milliseconds. Converting TR into milliseconds"
             )
@@ -885,7 +884,7 @@ def get_scan_params(
 
     elif TR and TR > 10:  # noqa: PLR2004
         # check to see, if TR is in milliseconds, convert it into seconds
-        warnings.warn("TR is in milliseconds, Converting it into seconds")
+        WFLOGGER.warn("TR is in milliseconds, Converting it into seconds")
         TR = TR / 1000.0
         WFLOGGER.info("New TR value %s s", TR)
         unit = "s"

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -132,7 +132,7 @@ def get_flag_wf(wf_name="get_flag"):
     input_node = pe.Node(util.IdentityInterface(fields=["in_flag"]), name="inputspec")
 
     get_flag = pe.Node(
-        util.Function(input_names=["in_flag"], function=_get_flag), name="get_flag"
+        Function(input_names=["in_flag"], function=_get_flag), name="get_flag"
     )
 
     wf.connect(input_node, "in_flag", get_flag, "in_flag")
@@ -322,7 +322,7 @@ def get_zscore(map_node=False, wf_name="z_score"):
         )
 
         op_string = pe.MapNode(
-            util.Function(
+            Function(
                 input_names=["mean", "std_dev"],
                 output_names=["op_string"],
                 function=get_operand_string,
@@ -345,7 +345,7 @@ def get_zscore(map_node=False, wf_name="z_score"):
         )
 
         op_string = pe.Node(
-            util.Function(
+            Function(
                 input_names=["mean", "std_dev"],
                 output_names=["op_string"],
                 function=get_operand_string,
@@ -400,7 +400,7 @@ def get_fisher_zscore(input_name, map_node=False, wf_name="fisher_z_score"):
     if map_node:
         # node to separate out
         fisher_z_score = pe.MapNode(
-            util.Function(
+            Function(
                 input_names=["correlation_file", "timeseries_one_d", "input_name"],
                 output_names=["out_file"],
                 function=compute_fisher_z_score,
@@ -410,7 +410,7 @@ def get_fisher_zscore(input_name, map_node=False, wf_name="fisher_z_score"):
         )
     else:
         fisher_z_score = pe.Node(
-            util.Function(
+            Function(
                 input_names=["correlation_file", "timeseries_one_d", "input_name"],
                 output_names=["out_file"],
                 function=compute_fisher_z_score,


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #2058 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Somewhere along the way from running `ruff` on the whole repo and [merging into `develop`](https://github.com/FCP-INDI/C-PAC/commit/83c38fb746f80d5fcc248cf33d445d531e4fb897),
1. <span name="one" id="one">we</span> ended up with https://github.com/FCP-INDI/C-PAC/blob/5ce5d379f8de00ca73032d7beafa28c29f792668/CPAC/utils/utils.py#L482 where it should have been something like

   ```Python
   value = convert_to(check(scan_parameters, None, scan, keys))
   ```

2. <span name="two" id="two">I</span> missed at least a couple signature import decorators
   1. <span name="two-dot-one" id="two-dot-one">https://github.com/FCP-INDI/C-PAC/blob/7d6f0eeb0a09894798ae7b0578ec1ca0aba0c9a6/CPAC/alff/utils.py#L9-L10</span> 
   2. <span name="two-dot-two" id="two-dot-two">https://github.com/FCP-INDI/C-PAC/blob/7d6f0eeb0a09894798ae7b0578ec1ca0aba0c9a6/CPAC/utils/utils.py#L754-L777</span>

3. <span name="three" id="three">we</span> automatically import all the always-created Nipype loggers as global variables in our subclass of Nipype's Function node class https://github.com/FCP-INDI/C-PAC/blob/5ce5d379f8de00ca73032d7beafa28c29f792668/CPAC/utils/interfaces/function/function.py#L233 but we still had some lingering instances of the superclass in the codebase; some of these superclass instances might try to call a logger by an undefined global variable name.

4. an f-string was missing an `f`: https://github.com/FCP-INDI/C-PAC/blob/5ce5d379f8de00ca73032d7beafa28c29f792668/CPAC/distortion_correction/distortion_correction.py#L167-L169 ↓ https://github.com/FCP-INDI/C-PAC/blob/979b0a9c715c8398b55134ca6d46db707800084c/CPAC/distortion_correction/distortion_correction.py#L167-L169

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

### [1.](#one)

In finding the bug, I noticed there are several different ways we're doing the same thing (fetching a value from a parameters dictionary and coercing its type if possible) in the current codebase.

#### existing ways
1. `convert_to(check())`
   https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L778-L794 https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L839-L842
2. `convert_to(try_fetch_parameter())`
   https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L806-L837 https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L855-L857
4. `check2(check())`
   https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L844-L850
5. `check()` with no type conversion
   https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/utils/utils.py#L852-L853

#### new only way
Instead of passing the dict, `subject_id`, and `scan` in every call, we just initialize a class that stores all that + the lookup and conversion methods and just pass the relevant parameters https://github.com/FCP-INDI/C-PAC/blob/b19907a8aa8ca909db66de81c3b3b575b17a078a/CPAC/utils/utils.py#L589-L611

https://github.com/FCP-INDI/C-PAC/blob/b19907a8aa8ca909db66de81c3b3b575b17a078a/CPAC/utils/utils.py#L819-L844

### [2.](#two)

I just added the missing imports to the `@Function.sig_imports` decorator on the function definitions.

### [3.](#three)

I replaced all the `nipype.interfaces.utility.Function()` calls with `CPAC.utils.interfaces.Function()` calls.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
With some faux scan parameters https://github.com/FCP-INDI/C-PAC/blob/b013cccb49c05e4297a0b088727ebb41e99e8988/CPAC/utils/tests/test_utils.py#L20-L47 test fetching and converting params vs expected outputs and [outputs from old functions](https://github.com/FCP-INDI/C-PAC/blob/b013cccb49c05e4297a0b088727ebb41e99e8988/CPAC/utils/tests/test_utils.py#L13) https://github.com/FCP-INDI/C-PAC/blob/b013cccb49c05e4297a0b088727ebb41e99e8988/CPAC/utils/tests/test_utils.py#L90-L145 and 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
