### PR TITLE
🐛 Fix double-logging

### DIFF
--- a/CPAC/__main__.py
+++ b/CPAC/__main__.py
@@ -15,7 +15,6 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
-from logging import basicConfig, INFO
 import os
 
 import click
@@ -26,7 +25,6 @@ from CPAC.utils.docs import version_report
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC")
-basicConfig(format="%(message)s", level=INFO)
 
 # CLI tree
 #

--- a/CPAC/cwas/tests/test_cwas.py
+++ b/CPAC/cwas/tests/test_cwas.py
@@ -16,8 +16,6 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Test the CWAS pipeline."""
 
-from logging import basicConfig, INFO
-
 import pytest
 import nibabel as nib
 
@@ -25,7 +23,6 @@ from CPAC.pipeline.nipype_pipeline_engine.plugins import MultiProcPlugin
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.cwas.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 
 @pytest.mark.skip(reason="requires RegressionTester")

--- a/CPAC/cwas/tests/test_pipeline_cwas.py
+++ b/CPAC/cwas/tests/test_pipeline_cwas.py
@@ -16,7 +16,6 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Test the CWAS pipeline."""
 
-from logging import basicConfig, INFO
 import os
 from urllib.error import URLError
 
@@ -30,7 +29,6 @@ from CPAC.cwas.pipeline import create_cwas
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.cwas.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 
 @pytest.mark.parametrize("z_score", [[0], [1], [0, 1], []])

--- a/CPAC/image_utils/tests/test_smooth.py
+++ b/CPAC/image_utils/tests/test_smooth.py
@@ -14,7 +14,6 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
-from logging import basicConfig, INFO
 import os
 
 import pytest
@@ -26,7 +25,6 @@ import CPAC.utils.test_init as test_utils
 from CPAC.utils.test_mocks import configuration_strategy_mock
 
 logger = getLogger("CPAC.image_utils.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 
 @pytest.mark.skip(reason="needs refactoring")

--- a/CPAC/nuisance/tests/test_utils.py
+++ b/CPAC/nuisance/tests/test_utils.py
@@ -1,4 +1,3 @@
-from logging import basicConfig, INFO
 import os
 import tempfile
 
@@ -10,7 +9,6 @@ from CPAC.nuisance.utils import calc_compcor_components, find_offending_time_poi
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.nuisance.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 mocked_outputs = p.resource_filename(
     "CPAC", os.path.join("nuisance", "tests", "motion_statistics")

--- a/CPAC/pipeline/check_outputs.py
+++ b/CPAC/pipeline/check_outputs.py
@@ -59,7 +59,11 @@ def check_outputs(output_dir: str, log_dir: str, pipe_name: str, unique_id: str)
     if isinstance(outputs_logger, (Logger, MockLogger)) and len(
         outputs_logger.handlers
     ):
-        outputs_log = getattr(outputs_logger.handlers[0], "baseFilename", None)
+        outputs_log = getattr(
+            MockLogger._get_first_file_handler(outputs_logger.handlers),
+            "baseFilename",
+            None,
+        )
     else:
         outputs_log = None
     if outputs_log is None:
@@ -103,7 +107,7 @@ def check_outputs(output_dir: str, log_dir: str, pipe_name: str, unique_id: str)
             try:
                 log_note = (
                     "Missing outputs have been logged in "
-                    f"{missing_log.handlers[0].baseFilename}"
+                    f"{MockLogger._get_first_file_handler(missing_log.handlers).baseFilename}"
                 )
             except (AttributeError, IndexError):
                 log_note = ""

--- a/CPAC/pipeline/test/test_cpac_group_runner.py
+++ b/CPAC/pipeline/test/test_cpac_group_runner.py
@@ -14,12 +14,11 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
-from logging import basicConfig, INFO
+
 
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.pipeline.test")
-basicConfig(format="%(message)s", level=INFO)
 
 
 def run_gather_outputs_func(pipeline_out_dir):

--- a/CPAC/utils/build_data_config.py
+++ b/CPAC/utils/build_data_config.py
@@ -16,14 +16,12 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Build a C-PAC data configuration."""
 
-from logging import basicConfig, INFO
 from pathlib import Path
 from typing import Any
 
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.utils.data-config")
-basicConfig(format="%(message)s", level=INFO)
 
 
 def _cannot_write(file_name: Path | str) -> None:

--- a/CPAC/utils/monitoring/custom_logging.py
+++ b/CPAC/utils/monitoring/custom_logging.py
@@ -59,7 +59,14 @@ def getLogger(name):  # pylint: disable=invalid-name
     if name in MOCK_LOGGERS:
         return MOCK_LOGGERS[name]
     logger = nipype_logging.getLogger(name)
-    return logging.getLogger(name) if logger is None else logger
+    if logger is None:
+        logger = logging.getLogger(name)
+        if not logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            logger.setLevel(logging.INFO)
+            logger.addHandler(handler)
+    return logger
 
 
 # Nipype built-in loggers

--- a/CPAC/utils/monitoring/custom_logging.py
+++ b/CPAC/utils/monitoring/custom_logging.py
@@ -203,10 +203,10 @@ class MockLogger:
     @staticmethod
     def _get_first_file_handler(
         handlers: Sequence[logging.Handler | MockHandler],
-    ) -> Optional[logging.FileHandler]:
+    ) -> Optional[logging.FileHandler | MockHandler]:
         """Given a list of Handlers, return the first FileHandler found or return None."""
         for handler in handlers:
-            if isinstance(handler, logging.FileHandler):
+            if isinstance(handler, (logging.FileHandler, MockHandler)):
                 return handler
         return None
 

--- a/CPAC/utils/ndmg_utils.py
+++ b/CPAC/utils/ndmg_utils.py
@@ -32,7 +32,6 @@
 # Modifications Copyright (C) 2022-2024  C-PAC Developers
 
 # This file is part of C-PAC.
-from logging import basicConfig, INFO
 import os
 
 import numpy as np
@@ -41,7 +40,6 @@ import nibabel as nib
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("nuerodata.m2g.ndmg")
-basicConfig(format="%(message)s", level=INFO)
 
 
 def ndmg_roi_timeseries(func_file, label_file):

--- a/CPAC/utils/tests/test_bids_utils.py
+++ b/CPAC/utils/tests/test_bids_utils.py
@@ -16,7 +16,6 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Tests for bids_utils."""
 
-from logging import basicConfig, INFO
 import os
 from subprocess import run
 
@@ -34,7 +33,6 @@ from CPAC.utils.bids_utils import (
 from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.utils.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 
 def create_sample_bids_structure(root_dir):

--- a/CPAC/utils/tests/test_symlinks.py
+++ b/CPAC/utils/tests/test_symlinks.py
@@ -14,7 +14,6 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
-from logging import basicConfig, INFO
 import os
 import tempfile
 
@@ -24,7 +23,6 @@ from CPAC.utils.monitoring.custom_logging import getLogger
 from CPAC.utils.symlinks import create_symlinks
 
 logger = getLogger("CPAC.utils.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 mocked_outputs = p.resource_filename(
     "CPAC", os.path.join("utils", "tests", "test_symlinks-outputs.txt")

--- a/CPAC/vmhc/tests/test_vmhc.py
+++ b/CPAC/vmhc/tests/test_vmhc.py
@@ -14,7 +14,6 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
-from logging import basicConfig, INFO
 import os
 
 import pytest
@@ -25,7 +24,6 @@ from CPAC.utils.test_mocks import configuration_strategy_mock
 from CPAC.vmhc.vmhc import vmhc as create_vmhc
 
 logger = getLogger("CPAC.utils.tests")
-basicConfig(format="%(message)s", level=INFO)
 
 
 @pytest.mark.skip(reason="test needs refactoring")


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes 
> [lots of the CPAC output messages are printing twice even with verbose turned off](https://cmi-cnl.slack.com/archives/C065W7YJ4V9/p1720811602525219)

by @e-kenneally 

## Description
<!-- Concisely describe what the pull request does. -->

Two logging handlers were often each handling each log message. With this PR, each logger will have either one nipype handler that streams and writes to file as configured or at most one each stream handler and file handler to handle streaming to terminal and writing to file, respectively.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

We were initializing non-nipype loggers with
```Python
basicConfig(format="%(message)s", level=INFO)
```
but that was setting a _global_ handler, which was also applying to nipype loggers.

With this PR, we just add a [StreamHandler](docs.python.org/3.11/library/logging.handlers#logging.StreamHandler) if a [Logger](docs.python.org/3.11/library/logging#logging.Logger) or [MockLogger](https://fcp-indi.github.io/docs/v1.8.7/developer/logging#CPAC.utils.monitoring.custom_logging.MockLogger) doesn't have any handlers: https://github.com/FCP-INDI/C-PAC/blob/e6cfc58bfdfaa6264bb761de06e6451874b04ae6/CPAC/utils/monitoring/custom_logging.py#L65-L69 and update the logic to not assume the first handler has a `baseFilename` attribute https://github.com/FCP-INDI/C-PAC/blob/e6cfc58bfdfaa6264bb761de06e6451874b04ae6/CPAC/utils/monitoring/custom_logging.py#L203-L211

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

1. The existing tests caught a bug based on assuming the first handler has a `baseFilename` attribute, so we fix that assumption in [`ebdd807`‒`e6cfc58`](https://github.com/FCP-INDI/C-PAC/compare/09a39f5e1308fc0039d14680dd3b9bf834046062...e6cfc58bfdfaa6264bb761de06e6451874b04ae6)
2. The [smoke test artifacts](https://github.com/FCP-INDI/C-PAC/actions/runs/10115976040#artifacts) show that MockLogger log files are still being generated.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
