### PR TITLE
🐛 Patch `NetCorr._list_outputs`

### DIFF
--- a/CPAC/utils/interfaces/netcorr.py
+++ b/CPAC/utils/interfaces/netcorr.py
@@ -19,6 +19,61 @@ NetCorrInputSpec.add_class_trait(
 class NetCorr(NipypeNetCorr):  # noqa: D101
     input_spec = NetCorrInputSpec
 
+    def _list_outputs(self):
+        """``nipype.interfaces.afni.preprocess.NetCorr._list_outputs`` with a bugfix.
+
+        Notes
+        -----
+        This method can be removed once nipy/nipype#3697 is merged and a release
+        including that PR is included in the C-PAC image.
+        """
+        # STATEMENT OF CHANGES:
+        #     This function is derived from sources licensed under the Apache-2.0 terms,
+        #     and this function has been changed.
+
+        # CHANGES:
+        #     * Includes changes from https://github.com/nipy/nipype/pull/3697 prior to all commits between https://github.com/nipy/nipype/tree/1.8.6 and that PR being perged.
+
+        # ORIGINAL WORK'S ATTRIBUTION NOTICE:
+        #    Copyright (c) 2009-2016, Nipype developers
+
+        #    Licensed under the Apache License, Version 2.0 (the "License");
+        #    you may not use this file except in compliance with the License.
+        #    You may obtain a copy of the License at
+
+        #        http://www.apache.org/licenses/LICENSE-2.0
+
+        #    Unless required by applicable law or agreed to in writing, software
+        #    distributed under the License is distributed on an "AS IS" BASIS,
+        #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        #    See the License for the specific language governing permissions and
+        #    limitations under the License.
+
+        #    Prior to release 0.12, Nipype was licensed under a BSD license.
+
+        # Modifications copyright (C) 2024  C-PAC Developers
+        import glob
+        import os
+
+        from nipype.interfaces.base.traits_extension import isdefined
+
+        outputs = self.output_spec().get()
+
+        if not isdefined(self.inputs.out_file):
+            prefix = self._gen_fname(self.inputs.in_file, suffix="_netcorr")
+        else:
+            prefix = self.inputs.out_file
+
+        # All outputs should be in the same directory as the prefix
+        odir = os.path.dirname(os.path.abspath(prefix))
+        outputs["out_corr_matrix"] = glob.glob(os.path.join(odir, "*.netcc"))[0]
+
+        if self.inputs.ts_wb_corr or self.inputs.ts_wb_Z:
+            corrdir = os.path.join(odir, prefix + "_000_INDIV")
+            outputs["out_corr_maps"] = glob.glob(os.path.join(corrdir, "*.nii.gz"))
+
+        return outputs
+
 
 NetCorr.__doc__ = f"""{NipypeNetCorr.__doc__}
 `CPAC.utils.interfaces.netcorr.NetCorr` adds an additional optional input, `automask_off`

--- a/CPAC/utils/interfaces/netcorr.py
+++ b/CPAC/utils/interfaces/netcorr.py
@@ -32,7 +32,7 @@ class NetCorr(NipypeNetCorr):  # noqa: D101
         #     and this function has been changed.
 
         # CHANGES:
-        #     * Includes changes from https://github.com/nipy/nipype/pull/3697 prior to all commits between https://github.com/nipy/nipype/tree/1.8.6 and that PR being perged.
+        #     * Includes changes from https://github.com/nipy/nipype/pull/3697 prior to all commits between https://github.com/nipy/nipype/tree/1.8.6 and that PR being merged and released.
 
         # ORIGINAL WORK'S ATTRIBUTION NOTICE:
         #    Copyright (c) 2009-2016, Nipype developers


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to Slack thread [`p1731021618662679`](https://cmi-cnl.slack.com/archives/C065W7YJ4V9/p1731021618662679?thread_ts=1730737939.657969&cid=C065W7YJ4V9)…[`p1731107909945459`](https://cmi-cnl.slack.com/archives/C065W7YJ4V9/p1731107909945459?thread_ts=1730737939.657969&cid=C065W7YJ4V9) by @birajstha, @tamsinrogers, @sgiavasis & @shnizzedy 
Related to https://github.com/nipy/nipype/issues/3696 by @shnizzedy
Related to https://github.com/nipy/nipype/issues/3697 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
Includes the fix from https://github.com/nipy/nipype/pull/3697 in C-PAC without waiting for the fix to be released in Nipype and then updating the Nipype version in the C-PAC container.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

> ### List of changes proposed in this PR (pull-request)
> <!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
> 
> * https://github.com/nipy/nipype/blob/237a9a7ca244ca87916e1f9c5bd73c3f08c00c5d/nipype/interfaces/afni/preprocess.py#L2744 ↓ https://github.com/nipy/nipype/blob/44e9d675d9773baaaa9aeddf38ce6a8d04a208b0/nipype/interfaces/afni/preprocess.py#L2744
>   * Replaces `NetCorr.inputs.ts_Z_corr` with `NetCorr.inputs.ts_wb_Z`
>   * Unwraps `ts_wb_*` checks from `isdefined`
> * Adds myself to `.zenodo.json` https://github.com/nipy/nipype/blob/cbcb487a90eb293acfabf1a444383c4a4dfa64c8/.zenodo.json#L923-L927

― https://github.com/nipy/nipype/pull/3697#issue-2650194312

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `merged_many_pipes` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
