### PR TITLE
📦️ Restore `bids-validator` installation in containerized C-PAC images

### DIFF
--- a/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
+++ b/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
@@ -29,7 +29,8 @@ FROM neurodebian:jammy-non-free
 LABEL org.opencontainers.image.description "NOT INTENDED FOR USE OTHER THAN AS A STAGE IMAGE IN A MULTI-STAGE BUILD \
 Ubuntu Jammy base image"
 LABEL org.opencontainers.image.source https://github.com/FCP-INDI/C-PAC
-ARG DEBIAN_FRONTEND=noninteractive
+ARG BIDS_VALIDATOR_VERSION=1.14.6 \
+    DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York \
     PATH=$PATH:/.local/bin \
     PYTHONPATH=$PYTHONPATH:/.local/lib/python3.10/site-packages
@@ -61,7 +62,11 @@ RUN groupadd -r c-pac \
     && echo $TZ > /etc/timezone \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
-    && update-locale LANG="en_US.UTF-8"
+    && update-locale LANG="en_US.UTF-8" \
+    # # install bids-validator
+    && curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts \
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    npm install -g "bids-validator@${BIDS_VALIDATOR_VERSION}"
 
 COPY --from=c-pac_templates /cpac_templates /cpac_templates
 COPY --from=dcan-hcp /opt/dcan-tools/pipeline/global /opt/dcan-tools/pipeline/global

--- a/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
+++ b/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile
@@ -65,8 +65,7 @@ RUN groupadd -r c-pac \
     && update-locale LANG="en_US.UTF-8" \
     # # install bids-validator
     && curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    npm install -g "bids-validator@${BIDS_VALIDATOR_VERSION}"
+    && npm install -g "bids-validator@${BIDS_VALIDATOR_VERSION}"
 
 COPY --from=c-pac_templates /cpac_templates /cpac_templates
 COPY --from=dcan-hcp /opt/dcan-tools/pipeline/global /opt/dcan-tools/pipeline/global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Supplied missing `subject_id` for longitudinal workflow logger and make that field optional for the logger.
+- Restored `bids-validator` functionality.
+
+### Removed
+
+- Variant image recipes.
+  - `ABCD-HCP`
+  - `fMRIPrep-LTS`
+- Typehinting support for Python < 3.10.
 
 ## [1.8.7] - 2024-05-03
 
 ### Added
 
-- `Robustfov` feature in `FSL-BET` to crop images ensuring removal of neck regions that may appear in the skull-stripped images. 
+- `Robustfov` feature in `FSL-BET` to crop images ensuring removal of neck regions that may appear in the skull-stripped images.
 - Ability to throttle nodes, estimating all available memory when threading.
 - Ability to configure FreeSurfer ingress from the command line.
 
@@ -255,7 +262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In a given pipeline configuration, segmentation probability maps and binary tissue masks are warped to template space, and those warped masks are included in the output directory
   - if `registration_workflows['functional_registration']['EPI_registration']['run segmentation']` is `On` and `segmentation['tissue_segmentation']['Template_Based']['template_for_segmentation']` includes `EPI_Template`
-  
+
     and/or
   - if `registration_workflows['anatomical_registration']['run']` is `On` and `segmentation['tissue_segmentation']['Template_Based']['template_for_segmentation']` includes `T1_Template`
 - Renamed connectivity matrices from `*_connectome.tsv` to `*_correlations.tsv`

--- a/CPAC/utils/tests/test_bids_utils.py
+++ b/CPAC/utils/tests/test_bids_utils.py
@@ -1,5 +1,7 @@
 """Tests for bids_utils"""
 import os
+from subprocess import run
+
 import pytest
 import yaml
 from CPAC.utils.bids_utils import bids_gen_cpac_sublist, \
@@ -45,7 +47,12 @@ def create_sample_bids_structure(root_dir):
             ])), 'w')
 
 
-@pytest.mark.parametrize('only_one_anat', [True, False])
+def test_bids_validator() -> None:
+    """Test subprocess call to `bids-validator`."""
+    run(["bids-validator", "--version"], check=True)
+
+
+@pytest.mark.parametrize("only_one_anat", [True, False])
 def test_create_cpac_data_config_only_one_anat(tmp_path, only_one_anat):
     """Function to test 'only_one_anat' parameter of
     'create_cpac_data_config' function"""

--- a/CPAC/utils/versioning/dependencies.py
+++ b/CPAC/utils/versioning/dependencies.py
@@ -119,9 +119,12 @@ def requirements() -> dict:
 
 
 REPORTED = dict(sorted({
-    **cli_version('ldd --version', formatting=first_line),
-    'Python': sys.version.replace('\n', ' ').replace('  ', ' '),
-    **cli_version('3dECM -help', delimiter='_',
-                  formatting=lambda _: last_line(_).split('{')[-1].rstrip('}'))
+    **cli_version("bids-validator --version", dependency="bids-validator",
+                  in_result=False, formatting=first_line),
+    **cli_version("ldd --version", formatting=first_line),
+    "Python": sys.version.replace("\n", " ").replace("  ", " "),
+    **cli_version("3dECM -help", delimiter="_",
+                  formatting=lambda _: last_line(_).split("{")[-1].rstrip("}"))
 }.items(), key=_version_sort))
+
 REQUIREMENTS = requirements()


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #2120 by @shnizzedy 
Related to #2110 by @shnizzedy
Related to [[comment]](https://neurostars.org/t/running-an-older-version-of-c-pac-v1-3-0/29178/4?u=shnizzedy) by @shnizzedy (response to [<img src="https://neurostars.org/uploads/default/optimized/1X/eadd889a719a1e6370fbe086d518eafd6cd4586c_2_32x32.png" alt="Neurostars" width="14px"/> Running an older version of C-PAC (V1.3.0)](https://neurostars.org/t/running-an-older-version-of-c-pac-v1-3-0/29178) by [@Ammar_Ibrahim](https://neurostars.org/u/Ammar_Ibrahim))

## Description
<!-- Concisely describe what the pull request does. -->

Merges <details><summary>the changes</summary>

> > In looking into the issue, I discovered that we inadvertently removed the bids-validator CLI, so trying to run with the BIDS validator in versions 1.8.6 and 1.8.7 will fail as well.
> 
> ― [<img src="https://neurostars.org/uploads/default/optimized/1X/eadd889a719a1e6370fbe086d518eafd6cd4586c_2_32x32.png" alt="Neurostars" width="14px"/> Re: Running an older version of C-PAC (V1.3.0)](https://neurostars.org/t/running-an-older-version-of-c-pac-v1-3-0/29178/4?u=shnizzedy)
> 
> This PR
> 
> 1. installs [`n`](https://www.npmjs.com/package/n) https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile#L67 and the Node.js version of [`bids-validator`](https://github.com/bids-standard/bids-validator) https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile#L32 https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/.github/Dockerfiles/Ubuntu.jammy-non-free.Dockerfile#L68
> 2. Adds `bids-validator` to the list of dependencies to log the version of https://github.com/FCP-INDI/C-PAC/blob/0232e722ab7078e4c9998b430321e30d483cac4d/CPAC/utils/versioning/dependencies.py#L139-L144

</details> from #2120 onto 6b3c934.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `hotfix/1.8.7-1` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
