### PR TITLE
✨Introduced desc-head_bold and changed sbref generating nodeblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Required positional parameter "wf" in input and output of `ingress_pipeconfig_paths` function, where a node to reorient templates is added to the `wf`.
 - Required positional parameter "orientation" to `resolve_resolution`.
 - Optional positional argument "cfg" to `create_lesion_preproc`.
-- New switch `mask_sbref` under `func_input_prep` in functional registration.
+- New switch `mask_sbref` under `func_input_prep` in functional registration and set to default `on`.
 - New resource `desc-head_bold` as non skull-stripped bold from nodeblock `bold_masking`.
 
 ### Changed
@@ -57,7 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - as output from FNIRT registration.
   - as inputs from Nodeblocks requesting it and, replaced with `space-template_desc-brain_mask`.
   - from outputs tsv.
-
+- Inputs `[desc-motion_bold, bold]` from `coregistration_prep_vol` nodeblock.
+- `input` field from `coregistration` in blank and default config.
+- `reg_with_skull` swtich from `func_input_prep` in blank and default config.
 
 ## [1.8.7] - 2024-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Required positional parameter "wf" in input and output of `ingress_pipeconfig_paths` function, where a node to reorient templates is added to the `wf`.
 - Required positional parameter "orientation" to `resolve_resolution`.
 - Optional positional argument "cfg" to `create_lesion_preproc`.
-- New switch `mask_sbref` under `Selected Functional Volume` in functional registration.
+- New switch `mask_sbref` under `func_input_prep` in functional registration.
 - New resource `desc-head_bold` as non skull-stripped bold from nodeblock `bold_masking`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Required positional parameter "wf" in input and output of `ingress_pipeconfig_paths` function, where a node to reorient templates is added to the `wf`.
 - Required positional parameter "orientation" to `resolve_resolution`.
 - Optional positional argument "cfg" to `create_lesion_preproc`.
+- New switch `mask_sbref` under `Selected Functional Volume` in functional registration.
+- New resource `desc-head_bold` as non skull-stripped bold from nodeblock `bold_masking`.
 
 ### Changed
 
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved `FSL-AFNI subworkflow` from inside a `bold_mask_fsl_afni` nodeblock into a separate function.
   - Renamed `desc-ref_bold` created in this workflow to `desc-unifized_bold`.
   - `coregistration_prep_fmriprep` nodeblock now checks if `desc-unifized_bold` exists in the Resource Pool, if not it runs the `FSL-AFNI subworkflow` to create it.
+- Input `desc-brain_bold` to `desc-preproc_bold` for `sbref` generation nodeblock `coregistration_prep_vol`.
 
 ### Fixed
 

--- a/CPAC/func_preproc/func_preproc.py
+++ b/CPAC/func_preproc/func_preproc.py
@@ -1740,6 +1740,10 @@ def bold_mask_ccs(wf, cfg, strat_pool, pipe_num, opt=None):
             "Description": "The skull-stripped BOLD time-series.",
             "SkullStripped": True,
         },
+        "desc-head_bold": {
+            "Description": "The non skull-stripped BOLD time-series.",
+            "SkullStripped": False,
+        },
     },
 )
 def bold_masking(wf, cfg, strat_pool, pipe_num, opt=None):
@@ -1751,8 +1755,8 @@ def bold_masking(wf, cfg, strat_pool, pipe_num, opt=None):
     func_edge_detect.inputs.expr = "a*b"
     func_edge_detect.inputs.outputtype = "NIFTI_GZ"
 
-    node, out = strat_pool.get_data("desc-preproc_bold")
-    wf.connect(node, out, func_edge_detect, "in_file_a")
+    node_head_bold, out_head_bold = strat_pool.get_data("desc-preproc_bold")
+    wf.connect(node_head_bold, out_head_bold, func_edge_detect, "in_file_a")
 
     node, out = strat_pool.get_data("space-bold_desc-brain_mask")
     wf.connect(node, out, func_edge_detect, "in_file_b")
@@ -1760,6 +1764,7 @@ def bold_masking(wf, cfg, strat_pool, pipe_num, opt=None):
     outputs = {
         "desc-preproc_bold": (func_edge_detect, "out_file"),
         "desc-brain_bold": (func_edge_detect, "out_file"),
+        "desc-head_bold": (node_head_bold, out_head_bold),
     }
 
     return (wf, outputs)

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -148,6 +148,7 @@ from CPAC.registration.registration import (
     coregistration_prep_vol,
     create_func_to_T1template_symmetric_xfm,
     create_func_to_T1template_xfm,
+    mask_sbref,
     overwrite_transform_anat_to_template,
     register_ANTs_anat_to_template,
     register_ANTs_EPI_to_template,
@@ -1287,6 +1288,7 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None):
                 coregistration_prep_vol,
                 coregistration_prep_mean,
                 coregistration_prep_fmriprep,
+                mask_sbref,
             ],
         ]
 

--- a/CPAC/pipeline/cpac_pipeline.py
+++ b/CPAC/pipeline/cpac_pipeline.py
@@ -1288,8 +1288,8 @@ def build_workflow(subject_id, sub_dict, cfg, pipeline_name=None):
                 coregistration_prep_vol,
                 coregistration_prep_mean,
                 coregistration_prep_fmriprep,
-                mask_sbref,
             ],
+            mask_sbref,
         ]
 
         # Distortion/Susceptibility Correction

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -725,12 +725,10 @@ latest_schema = Schema(
                     "reference": In({"brain", "restore-brain"}),
                     "interpolation": In({"trilinear", "sinc", "spline"}),
                     "using": str,
-                    "input": str,
                     "cost": str,
                     "dof": int,
                     "arguments": Maybe(str),
                     "func_input_prep": {
-                        "reg_with_skull": bool1_1,
                         "input": [
                             In(
                                 {

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -743,8 +743,8 @@ latest_schema = Schema(
                         "Mean Functional": {"n4_correct_func": bool1_1},
                         "Selected Functional Volume": {
                             "func_reg_input_volume": int,
-                            "mask_sbref": bool1_1,
                         },
+                        "mask_sbref": bool1_1,
                     },
                     "boundary_based_registration": {
                         "run": forkable,

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -741,7 +741,10 @@ latest_schema = Schema(
                             )
                         ],
                         "Mean Functional": {"n4_correct_func": bool1_1},
-                        "Selected Functional Volume": {"func_reg_input_volume": int},
+                        "Selected Functional Volume": {
+                            "func_reg_input_volume": int,
+                            "mask_sbref": bool1_1,
+                        },
                     },
                     "boundary_based_registration": {
                         "run": forkable,

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -3167,7 +3167,7 @@ def mask_sbref(wf, cfg, strat_pool, pipe_num, opt=None):
         "input",
     ],
     option_val="Selected_Functional_Volume",
-    inputs=[("desc-preproc_bold", ["desc-head_bold", "bold"], "sbref")],
+    inputs=[("desc-preproc_bold", "sbref")],
     outputs=["sbref"],
 )
 def coregistration_prep_vol(wf, cfg, strat_pool, pipe_num, opt=None):
@@ -3182,14 +3182,7 @@ def coregistration_prep_vol(wf, cfg, strat_pool, pipe_num, opt=None):
         outputtype="NIFTI_GZ",
     )
 
-    if not cfg.registration_workflows["functional_registration"]["coregistration"][
-        "func_input_prep"
-    ]["reg_with_skull"]:
-        node, out = strat_pool.get_data("desc-preproc_bold")
-    else:
-        # TODO check which file is functional_skull_leaf
-        # TODO add a function to choose brain or skull?
-        node, out = strat_pool.get_data(["desc-head_bold", "bold"])
+    node, out = strat_pool.get_data("desc-preproc_bold")
 
     wf.connect(node, out, get_func_volume, "in_file_a")
 

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -3133,7 +3133,6 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
             "coregistration",
             "func_input_prep",
             "mask_sbref",
-            "run",
         ],
     ],
     inputs=["sbref", "space-bold_desc-brain_mask"],

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -199,9 +199,6 @@ registration_workflows:
       run: On
       func_input_prep:
 
-        # Choose whether to use functional brain or skull as the input to functional-to-anatomical registration
-        reg_with_skull: On
-
         # Choose whether to use the mean of the functional/EPI as the input to functional-to-anatomical registration or one of the volumes from the functional 4D timeseries that you choose.
         # input: ['Mean_Functional', 'Selected_Functional_Volume', 'fmriprep_reference']
         input: [Selected_Functional_Volume]

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -725,7 +725,7 @@ registration_workflows:
           func_reg_input_volume: 0
 
         # Independent of the above `reg_with_skull` option
-        mask_sbref: On
+        mask_sbref: Off
 
       boundary_based_registration:
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -706,9 +706,6 @@ registration_workflows:
       run: Off
       func_input_prep:
 
-        # Choose whether to use functional brain or skull as the input to functional-to-anatomical registration
-        reg_with_skull: Off
-
         # Choose whether to use the mean of the functional/EPI as the input to functional-to-anatomical registration or one of the volumes from the functional 4D timeseries that you choose.
         # input: ['Mean_Functional', 'Selected_Functional_Volume', 'fmriprep_reference']
         input: [Mean_Functional]
@@ -724,8 +721,8 @@ registration_workflows:
           #Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
           func_reg_input_volume: 0
 
-        # Independent of the above `reg_with_skull` option
-        mask_sbref: Off
+        # Mask the sbref created by coregistration input prep nodeblocks above before registration
+        mask_sbref: On
 
       boundary_based_registration:
 
@@ -755,8 +752,7 @@ registration_workflows:
       # Choose FSL or ABCD as coregistration method
       using: FSL
 
-      # Choose brain or whole-head as coregistration input
-      input: brain
+      #TODO Add input field here to choose between whole head or brain
 
       # Choose coregistration interpolation
       interpolation: trilinear

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -724,7 +724,8 @@ registration_workflows:
           #Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
           func_reg_input_volume: 0
 
-          mask_sbref: true
+        # Independent of the above `reg_with_skull` option
+        mask_sbref: On
 
       boundary_based_registration:
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -724,6 +724,8 @@ registration_workflows:
           #Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
           func_reg_input_volume: 0
 
+          mask_sbref: true
+
       boundary_based_registration:
 
         # this is a fork point

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -766,8 +766,7 @@ registration_workflows:
       # Choose FSL or ABCD as coregistration method
       using: FSL
 
-      # Choose brain or whole-head as coregistration input
-      input: brain
+      #TODO Add input field here to choose between whole head or brain
 
       # Choose coregistration interpolation
       interpolation: trilinear
@@ -782,9 +781,6 @@ registration_workflows:
       arguments: None
 
       func_input_prep:
-
-        # Choose whether to use functional brain or skull as the input to functional-to-anatomical registration
-        reg_with_skull: Off
 
         # Choose whether to use the mean of the functional/EPI as the input to functional-to-anatomical registration or one of the volumes from the functional 4D timeseries that you choose.
         # input: ['Mean_Functional', 'Selected_Functional_Volume', 'fmriprep_reference']
@@ -801,6 +797,9 @@ registration_workflows:
           # Only for when 'Use as Functional-to-Anatomical Registration Input' is set to 'Selected Functional Volume'.
           #Input the index of which volume from the functional 4D timeseries input file you wish to use as the input for functional-to-anatomical registration.
           func_reg_input_volume: 0
+
+        # Mask the sbref created by coregistration input prep nodeblocks above before registration
+        mask_sbref: On
 
       boundary_based_registration:
         # this is a fork point


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #[2174](https://github.com/FCP-INDI/C-PAC/issues/2174) by @sgiavasis 

## Description
<!-- Concisely describe what the pull request does. -->
Refactors `sbref` generation by updating BOLD input selection to improve clarity and flexibility. Replaces `desc-brain_bold` with `desc-preproc_bold`, introduces `desc-head_bold` as a bookmark resource, and adds an option to `mask sbref` in the config.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- Changed the input to `desc-preproc_bold` 
- Removed the whole-head input `desc-head_bold` and `bold` 
- Created `desc-head_bold` as a bookmark resource at `bold_masking` nodeblock
- Added `mask_sbref` switch in the config as an option.
- 
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Try running the custom pipeline config as mentioned below
```YAML
registration_workflows:
  functional_registration:
    func_input_prep:
      input: [Selected_Functional_Volume]
functional_preproc:
  func_masking:
    apply_func_mask_in_native_space: off
```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Ran CPAC test-config with `default` and `abcd-options` pre-config. Both completed and the nodeblock connected successfully
![image](https://github.com/user-attachments/assets/34d339f0-85c5-4b2e-9935-aa8d8544801d)

Furthermore, made a custom pipeline modifying default config with the following changes and the test config ran successfully.
```YAML
registration_workflows:
  functional_registration:
    func_input_prep:
      input: [Selected_Functional_Volume]
functional_preproc:
  func_masking:
    apply_func_mask_in_native_space: off
```

Before the fix
![image](https://github.com/user-attachments/assets/00c38583-5402-4fd6-9119-efe8a54eff13)

After the fix, the `test-config` run completed.
![image](https://github.com/user-attachments/assets/56afd965-e6d0-471f-aa98-2e882cc2731d)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
