### PR TITLE
🐛 Restore outputs removed from "freesurfer_abcd_preproc" to "freesurfer_reconall"

### DIFF
--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -145,7 +145,7 @@ jobs:
           echo DOCKER_TAG=$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]'):$TAG >> $GITHUB_ENV
           cat $GITHUB_ENV
       - name: setup-conda
-        uses: s-weigand/setup-conda@v1.2.3
+        uses: conda-incubator/setup-miniconda@v3.1.1
       - name: Set up datalad-OSF
         run: |
           git config --global user.email "CMI_CPAC_Support@childmind.org"
@@ -203,7 +203,12 @@ jobs:
           echo DOCKER_TAG=$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]'):$TAG >> $GITHUB_ENV
           cat $GITHUB_ENV
       - name: setup-conda
-        uses: s-weigand/setup-conda@v1.2.3
+        uses: conda-incubator/setup-miniconda@v3.1.1
+        with:
+          activate-environment: datalad-osf
+          channels: conda-forge
+          conda-remove-defaults: "true"
+          python-version: 3.12
       - name: Set up datalad-OSF
         run: |
           git config --global user.email "CMI_CPAC_Support@childmind.org"

--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -217,6 +217,8 @@ jobs:
           pip install datalad-osf
       - name: Get rodent test data
         run: |
+          export GIT_TRACE=1
+          export DATALAD_LOG_LEVEL=DEBUG
           datalad clone osf://uya3r test-data
       - name: Run rodent smoke test
         run: |

--- a/.github/workflows/smoke_test_participant.yml
+++ b/.github/workflows/smoke_test_participant.yml
@@ -148,6 +148,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3.1.1
       - name: Set up datalad-OSF
         run: |
+          sudo apt-get update && sudo apt-get install -y git-annex
           git config --global user.email "CMI_CPAC_Support@childmind.org"
           git config --global user.name "Theodore (Machine User)"
           yes | conda install -c conda-forge datalad
@@ -211,6 +212,7 @@ jobs:
           python-version: 3.12
       - name: Set up datalad-OSF
         run: |
+          sudo apt-get update && sudo apt-get install -y git-annex
           git config --global user.email "CMI_CPAC_Support@childmind.org"
           git config --global user.name "Theodore (Machine User)"
           yes | conda install -c conda-forge datalad

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2904,6 +2904,18 @@ def freesurfer_abcd_preproc(wf, cfg, strat_pool, pipe_num, opt=None):
         "pipeline-fs_brainmask",
         "pipeline-fs_wmparc",
         "pipeline-fs_T1",
+        *[
+            f"pipeline-fs_hemi-{hemi}_{entity}"
+            for hemi in ["L", "R"]
+            for entity in [
+                "desc-surface_curv",
+                *[
+                    f"desc-surfaceMesh_{_}"
+                    for _ in ["pial", "smoothwm", "sphere", "white"]
+                ],
+                *[f"desc-surfaceMap_{_}" for _ in ["sulc", "thickness", "volume"]],
+            ]
+        ],
         *freesurfer_abcd_preproc.outputs,
         # we're grabbing the postproc outputs and appending them to
         # the reconall outputs


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2184 by @birajstha

## Description
<!-- Concisely describe what the pull request does. -->
Restores https://github.com/FCP-INDI/C-PAC/blob/7246e449ae56ba116203bead402b95fa84629d17/CPAC/anat_preproc/anat_preproc.py#L2767-L2782 ([removed in #2184](https://github.com/FCP-INDI/C-PAC/pull/2184/files#diff-b8ed898622a28e32db94baa4030d462bfab350311f4656b04153d6426dff8d43L2767-L2782)) to the outputs of https://github.com/FCP-INDI/C-PAC/blob/1771f7be37619bee50d9ac548ccdacc5f5bfe04c/CPAC/anat_preproc/anat_preproc.py#L2895-L2896

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* `"freesurfer_reconall"` includes all outputs of `"freesurfer_abcd_preproc"`, so when these outputs were removed from `"freesurfer_abcd_preproc"`, they were also removed from `"freesurfer_reconall"`, which led to some failing smoke tests (see [Screenshots](#screenshots) for an example).
* Also replaces the setup-conda GitHub Workflows Marketplace Action (the one that was there stopped working and hasn't been updated in a while).

<h2 id="screenshots" name="screenshots">Screenshots</h2>
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

[![NameError: 
[!] Output name "pipeline-fs_hemi-L_desc-surface_curv" in the block function does not match the outputs list ['freesurfer-subject-dir', 'pipeline-fs_raw-average', 'pipeline-fs_subcortical-seg', 'pipeline-fs_brainmask', 'pipeline-fs_wmparc', 'pipeline-fs_T1', 'desc-restore_T1w', 'desc-restore-brain_T1w', 'desc-ABCDpreproc_T1w', 'pipeline-fs_desc-fast_biasfield'] in Node Block "freesurfer_reconall"](https://github.com/user-attachments/assets/c2c6a867-61f0-4b1f-a945-675101d83807)](https://github.com/FCP-INDI/C-PAC/actions/runs/13247695353/job/37877592159)

[![smoke tests succeed](https://github.com/user-attachments/assets/b1c8a3af-c217-4285-bb56-966bdba180b5)](https://github.com/FCP-INDI/C-PAC/actions/runs/13576006308)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
