### PR TITLE
Freesurfer ingress reorient

### DIFF
--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -502,6 +502,38 @@ def mri_convert(in_file, reslice_like=None, out_file=None, args=None):
     return out_file
 
 
+def mri_convert_reorient(in_file, orientation, out_file=None):
+    """
+    Convert files from mgz to nifti format.
+
+    Parameters
+    ----------
+    in_file : string
+        A path of mgz input file
+    orientation : string
+        Orientation of the output file
+    out_file : string
+        A path of nifti output file
+    args : string
+        Arguments of mri_convert
+
+    Returns
+    -------
+    out_file : string
+        A path of nifti output file
+    """
+    import os
+
+    if out_file is None:
+        out_file = in_file.split(".")[0] + "_reoriented.mgz"
+
+    cmd = "mri_convert %s %s --out_orientation %s" % (in_file, out_file, orientation)
+
+    os.system(cmd)
+
+    return out_file
+
+
 def wb_command(in_file):
     import os
 

--- a/CPAC/anat_preproc/utils.py
+++ b/CPAC/anat_preproc/utils.py
@@ -504,23 +504,23 @@ def mri_convert(in_file, reslice_like=None, out_file=None, args=None):
 
 def mri_convert_reorient(in_file, orientation, out_file=None):
     """
-    Convert files from mgz to nifti format.
+    Reorient the mgz files using mri_orient.
 
     Parameters
     ----------
     in_file : string
-        A path of mgz input file
+        A path of mgz input file.
     orientation : string
-        Orientation of the output file
+        Orientation of the output file.
     out_file : string
-        A path of nifti output file
+        A path of mgz output file.
     args : string
-        Arguments of mri_convert
+        Arguments of mri_convert.
 
     Returns
     -------
     out_file : string
-        A path of nifti output file
+        A path of reoriented mgz output file.
     """
     import os
 

--- a/CPAC/pipeline/engine.py
+++ b/CPAC/pipeline/engine.py
@@ -2045,7 +2045,7 @@ def ingress_freesurfer(wf, rpool, cfg, data_paths, unique_id, part_id, ses_id):
                 creds_path=data_paths["creds_path"],
                 dl_dir=cfg.pipeline_setup["working_directory"]["path"],
             )
-            # if .mgz reorient to RPI
+            # reorient *.mgz
             if outfile.endswith(".mgz"):
                 reorient_mgz = pe.Node(
                     Function(

--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -2631,3 +2631,11 @@ def _replace_in_value_list(current_value, replacement_tuple):
         for v in current_value
         if bool(v) and v not in {"None", "Off", ""}
     ]
+
+
+def flip_orientation_code(code):
+    """
+    Reverts an orientation code by flipping R↔L, A↔P, and I↔S.
+    """
+    flip_dict = {"R": "L", "L": "R", "A": "P", "P": "A", "I": "S", "S": "I"}
+    return "".join(flip_dict[c] for c in code)


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2200 by @birajstha 
related to #2193 by @tamsinrogers 

Alignment issues during applying mask ingressed from Freesurfer outputs.
![image](https://github.com/user-attachments/assets/0f3a8d2b-280c-482a-a289-805093686195)


## Description
<!-- Concisely describe what the pull request does. -->
Resources from [ingress_freesurfer](https://github.com/FCP-INDI/C-PAC/blob/0cf8248c0d6901e9d31d66649b77cdba231560cf/CPAC/pipeline/engine.py#L1965) are skipping reorient and are used directly [like in here.](https://github.com/FCP-INDI/C-PAC/blob/96db8b0b65ab1d5f55fb3b895855af34d72c17e4/CPAC/anat_preproc/anat_preproc.py#L917C1-L943C25)

This causes the files ingressed to have different orientation and is incompatible with rest of the data causing alignment issues such as above.

This PR solves the above issue by aligning the ingressed resources to common orientation.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
After the fix
![image](https://github.com/user-attachments/assets/c9cf4906-ee2f-4dd4-8b9b-d45847c0d754)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
