### PR TITLE
🐛 Update resources to resolve failing smoke tests

### DIFF
--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -1601,7 +1601,7 @@ def FSL_registration_connector(
                 fnirt_reg_anat_mni,
                 "outputspec.output_head",
             ),
-            f"space-{sym}template_desc-{orig}_mask": (
+            f"space-{sym}template_desc-{'brain' if orig == 'T1w' else orig}_mask": (
                 fnirt_reg_anat_mni,
                 "outputspec.output_mask",
             ),

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -2318,26 +2318,28 @@ def register_FSL_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
         "dilated-symmetric-brain-mask",
     ],
     outputs={
-        "space-symtemplate_desc-preproc_T1w": {
-            "Template": "T1w-brain-template-symmetric"
+        **{
+            f"space-symtemplate_desc-{suffix}": {
+                "Template": "T1w-brain-template-symmetric"
+            }
+            for suffix in [
+                *[f"{desc}_T1w" for desc in ["brain", "preproc"]],
+                "brain_mask",
+            ]
         },
-        "from-T1w_to-symtemplate_mode-image_desc-linear_xfm": {
-            "Template": "T1w-template-symmetric"
-        },
-        "from-symtemplate_to-T1w_mode-image_desc-linear_xfm": {
-            "Template": "T1w-template-symmetric"
-        },
-        "from-T1w_to-symtemplate_mode-image_xfm": {
-            "Template": "T1w-template-symmetric"
-        },
-        "from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm": {
-            "Template": "T1w-template-symmetric"
-        },
-        "from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm": {
-            "Template": "T1w-template-symmetric"
-        },
-        "from-longitudinal_to-symtemplate_mode-image_xfm": {
-            "Template": "T1w-template-symmetric"
+        **{
+            output: {"Template": "T1w-template-symmetric"}
+            for output in [
+                "space-symtemplate_desc-head_T1w",
+                "from-T1w_to-symtemplate_mode-image_desc-linear_xfm",
+                "from-symtemplate_to-T1w_mode-image_desc-linear_xfm",
+                "from-T1w_to-symtemplate_mode-image_warp",
+                "from-T1w_to-symtemplate_mode-image_xfm",
+                "from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm",
+                "from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm",
+                "from-longitudinal_to-symtemplate_mode-image_xfm",
+                "space-symtemplate_desc-T1wT2w_biasfield",
+            ]
         },
     },
 )


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes [failing smoke tests](https://github.com/FCP-INDI/C-PAC/actions/runs/14110790786)
Related to #2182 by @birajstha 
Related to 20572de by @e-kenneally 

## Description
<!-- Concisely describe what the pull request does. -->
1. Updates one place where resources were being dynamically named `"space-template_desc-T1w_mask"` https://github.com/FCP-INDI/C-PAC/blob/252eed4ab3fd3353868f9061f85b7065dd5ab0c7/CPAC/registration/registration.py#L1604 to `"space-template_desc-brain_mask"` https://github.com/FCP-INDI/C-PAC/blob/e447211689a04ff7f291da5b1c05d97e028373e9/CPAC/registration/registration.py#L1604 re: #2182
2. Adds 5 resources to https://github.com/FCP-INDI/C-PAC/blob/beddfae7c1075823a39905530eb0e84b652909e9/CPAC/registration/registration.py#L2305-L2306 https://github.com/FCP-INDI/C-PAC/blob/beddfae7c1075823a39905530eb0e84b652909e9/CPAC/registration/registration.py#L2320-L2344 where a conditional was not met in any preconfigs (prior to 20572de56d66664bb718e0919766eabfeb2c6f36) https://github.com/FCP-INDI/C-PAC/blob/1018f8c47c02ede844dd6bd880e9954014086846/CPAC/registration/registration.py#L1457-L1458 https://github.com/FCP-INDI/C-PAC/blob/1018f8c47c02ede844dd6bd880e9954014086846/CPAC/registration/registration.py#L1467-L1483 but is not nested in that conditional block anymore after that commit https://github.com/FCP-INDI/C-PAC/blob/252eed4ab3fd3353868f9061f85b7065dd5ab0c7/CPAC/registration/registration.py#L1594-L1621

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I'm not completely confident about which template goes with each resource in `register_symmetric_FSL_anat_to_template`:

<table><tr><th rowspan="2">resource</th><th colspan="2">template</th></tr><tr><th>before this PR</th><th>with this PR</th></tr>
<tr><td><code>from-T1w_to-symtemplate_mode-image_desc-linear_xfm</code></td><td><code>T1w-template-symmetric</code></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>from-T1w_to-symtemplate_mode-image_warp</code></td><td><i>not included</i></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>from-T1w_to-symtemplate_mode-image_xfm</code></td><td><code>T1w-template-symmetric</code></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>from-longitudinal_to-symtemplate_mode-image_desc-linear_xfm</code></td><td><code>T1w-template-symmetric</code></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>from-longitudinal_to-symtemplate_mode-image_xfm</code></td><td><code>T1w-template-symmetric</code></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>from-symtemplate_to-T1w_mode-image_desc-linear_xfm</code></td><td><code>T1w-template-symmetric</code></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>from-symtemplate_to-longitudinal_mode-image_desc-linear_xfm</code></td><td><code>T1w-template-symmetric</code></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>space-symtemplate_desc-T1wT2w_biasfield</code></td><td><i>not included</i></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>space-symtemplate_desc-brain_T1w</code></td><td><i>not included</i></td><td><code>T1w-brain-template-symmetric</code></td></tr>
<tr><td><code>space-symtemplate_desc-brain_mask</code></td><td><i>not included</i></td><td><code>T1w-brain-template-symmetric</code></td></tr>
<tr><td><code>space-symtemplate_desc-head_T1w</code></td><td><i>not included</i></td><td><code>T1w-template-symmetric</code></td></tr>
<tr><td><code>space-symtemplate_desc-preproc_T1w</code></td><td><code>T1w-brain-template-symmetric</code></td><td><code>T1w-brain-template-symmetric</code></td></tr>
</table>

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
[![failing smoke tests](https://github.com/user-attachments/assets/6a83bae7-1f7b-41c2-b20d-dd07a0318c4c)](https://github.com/FCP-INDI/C-PAC/actions/runs/14110790786)

[![successful smoke tests](https://github.com/user-attachments/assets/c785494c-00d7-4bc9-ae9b-9a467b613f07)](https://github.com/FCP-INDI/C-PAC/actions/runs/14116485272)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
