### PR TITLE
🔧 Turn on XCP-QC by default in preconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `desc-ref_bold` created in this workflow to `desc-unifized_bold`.
   - `coregistration_prep_fmriprep` nodeblock now checks if `desc-unifized_bold` exists in the Resource Pool, if not it runs the `FSL-AFNI subworkflow` to create it.
 - Input `desc-brain_bold` to `desc-preproc_bold` for `sbref` generation nodeblock `coregistration_prep_vol`.
+- Turned `generate_xcpqc_files` on for all preconfigurations except `blank`.
 
 ### Fixed
 

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -13,6 +13,10 @@ pipeline_setup:
   # Name for this pipeline configuration - useful for identification.
   # This string will be sanitized and used in filepaths
   pipeline_name: cpac_abcd-options
+  output_directory:
+    quality_control:
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
   system_config:
 
     # The maximum amount of memory each participant's workflow can allocate.

--- a/CPAC/resources/configs/pipeline_config_abcd-prep.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-prep.yml
@@ -13,6 +13,10 @@ pipeline_setup:
   # Name for this pipeline configuration - useful for identification.
   # This string will be sanitized and used in filepaths
   pipeline_name: cpac_abcd-prep
+  output_directory:
+    quality_control:
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
   system_config:
 
     # The maximum amount of memory each participant's workflow can allocate.

--- a/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
+++ b/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_ccs-options.yml
+++ b/CPAC/resources/configs/pipeline_config_ccs-options.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_default-deprecated.yml
+++ b/CPAC/resources/configs/pipeline_config_default-deprecated.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
 anatomical_preproc:
   run: On
   acpc_alignment:

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -54,10 +54,10 @@ pipeline_setup:
     # Quality control outputs
     quality_control:
       # Generate quality control pages containing preprocessing and derivative outputs.
-      generate_quality_control_images: True
+      generate_quality_control_images: On
 
       # Generate eXtensible Connectivity Pipeline-style quality control files
-      generate_xcpqc_files: False
+      generate_xcpqc_files: On
 
   working_directory:
 

--- a/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-ingress.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
   outdir_ingress:
     run: On
     Template: MNI152NLin2009cAsym

--- a/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
+++ b/CPAC/resources/configs/pipeline_config_fmriprep-options.yml
@@ -13,6 +13,10 @@ pipeline_setup:
   # Name for this pipeline configuration - useful for identification.
   # This string will be sanitized and used in filepaths
   pipeline_name: cpac_fmriprep-options
+  output_directory:
+    quality_control:
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
   system_config:
 
     # Select Off if you intend to run CPAC on a single machine.

--- a/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey-ABCD.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
   system_config:
 
     # Select Off if you intend to run CPAC on a single machine.

--- a/CPAC/resources/configs/pipeline_config_monkey.yml
+++ b/CPAC/resources/configs/pipeline_config_monkey.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
   system_config:
 
     # Select Off if you intend to run CPAC on a single machine.

--- a/CPAC/resources/configs/pipeline_config_ndmg.yml
+++ b/CPAC/resources/configs/pipeline_config_ndmg.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
   system_config:
 
     # The number of cores to allocate to ANTS-based anatomical registration per participant.

--- a/CPAC/resources/configs/pipeline_config_regtest-1.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-1.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_regtest-2.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-2.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_regtest-3.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-3.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_regtest-4.yml
+++ b/CPAC/resources/configs/pipeline_config_regtest-4.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
     # Include extra versions and intermediate steps of functional preprocessing in the output directory.
     write_func_outputs: On
 

--- a/CPAC/resources/configs/pipeline_config_rodent.yml
+++ b/CPAC/resources/configs/pipeline_config_rodent.yml
@@ -21,6 +21,9 @@ pipeline_setup:
       # Generate quality control pages containing preprocessing and derivative outputs.
       generate_quality_control_images: On
 
+      # Generate eXtensible Connectivity Pipeline-style quality control files
+      generate_xcpqc_files: On
+
   system_config:
 
     # The maximum amount of memory each participant's workflow can allocate.


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
* Related to 

  > `pipeline_setup.output_directory.quality_control.generate_xcpqc_files` seems to be true by default for RBC, false for fmriPrep, ABCD and CCS

  by @nx10 [on <img alt="Slack" src="https://github.com/user-attachments/assets/33ead9cf-02c7-4304-b830-124ee8f8e7e9" height="12px">](https://cmi-cnl.slack.com/archives/C06DP5JLK9R/p1742399472065999?thread_ts=1742251320.388849&cid=C06DP5JLK9R)
* Related to conversation in [2025-03-27 <img alt="Teams meeting" src="https://github.com/user-attachments/assets/fede92ee-0d77-4c08-b48a-c066c59cbe69"> DAIR Topic Focus: Pipeline, Platforms & Sustainability](https://teams.microsoft.com/l/meetingrecap?driveId=b%21QofO9yx4CUqXWTzFrVX9VIoJ7c9A9RRFuHvA_oBee-vfTV_0E9K-TpX6W5ZAUyo9&driveItemId=01MCKYGNMIFVJBIKJHZJHZNXOYSMW2U2CE&sitePath=https%3A%2F%2Fchildmindinstitute759-my.sharepoint.com%2F%3Av%3A%2Fg%2Fpersonal%2Fgregory_kiar_childmind_org%2FEYgtUhQpJ8pPlt3Yky2qaEQBjvtxMqGnsl7FkQ9nTg35Xg&fileUrl=https%3A%2F%2Fchildmindinstitute759-my.sharepoint.com%2Fpersonal%2Fgregory_kiar_childmind_org%2FDocuments%2FRecordings%2FDAIR%2520Topic%2520Focus%2520Pipeline%2C%2520Platforms%2520%2526%2520Sustainability-20250327_153154-Meeting%2520Recording.mp4%3Fweb%3D1&iCalUid=040000008200E00074C5B7101A82E00807E9031B51CBA67FE31FDB01000000000000000010000000099C046E13A6E749B893FEB7A26C6750&masterICalUid=040000008200E00074C5B7101A82E0080000000051CBA67FE31FDB01000000000000000010000000099C046E13A6E749B893FEB7A26C6750&threadId=19%3Ameeting_NWI5ZWE5ODctNmVkOC00NGRkLWI2ZWMtY2EzZDNhZDA4NDQ2%40thread.v2&organizerId=87eff324-2b1c-46b7-b29e-0e3c6f33b17d&tenantId=7e9101c6-6f89-42a1-80ba-1af9e680cc3a&callId=902178ed-c3b9-4282-88a3-2078e1292ce0&threadType=meeting&meetingType=Recurring&subType=RecapSharingLink_RecapCore)

## Description
<!-- Concisely describe what the pull request does. -->
Turns `pipeline_setup.output_directory.quality_control.generate_xcpqc_files` on in all preconfigs except `blank`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
