### PR TITLE
Fix/restore brain intensity abcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `coregistration_prep_fmriprep` nodeblock now checks if `desc-unifized_bold` exists in the Resource Pool, if not it runs the `FSL-AFNI subworkflow` to create it.
 - Input `desc-brain_bold` to `desc-preproc_bold` for `sbref` generation nodeblock `coregistration_prep_vol`.
 - Turned `generate_xcpqc_files` on for all preconfigurations except `blank`.
-- Introduced specific switch for `correct_restore_brain_intensity_abcd` nodeblock, enabling it by default only in `abcd-options` pre-config.
+- Introduced specific switch `restore_t1w_intensity` for `correct_restore_brain_intensity_abcd` nodeblock, enabling it by default only in `abcd-options` pre-config.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `coregistration_prep_fmriprep` nodeblock now checks if `desc-unifized_bold` exists in the Resource Pool, if not it runs the `FSL-AFNI subworkflow` to create it.
 - Input `desc-brain_bold` to `desc-preproc_bold` for `sbref` generation nodeblock `coregistration_prep_vol`.
 - Turned `generate_xcpqc_files` on for all preconfigurations except `blank`.
+- Introduced specific switch for `correct_restore_brain_intensity_abcd` nodeblock, enabling it by default only in `abcd-options` pre-config.
 
 ### Fixed
 

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -3161,8 +3161,8 @@ def fast_bias_field_correction(config=None, wf_name="fast_bias_field_correction"
 
 @nodeblock(
     name="correct_restore_brain_intensity_abcd",
-    config=["anatomical_preproc", "brain_extraction", "FreeSurfer-ABCD"],
-    switch=["correct_restore_brain_intensity_abcd"],
+    config=["anatomical_preproc", "restore_t1w_intensity"],
+    switch=["run"],
     inputs=[
         (
             "desc-preproc_T1w",

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -3161,9 +3161,8 @@ def fast_bias_field_correction(config=None, wf_name="fast_bias_field_correction"
 
 @nodeblock(
     name="correct_restore_brain_intensity_abcd",
-    config=["anatomical_preproc", "brain_extraction"],
-    option_key="using",
-    option_val="FreeSurfer-ABCD",
+    config=["anatomical_preproc", "brain_extraction", "FreeSurfer-ABCD"],
+    switch=["correct_restore_brain_intensity_abcd"],
     inputs=[
         (
             "desc-preproc_T1w",

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -638,6 +638,9 @@ latest_schema = Schema(
                     "regmask_path": Maybe(str),
                 },
                 "FreeSurfer-BET": {"T1w_brain_template_mask_ccs": Maybe(str)},
+                "FreeSurfer-ABCD": {
+                    "correct_restore_brain_intensity_abcd": bool1_1,
+                },
             },
         },
         "segmentation": {

--- a/CPAC/pipeline/schema.py
+++ b/CPAC/pipeline/schema.py
@@ -638,9 +638,9 @@ latest_schema = Schema(
                     "regmask_path": Maybe(str),
                 },
                 "FreeSurfer-BET": {"T1w_brain_template_mask_ccs": Maybe(str)},
-                "FreeSurfer-ABCD": {
-                    "correct_restore_brain_intensity_abcd": bool1_1,
-                },
+            },
+            "restore_t1w_intensity": {
+                "run": bool1_1,
             },
         },
         "segmentation": {

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -84,8 +84,8 @@ anatomical_preproc:
     # this is a fork option
     using: [FreeSurfer-ABCD]
 
-    FreeSurfer-ABCD:
-      correct_restore_brain_intensity_abcd: On
+  restore_t1w_intensity:
+    run: On
 
   # Non-local means filtering via ANTs DenoiseImage
   non_local_means_filtering:

--- a/CPAC/resources/configs/pipeline_config_abcd-options.yml
+++ b/CPAC/resources/configs/pipeline_config_abcd-options.yml
@@ -84,6 +84,9 @@ anatomical_preproc:
     # this is a fork option
     using: [FreeSurfer-ABCD]
 
+    FreeSurfer-ABCD:
+      correct_restore_brain_intensity_abcd: On
+
   # Non-local means filtering via ANTs DenoiseImage
   non_local_means_filtering:
 

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -419,6 +419,9 @@ anatomical_preproc:
       # niworkflows-ants registration mask (can be optional)
       regmask_path: /ants_template/oasis/T_template0_BrainCerebellumRegistrationMask.nii.gz
 
+    FreeSurfer-ABCD:
+      correct_restore_brain_intensity_abcd: Off
+
   run_t2: Off
 
   # Bias field correction based on square root of T1w * T2w

--- a/CPAC/resources/configs/pipeline_config_blank.yml
+++ b/CPAC/resources/configs/pipeline_config_blank.yml
@@ -419,8 +419,8 @@ anatomical_preproc:
       # niworkflows-ants registration mask (can be optional)
       regmask_path: /ants_template/oasis/T_template0_BrainCerebellumRegistrationMask.nii.gz
 
-    FreeSurfer-ABCD:
-      correct_restore_brain_intensity_abcd: Off
+  restore_t1w_intensity:
+    run: Off
 
   run_t2: Off
 

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -484,8 +484,8 @@ anatomical_preproc:
       # Template to be used for FreeSurfer-BET brain extraction in CCS-options pipeline
       T1w_brain_template_mask_ccs: /ccs_template/MNI152_T1_1mm_first_brain_mask.nii.gz
 
-    FreeSurfer-ABCD:
-      correct_restore_brain_intensity_abcd: Off
+  restore_t1w_intensity:
+    run: Off
 
 
 segmentation:

--- a/CPAC/resources/configs/pipeline_config_default.yml
+++ b/CPAC/resources/configs/pipeline_config_default.yml
@@ -484,6 +484,9 @@ anatomical_preproc:
       # Template to be used for FreeSurfer-BET brain extraction in CCS-options pipeline
       T1w_brain_template_mask_ccs: /ccs_template/MNI152_T1_1mm_first_brain_mask.nii.gz
 
+    FreeSurfer-ABCD:
+      correct_restore_brain_intensity_abcd: Off
+
 
 segmentation:
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2206  by @birajstha 
Related to https://github.com/FCP-INDI/C-PAC/issues/2047
Details are discussed [here in the slack thread.](https://cmi-cnl.slack.com/archives/C065W7YJ4V9/p1743697694533529)
## Description
<!-- Concisely describe what the pull request does. -->
Adds a specific switch for `restore_t1w_intensity`
## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Tested running `test-config`.
It completed fine after the fix.
```bash
#!/usr/bin/bash
#SBATCH -N 1
#SBATCH -p RM-shared
#SBATCH -t 50:00:00

MED=/ocean/projects/med250004p
DATA=/ocean/projects/med250004p/bshresth/projects/fs_orientation/data
OUTPUT=/ocean/projects/med250004p/bshresth/projects/fs_orientation/output2
IMAGE=/ocean/projects/med250004p/bshresth/projects/fs_orientation/cpac_nightly.sif

PIPELINE=/ocean/projects/med250004p/bshresth/projects/fs_orientation/configs/ingress_fs.yml


subject=sub-PA001


repo=/ocean/projects/med250004p/bshresth/projects/fs_orientation/C-PAC
singularity run \
    -B $MED \
    -B $DATA:$DATA \
    -B $OUTPUT:$OUTPUT $IMAGE $DATA $OUTPUT test-config \
    --num_ants_threads 5 \
    --skip_bids_validator \
    --n_cpus 2 \
    --mem_gb 50 \
    --pipeline_file $PIPELINE \
    --participant_label $subject
```
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Before
![image](https://github.com/user-attachments/assets/29ee8c57-f773-40e1-a641-a197b5ca7491)

After the fix
![image](https://github.com/user-attachments/assets/67a0b99c-4a6b-4a49-9a06-27a5eec2c6d0)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
