### PR TITLE
♻️ DRY up output key collection for group config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed empty `shell` variable in cluster run scripts.
 - A bug in which bandpass filters always assumed 1D regressor files have exactly 5 header rows.
 - Removed an erroneous connection to AFNI 3dTProject in nuisance denoising that would unnecessarily send a spike regressor as a censor. This would sometimes cause TRs to unnecessarily be dropped from the timeseries as if scrubbing were being performed.
+- Lingering calls to `cpac_outputs.csv` (was changed to `cpac_outputs.tsv` in v1.8.1).
 
 ### Removed
 

--- a/CPAC/pipeline/cpac_group_runner.py
+++ b/CPAC/pipeline/cpac_group_runner.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024  C-PAC Developers
+# Copyright (C) 2022-2025  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -143,31 +143,12 @@ def gather_nifti_globs(pipeline_output_folder, resource_list, pull_func=False):
     import glob
     import os
 
-    import pandas as pd
-    import pkg_resources as p
+    from CPAC.utils.outputs import group_derivatives
 
     exts = ".nii"
     nifti_globs = []
 
-    keys_tsv = p.resource_filename("CPAC", "resources/cpac_outputs.tsv")
-    try:
-        keys = pd.read_csv(keys_tsv, delimiter="\t")
-    except Exception as e:
-        err = (
-            "\n[!] Could not access or read the cpac_outputs.tsv "
-            f"resource file:\n{keys_tsv}\n\nError details {e}\n"
-        )
-        raise Exception(err)
-
-    derivative_list = list(keys[keys["Sub-Directory"] == "func"]["Resource"])
-    derivative_list = derivative_list + list(
-        keys[keys["Sub-Directory"] == "anat"]["Resource"]
-    )
-
-    if pull_func:
-        derivative_list = derivative_list + list(
-            keys[keys["Space"] == "functional"]["Resource"]
-        )
+    derivative_list = group_derivatives(pull_func)
 
     if len(resource_list) == 0:
         err = "\n\n[!] No derivatives selected!\n\n"
@@ -361,33 +342,14 @@ def create_output_dict_list(
     """Create a dictionary of output filepaths and their associated information."""
     import os
 
-    import pandas as pd
-    import pkg_resources as p
-
     if len(resource_list) == 0:
         err = "\n\n[!] No derivatives selected!\n\n"
         raise Exception(err)
 
     if derivatives is None:
-        keys_tsv = p.resource_filename("CPAC", "resources/cpac_outputs.tsv")
-        try:
-            keys = pd.read_csv(keys_tsv, delimiter="\t")
-        except Exception as e:
-            err = (
-                "\n[!] Could not access or read the cpac_outputs.csv "
-                f"resource file:\n{keys_tsv}\n\nError details {e}\n"
-            )
-            raise Exception(err)
+        from CPAC.utils.outputs import group_derivatives
 
-        derivatives = list(keys[keys["Sub-Directory"] == "func"]["Resource"])
-        derivatives = derivatives + list(
-            keys[keys["Sub-Directory"] == "anat"]["Resource"]
-        )
-
-        if pull_func:
-            derivatives = derivatives + list(
-                keys[keys["Space"] == "functional"]["Resource"]
-            )
+        derivatives = group_derivatives(pull_func)
 
     # remove any extra /'s
     pipeline_output_folder = pipeline_output_folder.rstrip("/")
@@ -752,18 +714,10 @@ def prep_feat_inputs(group_config_file: str) -> dict:
     import os
 
     import pandas as pd
-    import pkg_resources as p
 
-    keys_tsv = p.resource_filename("CPAC", "resources/cpac_outputs.tsv")
-    try:
-        keys = pd.read_csv(keys_tsv, delimiter="\t")
-    except Exception as e:
-        err = (
-            "\n[!] Could not access or read the cpac_outputs.tsv "
-            f"resource file:\n{keys_tsv}\n\nError details {e}\n"
-        )
-        raise Exception(err)
+    from CPAC.utils.outputs import Outputs
 
+    keys = Outputs.reference
     derivatives = list(
         keys[keys["Derivative"] == "yes"][keys["Space"] == "template"][
             keys["Values"] == "z-score"

--- a/CPAC/utils/create_fsl_flame_preset.py
+++ b/CPAC/utils/create_fsl_flame_preset.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2024  C-PAC Developers
+# Copyright (C) 2018-2025  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -1091,20 +1091,6 @@ def run(
     #       or something
 
     import os
-
-    import pandas as pd
-    import pkg_resources as p
-
-    # make life easy
-    keys_csv = p.resource_filename("CPAC", "resources/cpac_outputs.csv")
-    try:
-        pd.read_csv(keys_csv)
-    except Exception as e:
-        err = (
-            "\n[!] Could not access or read the cpac_outputs.csv "
-            f"resource file:\n{keys_csv}\n\nError details {e}\n"
-        )
-        raise Exception(err)
 
     if derivative_list == "all":
         derivative_list = [

--- a/CPAC/utils/outputs.py
+++ b/CPAC/utils/outputs.py
@@ -17,6 +17,7 @@
 """Specify the resources that C-PAC writes to the output direcotry."""
 
 from importlib.resources import files
+from typing import ClassVar
 
 import pandas as pd
 
@@ -47,8 +48,12 @@ class Outputs:
         reference[reference["4D Time Series"] == "Yes"]["Resource"]
     )
 
-    anat = list(reference[reference["Sub-Directory"] == "anat"]["Resource"])
-    func = list(reference[reference["Sub-Directory"] == "func"]["Resource"])
+    anat: ClassVar[list[str]] = list(
+        reference[reference["Sub-Directory"] == "anat"]["Resource"]
+    )
+    func: ClassVar[list[str]] = list(
+        reference[reference["Sub-Directory"] == "func"]["Resource"]
+    )
 
     # outputs to send into smoothing, if smoothing is enabled, and
     # outputs to write out if the user selects to write non-smoothed outputs
@@ -64,6 +69,8 @@ class Outputs:
 
     all_template_filter = _template_filter | _epitemplate_filter | _symtemplate_filter
     all_native_filter = _T1w_native_filter | _bold_native_filter | _long_native_filter
+
+    bold_native: ClassVar[list[str]] = list(reference[_bold_native_filter]["Resource"])
 
     native_nonsmooth = list(
         reference[all_native_filter & _nonsmoothed_filter]["Resource"]
@@ -121,3 +128,11 @@ class Outputs:
         for gifti in giftis.itertuples()
         if " " in gifti.File
     }
+
+
+def group_derivatives(pull_func: bool = False) -> list[str]:
+    """Gather keys for anatomical and functional derivatives for group analysis."""
+    derivatives: list[str] = Outputs.func + Outputs.anat
+    if pull_func:
+        derivatives = derivatives + Outputs.bold_native
+    return derivatives


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes [Load preset paired t-test with CPAC](https://neurostars.org/t/load-preset-paired-t-test-with-cpac/33038?u=shnizzedy) by [**@luisagulleiro**](https://neurostars.org/u/luisagulleiro)

## Description
<!-- Concisely describe what the pull request does. -->
`cpac_outputs.csv` was transitioned to `cpac_outputs.tsv` in v1.8.1 (deprecated in #1518 and removed in #1569 but a couple calls in the group runner didn't get updated.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
This PR consolidates the loading of `outputs.tsv` to a single call and <span title="Don't Repeat Yourself">DRY</span>s up https://github.com/FCP-INDI/C-PAC/blob/2ffff67db94fe71690c65d2bc2c6cd76389eb7ca/CPAC/pipeline/cpac_group_runner.py#L382-L390 https://github.com/FCP-INDI/C-PAC/blob/2ffff67db94fe71690c65d2bc2c6cd76389eb7ca/CPAC/pipeline/cpac_group_runner.py#L162-L170 into https://github.com/FCP-INDI/C-PAC/blob/09853bdb75ca90997a361f778a5e8355ad51a691/CPAC/utils/outputs.py#L133-L138 https://github.com/FCP-INDI/C-PAC/blob/09853bdb75ca90997a361f778a5e8355ad51a691/CPAC/pipeline/cpac_group_runner.py#L352 https://github.com/FCP-INDI/C-PAC/blob/09853bdb75ca90997a361f778a5e8355ad51a691/CPAC/pipeline/cpac_group_runner.py#L151

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
