### PR TITLE
🐛 Fix `Invalid phase-encoding direction entered: b'j-'`

### DIFF
--- a/CPAC/utils/utils.py
+++ b/CPAC/utils/utils.py
@@ -525,6 +525,9 @@ class ScanParameters:
             msg = f"Missing value for {val_to_check} for participant {self.subject}."
             raise ValueError(msg)
 
+        if isinstance(ret_val, bytes):
+            ret_val = ret_val.decode("utf-8")
+
         return ret_val
 
     @overload
@@ -631,6 +634,8 @@ class ScanParameters:
                 f" ≅ '{matched_keys[1]}'."
             )
         if convert_to:
+            if isinstance(raw_value, bytes):
+                raw_value = raw_value.decode("utf-8")
             try:
                 value = convert_to(raw_value)
             except (TypeError, ValueError):
@@ -2634,8 +2639,6 @@ def _replace_in_value_list(current_value, replacement_tuple):
 
 
 def flip_orientation_code(code):
-    """
-    Reverts an orientation code by flipping R↔L, A↔P, and I↔S.
-    """
+    """Reverts an orientation code by flipping R↔L, A↔P, and I↔S."""
     flip_dict = {"R": "L", "L": "R", "A": "P", "P": "A", "I": "S", "S": "I"}
     return "".join(flip_dict[c] for c in code)


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2129 by @shnizzedy
Fixes #1036 by @sgiavasis 
Related to #2225 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Decodes bytestrings before coercing their type.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Before this change, bytstrings like `b"j-"` were being converted to string like `"b'j-'"`; now they'll be converted to strings like `"j-"`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
