### PR TITLE
🐛 Restore header to `censors.tsv`

### DIFF
--- a/CPAC/nuisance/nuisance.py
+++ b/CPAC/nuisance/nuisance.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2024  C-PAC Developers
+# Copyright (C) 2012-2025  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -14,6 +14,8 @@
 
 # You should have received a copy of the GNU Lesser General Public
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""Nusiance regression."""
+
 import os
 from typing import Literal
 
@@ -29,6 +31,7 @@ from CPAC.aroma.aroma import create_aroma
 from CPAC.nuisance.utils import (
     find_offending_time_points,
     generate_summarize_tissue_mask,
+    load_censor_tsv,
     temporal_variance_mask,
 )
 from CPAC.nuisance.utils.compcor import (
@@ -302,7 +305,7 @@ def gather_nuisance(
             raise ValueError(msg)
 
         try:
-            regressors = np.loadtxt(regressor_file)
+            regressors = load_censor_tsv(regressor_file, regressor_length)
         except (OSError, TypeError, UnicodeDecodeError, ValueError) as error:
             msg = f"Could not read regressor {regressor_type} from {regressor_file}."
             raise OSError(msg) from error
@@ -382,7 +385,7 @@ def gather_nuisance(
     if custom_file_paths:
         for custom_file_path in custom_file_paths:
             try:
-                custom_regressor = np.loadtxt(custom_file_path)
+                custom_regressor = load_censor_tsv(custom_file_path, regressor_length)
             except:
                 msg = "Could not read regressor {0} from {1}.".format(
                     "Custom", custom_file_path
@@ -421,7 +424,7 @@ def gather_nuisance(
             censor_volumes = np.ones((regressor_length,), dtype=int)
         else:
             try:
-                censor_volumes = np.loadtxt(regressor_file)
+                censor_volumes = load_censor_tsv(regressor_file, regressor_length)
             except:
                 msg = (
                     f"Could not read regressor {regressor_type} from {regressor_file}."

--- a/CPAC/nuisance/tests/test_utils.py
+++ b/CPAC/nuisance/tests/test_utils.py
@@ -1,8 +1,26 @@
+# Copyright (C) 2019-2025  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""Test nuisance utilities."""
+
+from importlib.resources import as_file, files
 import os
 import tempfile
 
 import numpy as np
-import pkg_resources as p
 import pytest
 
 from CPAC.nuisance.utils import calc_compcor_components, find_offending_time_points
@@ -10,24 +28,22 @@ from CPAC.utils.monitoring.custom_logging import getLogger
 
 logger = getLogger("CPAC.nuisance.tests")
 
-mocked_outputs = p.resource_filename(
-    "CPAC", os.path.join("nuisance", "tests", "motion_statistics")
-)
+_mocked_outputs = files("CPAC").joinpath("nuisance/tests/motion_statistics")
 
 
 @pytest.mark.skip(reason="needs refactoring")
 def test_find_offending_time_points():
     dl_dir = tempfile.mkdtemp()
     os.chdir(dl_dir)
-
-    censored = find_offending_time_points(
-        os.path.join(mocked_outputs, "FD_J.1D"),
-        os.path.join(mocked_outputs, "FD_P.1D"),
-        os.path.join(mocked_outputs, "DVARS.1D"),
-        2.0,
-        2.0,
-        "1.5SD",
-    )
+    with as_file(_mocked_outputs) as mocked_outputs:
+        censored = find_offending_time_points(
+            str(mocked_outputs / "FD_J.1D"),
+            str(mocked_outputs / "FD_P.1D"),
+            str(mocked_outputs / "DVARS.1D"),
+            2.0,
+            2.0,
+            "1.5SD",
+        )
 
     censored = np.loadtxt(censored).astype(bool)
 
@@ -41,4 +57,4 @@ def test_calc_compcor_components():
 
     compcor_filename = calc_compcor_components(data_filename, 5, mask_filename)
     logger.info("compcor components written to %s", compcor_filename)
-    assert 0 == 1
+

--- a/CPAC/nuisance/utils/__init__.py
+++ b/CPAC/nuisance/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2024  C-PAC Developers
+# Copyright (C) 2019-2025  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -21,6 +21,7 @@ from .compcor import calc_compcor_components
 from .utils import (
     find_offending_time_points,
     generate_summarize_tissue_mask,
+    load_censor_tsv,
     NuisanceRegressor,
     temporal_variance_mask,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "compcor",
     "find_offending_time_points",
     "generate_summarize_tissue_mask",
+    "load_censor_tsv",
     "NuisanceRegressor",
     "temporal_variance_mask",
 ]

--- a/CPAC/nuisance/utils/utils.py
+++ b/CPAC/nuisance/utils/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2024  C-PAC Developers
+# Copyright (C) 2019-2025  C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -21,6 +21,7 @@ import os
 import re
 from typing import Optional
 
+import numpy as np
 from nipype.interfaces import afni, ants, fsl
 import nipype.interfaces.utility as util
 from nipype.pipeline.engine import Workflow
@@ -860,3 +861,19 @@ class NuisanceRegressor(object):
     def __repr__(self) -> str:
         """Return a string representation of the nuisance regressor."""
         return NuisanceRegressor.encode(self.selector)
+
+
+def load_censor_tsv(filepath: str, expected_length: int) -> np.ndarray:
+    """Load censor TSV and verify length."""
+    header = False
+    censor = np.empty((0))
+    try:
+        censor = np.loadtxt(filepath)
+    except ValueError:
+        header = True
+    if header or censor.shape[0] == expected_length + 1:
+        censor = np.loadtxt(filepath, skiprows=1)
+    if censor.shape[0] == expected_length:
+        return censor
+    msg = f"Censor file length ({censor.shape[0]}) does not match expected length ({expected_length})."
+    raise ValueError(msg)

--- a/CPAC/nuisance/utils/utils.py
+++ b/CPAC/nuisance/utils/utils.py
@@ -139,7 +139,7 @@ def find_offending_time_points(
     censor_vector[extended_censors] = 0
 
     out_file_path = os.path.join(os.getcwd(), "censors.tsv")
-    np.savetxt(out_file_path, censor_vector, fmt="%d", comments="")
+    np.savetxt(out_file_path, censor_vector, fmt="%d", header="censor", comments="")
 
     return out_file_path
 


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2181 by @sgiavasis 
Related to #2225 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Restores the header

```TSV
censor
```

to `censors.tsv`. Without it, 3dTProject was reading the first row as the header, resulting in 1-too-few timepoints (and the timepoints being off by one).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
