### PR TITLE
♻️ Make datetime-subtraction-safe None values

### DIFF
--- a/CPAC/utils/monitoring/draw_gantt_chart.py
+++ b/CPAC/utils/monitoring/draw_gantt_chart.py
@@ -23,7 +23,7 @@
 
 #     Prior to release 0.12, Nipype was licensed under a BSD license.
 
-# Modifications Copyright (C) 2021-2023 C-PAC Developers
+# Modifications Copyright (C) 2021-2025 C-PAC Developers
 
 # This file is part of C-PAC.
 
@@ -51,6 +51,8 @@ import random
 from warnings import warn
 
 from nipype.utils.draw_gantt_chart import draw_lines, draw_resource_bar, log_to_dict
+
+from CPAC.utils.monitoring.monitoring import DatetimeWithSafeNone
 
 
 def create_event_dict(start_time, nodes_list):
@@ -407,7 +409,11 @@ def generate_gantt_chart(
     # Create the header of the report with useful information
     start_node = nodes_list[0]
     last_node = nodes_list[-1]
-    duration = (last_node["finish"] - start_node["start"]).total_seconds()
+    try:
+        duration = (last_node["finish"] - start_node["start"]).total_seconds()
+    except TypeError:
+        # no duration
+        return
 
     # Get events based dictionary of node run stats
     events = create_event_dict(start_node["start"], nodes_list)
@@ -656,12 +662,12 @@ def _timing_timestamp(node):
         msg = "No logged nodes have timing information."
         raise ProcessLookupError(msg)
     return {
-        k: (
+        k: DatetimeWithSafeNone(
             datetime.strptime(v, "%Y-%m-%dT%H:%M:%S.%f")
             if "." in v
             else datetime.fromisoformat(v)
         )
         if (k in {"start", "finish"} and isinstance(v, str))
-        else v
+        else DatetimeWithSafeNone(v)
         for k, v in node.items()
     }

--- a/CPAC/utils/monitoring/monitoring.py
+++ b/CPAC/utils/monitoring/monitoring.py
@@ -23,7 +23,7 @@ import math
 import os
 import socketserver
 import threading
-from typing import Optional, TypeAlias
+from typing import Any, Optional, TypeAlias
 
 import networkx as nx
 from traits.trait_base import Undefined
@@ -124,6 +124,23 @@ class DatetimeWithSafeNone(datetime, _NoTime):
         return super().__str__()
 
 
+class DatetimeJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles DatetimeWithSafeNone instances."""
+
+    def default(self, o: Any) -> str:
+        """Convert datetime objects to ISO format."""
+        if isinstance(o, datetime):
+            return o.isoformat()
+        if o is None or o is NoTime:
+            return ""
+        return super().default(o)
+
+
+def json_dumps(obj: Any, **kwargs) -> str:
+    """Convert an object to a JSON string."""
+    return json.dumps(obj, cls=DatetimeJSONEncoder, **kwargs)
+
+
 OptionalDatetime: TypeAlias = Optional[datetime | str | DatetimeWithSafeNone | _NoTime]
 """Type alias for a datetime, ISO-format string or None."""
 
@@ -144,7 +161,7 @@ def recurse_nodes(workflow, prefix=""):
 def log_nodes_initial(workflow):
     logger = getLogger("callback")
     for node in recurse_nodes(workflow):
-        logger.debug(json.dumps(node))
+        logger.debug(json_dumps(node))
 
 
 def log_nodes_cb(node, status):
@@ -242,7 +259,7 @@ def log_nodes_cb(node, status):
     ):
         status_dict["error"] = True
 
-    logger.debug(json.dumps(status_dict))
+    logger.debug(json_dumps(status_dict))
 
 
 log_nodes_cb.__doc__ = f"""{_nipype_log_nodes_cb.__doc__}
@@ -299,7 +316,7 @@ class LoggingRequestHandler(socketserver.BaseRequestHandler):
                 tree = {s: t for s, t in tree.items() if t}
 
         headers = "HTTP/1.1 200 OK\nConnection: close\n\n"
-        self.request.sendall(headers + json.dumps(tree) + "\n")
+        self.request.sendall(headers + json_dumps(tree) + "\n")
 
 
 class LoggingHTTPServer(socketserver.ThreadingTCPServer, object):

--- a/CPAC/utils/monitoring/monitoring.py
+++ b/CPAC/utils/monitoring/monitoring.py
@@ -1,9 +1,29 @@
+# Copyright (C) 2018-2025  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
+"""Monitoring utilities for C-PAC."""
+
+from datetime import datetime, timedelta
 import glob
 import json
 import math
 import os
 import socketserver
 import threading
+from typing import Optional, TypeAlias
 
 import networkx as nx
 from traits.trait_base import Undefined
@@ -13,8 +33,103 @@ from CPAC.pipeline import nipype_pipeline_engine as pe
 from .custom_logging import getLogger
 
 
-# Log initial information from all the nodes
+def _safe_none_diff(
+    self: "DatetimeWithSafeNone | _NoTime", other: "DatetimeWithSafeNone | _NoTime"
+) -> datetime | timedelta:
+    """Subtract between a datetime or timedelta or None."""
+    if isinstance(self, _NoTime):
+        return timedelta(0)
+    if isinstance(other, DatetimeWithSafeNone):
+        if isinstance(other, _NoTime):
+            return timedelta(0)
+        return self - other
+    if isinstance(other, (datetime, timedelta)):
+        return self._dt - other
+    msg = f"Cannot subtract {type(other)} from {type(self)}"
+    raise NotImplementedError(msg)
+
+
+class _NoTime:
+    """A wrapper for None values that can be used in place of a datetime object."""
+
+    def __bool__(self) -> bool:
+        """Return False for _NoTime."""
+        return False
+
+    def __int__(self) -> int:
+        """Return 0 for _NoTime."""
+        return 0
+
+    def __repr__(self) -> str:
+        """Return 'NoTime' for _NoTime."""
+        return "NoTime"
+
+    def __str__(self) -> str:
+        """Return 'NoTime' for _NoTime."""
+        return "NoTime"
+
+    def __sub__(self, other: "DatetimeWithSafeNone | _NoTime") -> datetime | timedelta:
+        """Subtract between None and a datetime or timedelta or None."""
+        return _safe_none_diff(self, other)
+
+
+NoTime = _NoTime()
+"""A singleton None that can be used in place of a datetime object."""
+
+
+class DatetimeWithSafeNone(datetime, _NoTime):
+    """Time class that can be None or a time value."""
+
+    def __new__(cls, dt: "OptionalDatetime") -> "DatetimeWithSafeNone | _NoTime":
+        """Create a new instance of the class."""
+        if dt is None:
+            return NoTime
+        if isinstance(dt, datetime):
+            return datetime.__new__(
+                cls,
+                dt.year,
+                dt.month,
+                dt.day,
+                dt.hour,
+                dt.minute,
+                dt.second,
+                dt.microsecond,
+                dt.tzinfo,
+            )
+        if isinstance(dt, str):
+            try:
+                return DatetimeWithSafeNone(datetime.fromisoformat(dt))
+            except (ValueError, TypeError):
+                error = f"Invalid ISO-format datetime string: {dt}"
+        else:
+            error = f"Cannot convert {type(dt)} to datetime"
+        raise TypeError(error)
+
+    def __bool__(self) -> bool:
+        """Return True if not NoTime."""
+        return self is not NoTime
+
+    def __sub__(self, other: "DatetimeWithSafeNone | _NoTime") -> datetime | timedelta:
+        """Subtract between a datetime or timedelta or None."""
+        return _safe_none_diff(self, other)
+
+    def __repr__(self) -> str:
+        """Return the string representation of the datetime or NoTime."""
+        if self:
+            return datetime.__repr__(self)
+        return "NoTime"
+
+    def __str__(self) -> str:
+        """Return the string representation of the datetime or NoTime."""
+        return super().__str__()
+
+
+OptionalDatetime: TypeAlias = Optional[datetime | str | DatetimeWithSafeNone | _NoTime]
+"""Type alias for a datetime, ISO-format string or None."""
+
+
 def recurse_nodes(workflow, prefix=""):
+    """Log initial information from all the nodes."""
     for node in nx.topological_sort(workflow._graph):
         if isinstance(node, pe.Workflow):
             for subnode in recurse_nodes(node, prefix + workflow.name + "."):
@@ -111,8 +226,8 @@ def log_nodes_cb(node, status):
     status_dict = {
         "id": str(node),
         "hash": node.inputs.get_hashval()[1],
-        "start": getattr(runtime, "startTime", None),
-        "finish": getattr(runtime, "endTime", None),
+        "start": DatetimeWithSafeNone(getattr(runtime, "startTime", None)),
+        "finish": DatetimeWithSafeNone(getattr(runtime, "endTime", None)),
         "runtime_threads": runtime_threads,
         "runtime_memory_gb": getattr(runtime, "mem_peak_gb", "N/A"),
         "estimated_memory_gb": node.mem_gb,
@@ -122,7 +237,9 @@ def log_nodes_cb(node, status):
     if hasattr(node, "input_data_shape") and node.input_data_shape is not Undefined:
         status_dict["input_data_shape"] = node.input_data_shape
 
-    if status_dict["start"] is None or status_dict["finish"] is None:
+    if any(
+        not isinstance(status_dict[label], datetime) for label in ["start", "finish"]
+    ):
         status_dict["error"] = True
 
     logger.debug(json.dumps(status_dict))
@@ -155,7 +272,7 @@ class LoggingRequestHandler(socketserver.BaseRequestHandler):
 
             with open(callback_file, "rb") as lf:
                 for l in lf.readlines():  # noqa: E741
-                    l = l.strip()  # noqa: E741
+                    l = l.strip()  # noqa: E741,PLW2901
                     try:
                         node = json.loads(l)
                         if node["id"] not in tree[subject]:

--- a/CPAC/utils/tests/test_utils.py
+++ b/CPAC/utils/tests/test_utils.py
@@ -1,5 +1,22 @@
+# Copyright (C) 2018-2025  C-PAC Developers
+
+# This file is part of C-PAC.
+
+# C-PAC is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# C-PAC is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Tests of CPAC utility functions."""
 
+from datetime import datetime, timedelta
 import multiprocessing
 from unittest import mock
 
@@ -10,6 +27,7 @@ from CPAC.func_preproc import get_motion_ref
 from CPAC.pipeline.nodeblock import NodeBlockFunction
 from CPAC.utils.configuration import Configuration
 from CPAC.utils.monitoring.custom_logging import log_subprocess
+from CPAC.utils.monitoring.monitoring import DatetimeWithSafeNone, OptionalDatetime
 from CPAC.utils.tests import old_functions
 from CPAC.utils.utils import (
     check_config_resources,
@@ -168,3 +186,19 @@ def test_system_deps():
     Raises an exception if dependencies are not met.
     """
     check_system_deps(*([True] * 4))
+
+
+@pytest.mark.parametrize(
+    "t1", [datetime.now(), datetime.isoformat(datetime.now()), None]
+)
+@pytest.mark.parametrize(
+    "t2", [datetime.now(), datetime.isoformat(datetime.now()), None]
+)
+def test_datetime_with_safe_none(t1: OptionalDatetime, t2: OptionalDatetime):
+    """Test DatetimeWithSafeNone class works with datetime and None."""
+    t1 = DatetimeWithSafeNone(t1)
+    t2 = DatetimeWithSafeNone(t2)
+    if t1 and t2:
+        assert isinstance(t2 - t1, timedelta)
+    else:
+        assert t2 - t1 == timedelta(0)

--- a/CPAC/utils/tests/test_utils.py
+++ b/CPAC/utils/tests/test_utils.py
@@ -188,6 +188,20 @@ def test_system_deps():
     check_system_deps(*([True] * 4))
 
 
+def check_expected_keys(
+    sink_native_transforms: bool, outputs: dict, expected_keys: set
+) -> None:
+    """Check if expected keys are present in outputs based on sink_native_transforms."""
+    if sink_native_transforms:
+        assert expected_keys.issubset(
+            outputs.keys()
+        ), f"Expected outputs {expected_keys} not found in {outputs.keys()}"
+    else:
+        assert not expected_keys.intersection(
+            outputs.keys()
+        ), f"Outputs {expected_keys} should not be present when sink_native_transforms is Off"
+
+
 @pytest.mark.parametrize(
     "t1", [datetime.now(), datetime.isoformat(datetime.now()), None]
 )

--- a/CPAC/utils/tests/test_utils.py
+++ b/CPAC/utils/tests/test_utils.py
@@ -187,6 +187,7 @@ def test_system_deps():
     """
     check_system_deps(*([True] * 4))
 
+
 @pytest.mark.parametrize(
     "t1", [datetime.now(), datetime.isoformat(datetime.now()), None]
 )


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->

Fixes #2229 by @shnizzedy 
Related to #2230 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->

Working on #2230, I've been annoyed that #2229 didn't catch all of the places where the monitor-logging functionality might try to subtract a `NoneType` from a `datetime` instance, so I created a custom subclass of `datetime.datetime` to handle those differences by returning a `timedelta(0)` if either side of the `a - b` is `NoTime`.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

I also added a custom encoder for dumping JSON to handle these objects https://github.com/FCP-INDI/C-PAC/blob/d5fe464fbf7ea20b02515ca5017c42c7f356c857/CPAC/utils/monitoring/monitoring.py#L127-L141

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/d5fe464fbf7ea20b02515ca5017c42c7f356c857/CPAC/utils/tests/test_utils.py#L191-L204

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
