### PR TITLE
🐛 Fix ideal_bandpass filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed an erroneous connection to AFNI 3dTProject in nuisance denoising that would unnecessarily send a spike regressor as a censor. This would sometimes cause TRs to unnecessarily be dropped from the timeseries as if scrubbing were being performed.
 - Lingering calls to `cpac_outputs.csv` (was changed to `cpac_outputs.tsv` in v1.8.1).
 - A bug in the `freesurfer_abcd_preproc` nodeblock where the `Template` image was incorrectly used as `reference` during the `inverse_warp` step. Replacing it with the subject-specific `T1w` image resolved the issue of the `desc-restoreBrain_T1w` being chipped off.
+- A bug in `ideal_bandpass` where the frequency mask was incorrectly applied, which caused filter to fail in certain cases.
 
 ### Removed
 

--- a/CPAC/nuisance/bandpass.py
+++ b/CPAC/nuisance/bandpass.py
@@ -6,6 +6,8 @@ from numpy.typing import NDArray
 import nibabel as nib
 from scipy.fftpack import fft, ifft
 
+from CPAC.utils.monitoring import IFLOGGER
+
 
 def ideal_bandpass(data, sample_period, bandpass_freqs):
     """
@@ -106,6 +108,8 @@ def bandpass_voxels(realigned_file, regressor_file, bandpass_freqs, sample_perio
         sample_period = float(hdr.get_zooms()[3])
         # Sketchy check to convert TRs in millisecond units
         if sample_period > 20.0:
+            message = f"Sample period ({sample_period}) is very large. Assuming milliseconds and converting to seconds."
+            IFLOGGER.warning(message)
             sample_period /= 1000.0
 
     Y_bp = np.zeros_like(Y)

--- a/CPAC/nuisance/bandpass.py
+++ b/CPAC/nuisance/bandpass.py
@@ -47,7 +47,7 @@ def ideal_bandpass(data, sample_period, bandpass_freqs):
     else:
         low_cutoff_i = np.ceil(LowCutoff * N * sample_period).astype("int")
 
-    if HighCutoff > nyquist_freq or HighCutoff is None:
+    if HighCutoff is None or HighCutoff > nyquist_freq:
         # Cutoff beyond fs/2 or unspecified (become a highpass filter)
         high_cutoff_i = int(N / 2)
     else:

--- a/CPAC/nuisance/bandpass.py
+++ b/CPAC/nuisance/bandpass.py
@@ -8,41 +8,55 @@ from scipy.fftpack import fft, ifft
 
 
 def ideal_bandpass(data, sample_period, bandpass_freqs):
-    # Derived from YAN Chao-Gan 120504 based on REST.
+    """
+    Apply ideal bandpass filtering to a 1D time series data using FFT. Derived from YAN Chao-Gan 120504 based on REST.
+
+    Parameters
+    ----------
+    data : NDArray
+        1D time series data to be filtered.
+    sample_period : float
+        Length of sampling period in seconds.
+    bandpass_freqs : tuple
+        Tuple containing the bandpass frequencies (LowCutoff, HighCutoff).
+
+    Returns
+    -------
+    NDArray
+        Filtered time series data.
+
+    """
     sample_freq = 1.0 / sample_period
     sample_length = data.shape[0]
+    nyquist_freq = sample_freq / 2.0
 
-    data_p = np.zeros(int(2 ** np.ceil(np.log2(sample_length))))
+    # Length of zero-padded data for efficient FFT
+    N = int(2 ** np.ceil(np.log2(len(data))))
+    data_p = np.zeros(N)
     data_p[:sample_length] = data
 
     LowCutoff, HighCutoff = bandpass_freqs
 
     if LowCutoff is None:  # No lower cutoff (low-pass filter)
         low_cutoff_i = 0
-    elif LowCutoff > sample_freq / 2.0:
+    elif LowCutoff > nyquist_freq:
         # Cutoff beyond fs/2 (all-stop filter)
-        low_cutoff_i = int(data_p.shape[0] / 2)
+        low_cutoff_i = int(N / 2)
     else:
-        low_cutoff_i = np.ceil(LowCutoff * data_p.shape[0] * sample_period).astype(
-            "int"
-        )
+        low_cutoff_i = np.ceil(LowCutoff * N * sample_period).astype("int")
 
-    if HighCutoff > sample_freq / 2.0 or HighCutoff is None:
+    if HighCutoff > nyquist_freq or HighCutoff is None:
         # Cutoff beyond fs/2 or unspecified (become a highpass filter)
-        high_cutoff_i = int(data_p.shape[0] / 2)
+        high_cutoff_i = int(N / 2)
     else:
-        high_cutoff_i = np.fix(HighCutoff * data_p.shape[0] * sample_period).astype(
-            "int"
-        )
+        high_cutoff_i = np.fix(HighCutoff * N * sample_period).astype("int")
 
     freq_mask = np.zeros_like(data_p, dtype="bool")
     freq_mask[low_cutoff_i : high_cutoff_i + 1] = True
-    freq_mask[data_p.shape[0] - high_cutoff_i : data_p.shape[0] + 1 - low_cutoff_i] = (
-        True
-    )
+    freq_mask[N - high_cutoff_i : N + 1 - low_cutoff_i] = True
 
     f_data = fft(data_p)
-    f_data[freq_mask is not True] = 0.0
+    f_data[~freq_mask] = 0.0
     return np.real_if_close(ifft(f_data)[:sample_length])
 
 

--- a/CPAC/nuisance/tests/test_bandpass.py
+++ b/CPAC/nuisance/tests/test_bandpass.py
@@ -50,6 +50,7 @@ def test_read_1D(start_line: int, tmp_path: Path) -> None:
     assert len(header) == 5 - start_line
 
 
+@pytest.mark.parametrize("sample_period", [1.0, 1000.0])
 @pytest.mark.parametrize(
     "lowcut, highcut, in_freq, out_freq",
     [
@@ -58,9 +59,8 @@ def test_read_1D(start_line: int, tmp_path: Path) -> None:
         (0.02, 0.08, 0.04, 0.12),
     ],
 )
-def test_ideal_bandpass_with_various_cutoffs(lowcut, highcut, in_freq, out_freq):
+def test_ideal_bandpass_with_various_cutoffs(lowcut, highcut, in_freq, out_freq, sample_period):
     """Test the ideal bandpass filter with various cutoff frequencies."""
-    sample_period = 1.0
     t = np.arange(512) * sample_period
     signal = np.sin(2 * np.pi * in_freq * t) + np.sin(2 * np.pi * out_freq * t)
 

--- a/CPAC/nuisance/tests/test_bandpass.py
+++ b/CPAC/nuisance/tests/test_bandpass.py
@@ -50,19 +50,19 @@ def test_read_1D(start_line: int, tmp_path: Path) -> None:
     assert len(header) == 5 - start_line
 
 
-@pytest.mark.parametrize("sample_period", [1.0, 1000.0])
 @pytest.mark.parametrize(
     "lowcut, highcut, in_freq, out_freq",
     [
         (0.005, 0.05, 0.01, 0.2),
         (0.01, 0.1, 0.02, 0.15),
         (0.02, 0.08, 0.04, 0.12),
+        (None, 0.1, 0.02, 0.15),
+        (0.2, None, 0.22, 0.1),
     ],
 )
-def test_ideal_bandpass_with_various_cutoffs(
-    lowcut, highcut, in_freq, out_freq, sample_period
-):
+def test_ideal_bandpass_with_various_cutoffs(lowcut, highcut, in_freq, out_freq):
     """Test the ideal bandpass filter with various cutoff frequencies."""
+    sample_period = 1.0
     t = np.arange(512) * sample_period
     signal = np.sin(2 * np.pi * in_freq * t) + np.sin(2 * np.pi * out_freq * t)
 
@@ -77,3 +77,30 @@ def test_ideal_bandpass_with_various_cutoffs(
 
     assert filt_fft[idx_in] > 0.5 * orig_fft[idx_in]
     assert filt_fft[idx_out] < 0.1 * orig_fft[idx_out]
+
+
+@pytest.mark.parametrize("sample_period", [1.0, 1000.0])
+def test_ideal_bandpass_cutoffs_clamped_to_nyquist(sample_period):
+    """Test that ideal_bandpass clamps cutoffs to Nyquist frequency."""
+    N = 512
+    t = np.arange(N) * sample_period
+    nyquist = 0.5 / sample_period
+
+    freq_below = nyquist * 0.95
+    freq_above = nyquist * 1.05
+
+    signal = np.sin(2 * np.pi * freq_below * t) + np.sin(2 * np.pi * freq_above * t)
+
+    lowcut = nyquist + 0.01
+    highcut = nyquist + 0.1
+
+    filtered = ideal_bandpass(signal, sample_period, (lowcut, highcut))
+
+    freqs = np.fft.fftfreq(N, d=sample_period)
+    filt_fft = np.abs(fft(filtered))
+
+    idx_below = np.argmin(np.abs(freqs - freq_below))
+    idx_above = np.argmin(np.abs(freqs - freq_above))
+
+    assert filt_fft[idx_below] < 1e-3
+    assert filt_fft[idx_above] < 1e-3

--- a/CPAC/nuisance/tests/test_bandpass.py
+++ b/CPAC/nuisance/tests/test_bandpass.py
@@ -59,7 +59,9 @@ def test_read_1D(start_line: int, tmp_path: Path) -> None:
         (0.02, 0.08, 0.04, 0.12),
     ],
 )
-def test_ideal_bandpass_with_various_cutoffs(lowcut, highcut, in_freq, out_freq, sample_period):
+def test_ideal_bandpass_with_various_cutoffs(
+    lowcut, highcut, in_freq, out_freq, sample_period
+):
     """Test the ideal bandpass filter with various cutoff frequencies."""
     t = np.arange(512) * sample_period
     signal = np.sin(2 * np.pi * in_freq * t) + np.sin(2 * np.pi * out_freq * t)

--- a/CPAC/nuisance/tests/test_bandpass.py
+++ b/CPAC/nuisance/tests/test_bandpass.py
@@ -20,13 +20,12 @@ from importlib.abc import Traversable
 from importlib.resources import files
 from pathlib import Path
 
+import numpy as np
 from numpy.typing import NDArray
 import pytest
-import numpy as np
-import scipy.fft import fft
+from scipy.fft import fft
 
-from CPAC.nuisance.bandpass import read_1D
-from CPAC.nuisance.bandpass import ideal_bandpass
+from CPAC.nuisance.bandpass import ideal_bandpass, read_1D
 
 RAW_ONE_D: Traversable = files("CPAC").joinpath("nuisance/tests/regressors.1D")
 
@@ -51,12 +50,16 @@ def test_read_1D(start_line: int, tmp_path: Path) -> None:
     assert len(header) == 5 - start_line
 
 
-@pytest.mark.parametrize("lowcut, highcut, in_freq, out_freq", [
-    (0.005, 0.05, 0.01, 0.2),
-    (0.01, 0.1, 0.02, 0.15),
-    (0.02, 0.08, 0.04, 0.12),
-])
+@pytest.mark.parametrize(
+    "lowcut, highcut, in_freq, out_freq",
+    [
+        (0.005, 0.05, 0.01, 0.2),
+        (0.01, 0.1, 0.02, 0.15),
+        (0.02, 0.08, 0.04, 0.12),
+    ],
+)
 def test_ideal_bandpass_with_various_cutoffs(lowcut, highcut, in_freq, out_freq):
+    """Test the ideal bandpass filter with various cutoff frequencies."""
     sample_period = 1.0
     t = np.arange(512) * sample_period
     signal = np.sin(2 * np.pi * in_freq * t) + np.sin(2 * np.pi * out_freq * t)

--- a/CPAC/nuisance/tests/test_bandpass.py
+++ b/CPAC/nuisance/tests/test_bandpass.py
@@ -22,8 +22,11 @@ from pathlib import Path
 
 from numpy.typing import NDArray
 import pytest
+import numpy as np
+import scipy.fft import fft
 
 from CPAC.nuisance.bandpass import read_1D
+from CPAC.nuisance.bandpass import ideal_bandpass
 
 RAW_ONE_D: Traversable = files("CPAC").joinpath("nuisance/tests/regressors.1D")
 
@@ -46,3 +49,26 @@ def test_read_1D(start_line: int, tmp_path: Path) -> None:
     assert data.shape == (10, 29)
     # all header lines should be captured
     assert len(header) == 5 - start_line
+
+
+@pytest.mark.parametrize("lowcut, highcut, in_freq, out_freq", [
+    (0.005, 0.05, 0.01, 0.2),
+    (0.01, 0.1, 0.02, 0.15),
+    (0.02, 0.08, 0.04, 0.12),
+])
+def test_ideal_bandpass_with_various_cutoffs(lowcut, highcut, in_freq, out_freq):
+    sample_period = 1.0
+    t = np.arange(512) * sample_period
+    signal = np.sin(2 * np.pi * in_freq * t) + np.sin(2 * np.pi * out_freq * t)
+
+    filtered = ideal_bandpass(signal, sample_period, (lowcut, highcut))
+
+    freqs = np.fft.fftfreq(len(signal), d=sample_period)
+    orig_fft = np.abs(fft(signal))
+    filt_fft = np.abs(fft(filtered))
+
+    idx_in = np.argmin(np.abs(freqs - in_freq))
+    idx_out = np.argmin(np.abs(freqs - out_freq))
+
+    assert filt_fft[idx_in] > 0.5 * orig_fft[idx_in]
+    assert filt_fft[idx_out] < 0.1 * orig_fft[idx_out]


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes `numpy.linalg.LinAlgError: singular matrix` error in  #2225 by @shnizzedy 
Fixes eigenvector centrality crash in in-progress #2230 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
This PR fixes a bug in the ideal_bandpass function where the frequency mask was incorrectly applied, which could cause the filter to fail or behave unexpectedly, especially for certain edge cases in bandpass frequency selection.

The issue was caused by an incorrect use of boolean logic (f_data[freq_mask is not True] = 0.0) which did not apply the mask elementwise. This has now been corrected to f_data[~freq_mask] = 0.0.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Replaced
```python
f_data[freq_mask is not True] = 0.0
```
with
```python
f_data[~freq_mask] = 0.0
```
which applies the negation elementwise, as intended.

The FFT zero-padding and bandpass index calculation remain unchanged in terms of functionality. Variable naming was slightly improved for readability (e.g., nyquist_freq used instead of repeated sample_freq / 2.0).

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Manually inspected non-zero outputs from this function.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Before fix
![image](https://github.com/user-attachments/assets/bc241594-7d2f-4be6-9bb3-ad2544acd49a)

After fix
![image](https://github.com/user-attachments/assets/4bff5ac5-a169-440f-9cb7-4d496a9c7b13)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
