### PR TITLE
Fixing ccs options brain masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch `sink_native_transforms` under `registration_workflows` to output all `.mat` files in ANTs and FSL Transforms.
 - `deoblique` field in pipeline config with `warp` and `refit` options to apply `3dWarp` or `3drefit` during data initialization.
 - `organism` configuration option.
+- Functionality to convert `space-T1w_desc-loose_brain_mask` and `space-T1w_desc-tight_brain_mask` into generic brain mask `space-T1w_desc-brain_mask` to use in brain extraction nodeblock downstream.
 
 ### Changed
 

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1303,7 +1303,7 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
     # fslmaths tmp_mask.nii.gz -mas ${CCSDIR}/templates/MNI152_T1_1mm_first_brain_mask.nii.gz tmp_mask.nii.gz
     apply_mask = pe.Node(interface=fsl.maths.ApplyMask(), name=f"apply_mask_{node_id}")
 
-    wf.connect(skullstrip, "out_file", apply_mask, "in_file")
+    wf.connect(skullstrip, "mask_file", apply_mask, "in_file")
 
     node, out = strat_pool.get_data("T1w-brain-template-mask-ccs")
     wf.connect(node, out, apply_mask, "mask_file")
@@ -1347,36 +1347,18 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     wf.connect(combine_mask, "out_file", binarize_combined_mask, "in_file")
 
-    # CCS brain mask is in FS space, transfer it back to native T1 space
-    fs_fsl_brain_mask_to_native = pe.Node(
-        interface=freesurfer.ApplyVolTransform(),
-        name=f"fs_fsl_brain_mask_to_native_{node_id}",
-    )
-    fs_fsl_brain_mask_to_native.inputs.reg_header = True
-    fs_fsl_brain_mask_to_native.inputs.interp = "nearest"
-
-    wf.connect(
-        binarize_combined_mask, "out_file", fs_fsl_brain_mask_to_native, "source_file"
-    )
-
-    node, out = strat_pool.get_data("pipeline-fs_raw-average")
-    wf.connect(node, out, fs_fsl_brain_mask_to_native, "target_file")
-
-    node, out = strat_pool.get_data("freesurfer-subject-dir")
-    wf.connect(node, out, fs_fsl_brain_mask_to_native, "subjects_dir")
-
     if opt == "FreeSurfer-BET-Tight":
         outputs = {
             "space-T1w_desc-tight_brain_mask": (
-                fs_fsl_brain_mask_to_native,
-                "transformed_file",
+                binarize_combined_mask,
+                "out_file",
             )
         }
     elif opt == "FreeSurfer-BET-Loose":
         outputs = {
             "space-T1w_desc-loose_brain_mask": (
-                fs_fsl_brain_mask_to_native,
-                "transformed_file",
+                binarize_combined_mask,
+                "out_file",
             )
         }
 
@@ -2062,7 +2044,7 @@ def brain_mask_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "space-T1w_desc-brain_mask": {
             "Description": "Brain mask extracted using FreeSurfer-BET-Tight method",
             "Method": "FreeSurfer-BET-Tight",
-            "Threshold": "tight",
+            "Threshold": "tight"
         }
     },
 )
@@ -2070,9 +2052,7 @@ def brain_mask_freesurfer_fsl_tight(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
     # Convert the tight brain mask to generic brain mask
-    outputs["space-T1w_desc-brain_mask"] = outputs.pop(
-        "space-T1w_desc-tight_brain_mask"
-    )
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-tight_brain_mask")
     return (wf, outputs)
 
 
@@ -2121,7 +2101,7 @@ def brain_mask_acpc_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "space-T1w_desc-brain_mask": {
             "Description": "Brain mask extracted using FreeSurfer-BET-Loose method",
             "Method": "FreeSurfer-BET-Loose",
-            "Threshold": "loose",
+            "Threshold": "loose"
         }
     },
 )
@@ -2129,9 +2109,7 @@ def brain_mask_freesurfer_fsl_loose(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
     # Convert the loose brain mask to generic brain mask
-    outputs["space-T1w_desc-brain_mask"] = outputs.pop(
-        "space-T1w_desc-loose_brain_mask"
-    )
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-loose_brain_mask")
     return (wf, outputs)
 
 

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2044,7 +2044,7 @@ def brain_mask_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "space-T1w_desc-brain_mask": {
             "Description": "Brain mask extracted using FreeSurfer-BET-Tight method",
             "Method": "FreeSurfer-BET-Tight",
-            "Threshold": "tight"
+            "Threshold": "tight",
         }
     },
 )
@@ -2052,7 +2052,9 @@ def brain_mask_freesurfer_fsl_tight(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
     # Convert the tight brain mask to generic brain mask
-    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-tight_brain_mask")
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop(
+        "space-T1w_desc-tight_brain_mask"
+    )
     return (wf, outputs)
 
 
@@ -2101,7 +2103,7 @@ def brain_mask_acpc_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "space-T1w_desc-brain_mask": {
             "Description": "Brain mask extracted using FreeSurfer-BET-Loose method",
             "Method": "FreeSurfer-BET-Loose",
-            "Threshold": "loose"
+            "Threshold": "loose",
         }
     },
 )
@@ -2109,7 +2111,9 @@ def brain_mask_freesurfer_fsl_loose(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
     # Convert the loose brain mask to generic brain mask
-    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-loose_brain_mask")
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop(
+        "space-T1w_desc-loose_brain_mask"
+    )
     return (wf, outputs)
 
 

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2062,7 +2062,7 @@ def brain_mask_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "space-T1w_desc-brain_mask": {
             "Description": "Brain mask extracted using FreeSurfer-BET-Tight method",
             "Method": "FreeSurfer-BET-Tight",
-            "Threshold": "tight"
+            "Threshold": "tight",
         }
     },
 )
@@ -2070,7 +2070,9 @@ def brain_mask_freesurfer_fsl_tight(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
     # Convert the tight brain mask to generic brain mask
-    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-tight_brain_mask")
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop(
+        "space-T1w_desc-tight_brain_mask"
+    )
     return (wf, outputs)
 
 
@@ -2119,7 +2121,7 @@ def brain_mask_acpc_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "space-T1w_desc-brain_mask": {
             "Description": "Brain mask extracted using FreeSurfer-BET-Loose method",
             "Method": "FreeSurfer-BET-Loose",
-            "Threshold": "loose"
+            "Threshold": "loose",
         }
     },
 )
@@ -2127,7 +2129,9 @@ def brain_mask_freesurfer_fsl_loose(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
     # Convert the loose brain mask to generic brain mask
-    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-loose_brain_mask")
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop(
+        "space-T1w_desc-loose_brain_mask"
+    )
     return (wf, outputs)
 
 

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -2058,11 +2058,19 @@ def brain_mask_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "T1w-brain-template-mask-ccs",
         "T1w-ACPC-template",
     ],
-    outputs=["space-T1w_desc-tight_brain_mask"],
+    outputs={
+        "space-T1w_desc-brain_mask": {
+            "Description": "Brain mask extracted using FreeSurfer-BET-Tight method",
+            "Method": "FreeSurfer-BET-Tight",
+            "Threshold": "tight"
+        }
+    },
 )
 def brain_mask_freesurfer_fsl_tight(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
+    # Convert the tight brain mask to generic brain mask
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-tight_brain_mask")
     return (wf, outputs)
 
 
@@ -2107,11 +2115,19 @@ def brain_mask_acpc_freesurfer_abcd(wf, cfg, strat_pool, pipe_num, opt=None):
         "T1w-brain-template-mask-ccs",
         "T1w-ACPC-template",
     ],
-    outputs=["space-T1w_desc-loose_brain_mask"],
+    outputs={
+        "space-T1w_desc-brain_mask": {
+            "Description": "Brain mask extracted using FreeSurfer-BET-Loose method",
+            "Method": "FreeSurfer-BET-Loose",
+            "Threshold": "loose"
+        }
+    },
 )
 def brain_mask_freesurfer_fsl_loose(wf, cfg, strat_pool, pipe_num, opt=None):
     wf, outputs = freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt)
 
+    # Convert the loose brain mask to generic brain mask
+    outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-loose_brain_mask")
     return (wf, outputs)
 
 

--- a/CPAC/anat_preproc/tests/test_anat_preproc.py
+++ b/CPAC/anat_preproc/tests/test_anat_preproc.py
@@ -6,7 +6,11 @@ import nibabel as nib
 
 from .. import anat_preproc
 from unittest.mock import Mock, patch
-from ..anat_preproc import brain_mask_freesurfer_fsl_loose, brain_mask_freesurfer_fsl_tight
+from ..anat_preproc import (
+    brain_mask_freesurfer_fsl_loose,
+    brain_mask_freesurfer_fsl_tight,
+)
+
 
 class TestAnatPreproc:
     def __init__(self):
@@ -272,10 +276,10 @@ class TestAnatPreproc:
             assert correlation[0, 1] >= 0.97
 
 
-@patch('CPAC.anat_preproc.anat_preproc.freesurfer_fsl_brain_connector')
+@patch("CPAC.anat_preproc.anat_preproc.freesurfer_fsl_brain_connector")
 def test_brain_mask_freesurfer_fsl_loose(mock_connector):
     """Test that brain_mask_freesurfer_fsl_loose correctly renames output key."""
-    
+
     mock_wf = Mock()
     mock_cfg = Mock()
     mock_strat_pool = Mock()
@@ -283,20 +287,22 @@ def test_brain_mask_freesurfer_fsl_loose(mock_connector):
 
     mock_outputs = {
         "space-T1w_desc-loose_brain_mask": "brain_mask_data",
-        "other_output": "other_data"
+        "other_output": "other_data",
     }
-    
+
     mock_connector.return_value = (mock_wf, mock_outputs)
-    
+
     result_wf, result_outputs = brain_mask_freesurfer_fsl_loose(
         mock_wf, mock_cfg, mock_strat_pool, pipe_num
     )
-    
-    mock_connector.assert_called_once_with(mock_wf, mock_cfg, mock_strat_pool, pipe_num, None)
-    
+
+    mock_connector.assert_called_once_with(
+        mock_wf, mock_cfg, mock_strat_pool, pipe_num, None
+    )
+
     # Assert workflow returned unchanged
     assert result_wf == mock_wf
-    
+
     # Assert output key was renamed correctly
     assert "space-T1w_desc-brain_mask" in result_outputs
     assert "space-T1w_desc-loose_brain_mask" not in result_outputs
@@ -304,10 +310,10 @@ def test_brain_mask_freesurfer_fsl_loose(mock_connector):
     assert result_outputs["other_output"] == "other_data"
 
 
-@patch('CPAC.anat_preproc.anat_preproc.freesurfer_fsl_brain_connector')
+@patch("CPAC.anat_preproc.anat_preproc.freesurfer_fsl_brain_connector")
 def test_brain_mask_freesurfer_fsl_tight(mock_connector):
     """Test that brain_mask_freesurfer_fsl_tight correctly renames output key."""
-    
+
     mock_wf = Mock()
     mock_cfg = Mock()
     mock_strat_pool = Mock()
@@ -315,20 +321,22 @@ def test_brain_mask_freesurfer_fsl_tight(mock_connector):
 
     mock_outputs = {
         "space-T1w_desc-tight_brain_mask": "brain_mask_data",
-        "other_output": "other_data"
+        "other_output": "other_data",
     }
-    
+
     mock_connector.return_value = (mock_wf, mock_outputs)
-    
+
     result_wf, result_outputs = brain_mask_freesurfer_fsl_tight(
         mock_wf, mock_cfg, mock_strat_pool, pipe_num
     )
-    
-    mock_connector.assert_called_once_with(mock_wf, mock_cfg, mock_strat_pool, pipe_num, None)
-    
+
+    mock_connector.assert_called_once_with(
+        mock_wf, mock_cfg, mock_strat_pool, pipe_num, None
+    )
+
     # Assert workflow returned unchanged
     assert result_wf == mock_wf
-    
+
     # Assert output key was renamed correctly
     assert "space-T1w_desc-brain_mask" in result_outputs
     assert "space-T1w_desc-tight_brain_mask" not in result_outputs

--- a/CPAC/anat_preproc/tests/test_anat_preproc.py
+++ b/CPAC/anat_preproc/tests/test_anat_preproc.py
@@ -5,7 +5,8 @@ import numpy as np
 import nibabel as nib
 
 from .. import anat_preproc
-
+from unittest.mock import Mock, patch
+from ..anat_preproc import brain_mask_freesurfer_fsl_loose, brain_mask_freesurfer_fsl_tight
 
 class TestAnatPreproc:
     def __init__(self):
@@ -269,3 +270,67 @@ class TestAnatPreproc:
             # print 'correlation: ', correlation
 
             assert correlation[0, 1] >= 0.97
+
+
+@patch('CPAC.anat_preproc.anat_preproc.freesurfer_fsl_brain_connector')
+def test_brain_mask_freesurfer_fsl_loose(mock_connector):
+    """Test that brain_mask_freesurfer_fsl_loose correctly renames output key."""
+    
+    mock_wf = Mock()
+    mock_cfg = Mock()
+    mock_strat_pool = Mock()
+    pipe_num = 1
+
+    mock_outputs = {
+        "space-T1w_desc-loose_brain_mask": "brain_mask_data",
+        "other_output": "other_data"
+    }
+    
+    mock_connector.return_value = (mock_wf, mock_outputs)
+    
+    result_wf, result_outputs = brain_mask_freesurfer_fsl_loose(
+        mock_wf, mock_cfg, mock_strat_pool, pipe_num
+    )
+    
+    mock_connector.assert_called_once_with(mock_wf, mock_cfg, mock_strat_pool, pipe_num, None)
+    
+    # Assert workflow returned unchanged
+    assert result_wf == mock_wf
+    
+    # Assert output key was renamed correctly
+    assert "space-T1w_desc-brain_mask" in result_outputs
+    assert "space-T1w_desc-loose_brain_mask" not in result_outputs
+    assert result_outputs["space-T1w_desc-brain_mask"] == "brain_mask_data"
+    assert result_outputs["other_output"] == "other_data"
+
+
+@patch('CPAC.anat_preproc.anat_preproc.freesurfer_fsl_brain_connector')
+def test_brain_mask_freesurfer_fsl_tight(mock_connector):
+    """Test that brain_mask_freesurfer_fsl_tight correctly renames output key."""
+    
+    mock_wf = Mock()
+    mock_cfg = Mock()
+    mock_strat_pool = Mock()
+    pipe_num = 1
+
+    mock_outputs = {
+        "space-T1w_desc-tight_brain_mask": "brain_mask_data",
+        "other_output": "other_data"
+    }
+    
+    mock_connector.return_value = (mock_wf, mock_outputs)
+    
+    result_wf, result_outputs = brain_mask_freesurfer_fsl_tight(
+        mock_wf, mock_cfg, mock_strat_pool, pipe_num
+    )
+    
+    mock_connector.assert_called_once_with(mock_wf, mock_cfg, mock_strat_pool, pipe_num, None)
+    
+    # Assert workflow returned unchanged
+    assert result_wf == mock_wf
+    
+    # Assert output key was renamed correctly
+    assert "space-T1w_desc-brain_mask" in result_outputs
+    assert "space-T1w_desc-tight_brain_mask" not in result_outputs
+    assert result_outputs["space-T1w_desc-brain_mask"] == "brain_mask_data"
+    assert result_outputs["other_output"] == "other_data"


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes 
- #2263 by @sgiavasis 
- #2266 by @sgiavasis 

## Description
<!-- Concisely describe what the pull request does. -->
Modified `ccs-options` Tight/Loose brain mask generation nodeblocks to name the masks appropriately so that it moves downstream to the rest of pipeline and can be used in `brain extraction` as swappable `T1w brain masks`.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Converts the tight/loose brain masks into generic mask that can be used downstream.
```python
outputs["space-T1w_desc-brain_mask"] = outputs.pop("space-T1w_desc-loose_brain_mask")
```
Adding metadata info into the nodeblock decorator as
```python
    outputs={
        "space-T1w_desc-brain_mask": {
            "Description": "Brain mask extracted using FreeSurfer-BET-Loose method",
            "Method": "FreeSurfer-BET-Loose",
            "Threshold": "loose"
        }
```
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Run CPAC with config where these brain extraction methods are enabled and then see if the respective outputs are available in the output/anat dir.
```YAML
anatomical_preproc:
  run: On
  brain_extraction:
    run: On
    using: [FreeSurfer-BET-Tight, FreeSurfer-BET-Loose]
```
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Ran Config with
![image](https://github.com/user-attachments/assets/d10d9cc4-c1b9-4f7b-b6f3-4a529d95730e)

and checked the `output/anat`
![image](https://github.com/user-attachments/assets/67065ed6-9878-4687-95c0-a9aa0ff73c65)

CPAC Variant info in the metadata
![image](https://github.com/user-attachments/assets/160aaa75-e7d7-49f5-a502-3ba89d97e0de)

Final Masked Brain from Tight (left) Loose (right)
![image](https://github.com/user-attachments/assets/4b33164d-3e46-4448-8e31-8407c0ea9bd2)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
