### PR TITLE
adding match_fov node before apply_warp

### DIFF
--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -3066,7 +3066,9 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
         wf.connect(merge_inv_xfms_to_list, "out", merge_inv_xfms, "in_files")
 
         # Match FOVs using flirt -in infile -ref MNI152_T1_1mm_resample.nii.gz -out my_T1w_resampled.nii.gz -applyxfm -usesqform
-        match_fovs_T1w = pe.Node(interface=fsl.FLIRT(), name=f"match_fovs_T1w_{pipe_num}")
+        match_fovs_T1w = pe.Node(
+            interface=fsl.FLIRT(), name=f"match_fovs_T1w_{pipe_num}"
+        )
         match_fovs_T1w.inputs.apply_xfm = True
         match_fovs_T1w.inputs.uses_qform = True
 
@@ -3089,7 +3091,9 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
             merge_xfms, "merged_file", fsl_apply_warp_t1_to_template, "field_file"
         )
 
-        match_fovs_T1w_brain = pe.Node(interface=fsl.FLIRT(), name=f"match_fovs_T1w_brain_{pipe_num}")
+        match_fovs_T1w_brain = pe.Node(
+            interface=fsl.FLIRT(), name=f"match_fovs_T1w_brain_{pipe_num}"
+        )
         match_fovs_T1w_brain.inputs.apply_xfm = True
         match_fovs_T1w_brain.inputs.uses_qform = True
 
@@ -3103,7 +3107,12 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
         # TODO connect T1wRestoreBrain, check T1wRestoreBrain quality
         node, out = strat_pool.get_data(["desc-restore-brain_T1w", "desc-preproc_T1w"])
         wf.connect(node, out, match_fovs_T1w_brain, "in_file")
-        wf.connect(match_fovs_T1w_brain, "out_file", fsl_apply_warp_t1_brain_to_template, "in_file")
+        wf.connect(
+            match_fovs_T1w_brain,
+            "out_file",
+            fsl_apply_warp_t1_brain_to_template,
+            "in_file",
+        )
 
         node, out = strat_pool.get_data("T1w-brain-template")
         wf.connect(node, out, match_fovs_T1w_brain, "reference")
@@ -3113,7 +3122,9 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
             merge_xfms, "merged_file", fsl_apply_warp_t1_brain_to_template, "field_file"
         )
 
-        match_fovs_T1w_brain_mask = pe.Node(interface=fsl.FLIRT(), name=f"match_fovs_T1w_brain_mask_{pipe_num}")
+        match_fovs_T1w_brain_mask = pe.Node(
+            interface=fsl.FLIRT(), name=f"match_fovs_T1w_brain_mask_{pipe_num}"
+        )
         match_fovs_T1w_brain_mask.inputs.apply_xfm = True
         match_fovs_T1w_brain_mask.inputs.uses_qform = True
 
@@ -3126,7 +3137,12 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
 
         node, out = strat_pool.get_data("space-T1w_desc-brain_mask")
         wf.connect(node, out, match_fovs_T1w_brain_mask, "in_file")
-        wf.connect(match_fovs_T1w_brain_mask, "out_file", fsl_apply_warp_t1_brain_mask_to_template, "in_file")
+        wf.connect(
+            match_fovs_T1w_brain_mask,
+            "out_file",
+            fsl_apply_warp_t1_brain_mask_to_template,
+            "in_file",
+        )
 
         node, out = strat_pool.get_data("T1w-brain-template-mask")
         wf.connect(node, out, match_fovs_T1w_brain_mask, "reference")

--- a/CPAC/registration/registration.py
+++ b/CPAC/registration/registration.py
@@ -2906,6 +2906,8 @@ def register_ANTs_EPI_to_template(wf, cfg, strat_pool, pipe_num, opt=None):
             ["desc-preproc_T1w", "desc-reorient_T1w", "T1w"],
             "space-T1w_desc-brain_mask",
             "T1w-template",
+            "T1w-brain-template",
+            "T1w-brain-template-mask",
             "from-T1w_to-template_mode-image_xfm",
             "from-template_to-T1w_mode-image_xfm",
             "space-template_desc-brain_T1w",
@@ -3063,6 +3065,11 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
 
         wf.connect(merge_inv_xfms_to_list, "out", merge_inv_xfms, "in_files")
 
+        # Match FOVs using flirt -in infile -ref MNI152_T1_1mm_resample.nii.gz -out my_T1w_resampled.nii.gz -applyxfm -usesqform
+        match_fovs_T1w = pe.Node(interface=fsl.FLIRT(), name=f"match_fovs_T1w_{pipe_num}")
+        match_fovs_T1w.inputs.apply_xfm = True
+        match_fovs_T1w.inputs.uses_qform = True
+
         # applywarp --rel --interp=spline -i ${T1wRestore} -r ${Reference} -w ${OutputTransform} -o ${OutputT1wImageRestore}
         fsl_apply_warp_t1_to_template = pe.Node(
             interface=fsl.ApplyWarp(), name=f"FSL-ABCD_T1_to_template_{pipe_num}"
@@ -3070,15 +3077,21 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
         fsl_apply_warp_t1_to_template.inputs.relwarp = True
         fsl_apply_warp_t1_to_template.inputs.interp = "spline"
 
-        node, out = strat_pool.get_data(["desc-restore_T1w", "desc-preproc_T1w"])
-        wf.connect(node, out, fsl_apply_warp_t1_to_template, "in_file")
-
         node, out = strat_pool.get_data("T1w-template")
+        wf.connect(node, out, match_fovs_T1w, "reference")
         wf.connect(node, out, fsl_apply_warp_t1_to_template, "ref_file")
+
+        node, out = strat_pool.get_data(["desc-restore_T1w", "desc-preproc_T1w"])
+        wf.connect(node, out, match_fovs_T1w, "in_file")
+        wf.connect(match_fovs_T1w, "out_file", fsl_apply_warp_t1_to_template, "in_file")
 
         wf.connect(
             merge_xfms, "merged_file", fsl_apply_warp_t1_to_template, "field_file"
         )
+
+        match_fovs_T1w_brain = pe.Node(interface=fsl.FLIRT(), name=f"match_fovs_T1w_brain_{pipe_num}")
+        match_fovs_T1w_brain.inputs.apply_xfm = True
+        match_fovs_T1w_brain.inputs.uses_qform = True
 
         # applywarp --rel --interp=nn -i ${T1wRestoreBrain} -r ${Reference} -w ${OutputTransform} -o ${OutputT1wImageRestoreBrain}
         fsl_apply_warp_t1_brain_to_template = pe.Node(
@@ -3088,15 +3101,21 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
         fsl_apply_warp_t1_brain_to_template.inputs.interp = "nn"
 
         # TODO connect T1wRestoreBrain, check T1wRestoreBrain quality
-        node, out = strat_pool.get_data("desc-preproc_T1w")
-        wf.connect(node, out, fsl_apply_warp_t1_brain_to_template, "in_file")
+        node, out = strat_pool.get_data(["desc-restore-brain_T1w", "desc-preproc_T1w"])
+        wf.connect(node, out, match_fovs_T1w_brain, "in_file")
+        wf.connect(match_fovs_T1w_brain, "out_file", fsl_apply_warp_t1_brain_to_template, "in_file")
 
-        node, out = strat_pool.get_data("T1w-template")
+        node, out = strat_pool.get_data("T1w-brain-template")
+        wf.connect(node, out, match_fovs_T1w_brain, "reference")
         wf.connect(node, out, fsl_apply_warp_t1_brain_to_template, "ref_file")
 
         wf.connect(
             merge_xfms, "merged_file", fsl_apply_warp_t1_brain_to_template, "field_file"
         )
+
+        match_fovs_T1w_brain_mask = pe.Node(interface=fsl.FLIRT(), name=f"match_fovs_T1w_brain_mask_{pipe_num}")
+        match_fovs_T1w_brain_mask.inputs.apply_xfm = True
+        match_fovs_T1w_brain_mask.inputs.uses_qform = True
 
         fsl_apply_warp_t1_brain_mask_to_template = pe.Node(
             interface=fsl.ApplyWarp(),
@@ -3106,9 +3125,11 @@ def overwrite_transform_anat_to_template(wf, cfg, strat_pool, pipe_num, opt=None
         fsl_apply_warp_t1_brain_mask_to_template.inputs.interp = "nn"
 
         node, out = strat_pool.get_data("space-T1w_desc-brain_mask")
-        wf.connect(node, out, fsl_apply_warp_t1_brain_mask_to_template, "in_file")
+        wf.connect(node, out, match_fovs_T1w_brain_mask, "in_file")
+        wf.connect(match_fovs_T1w_brain_mask, "out_file", fsl_apply_warp_t1_brain_mask_to_template, "in_file")
 
-        node, out = strat_pool.get_data("T1w-template")
+        node, out = strat_pool.get_data("T1w-brain-template-mask")
+        wf.connect(node, out, match_fovs_T1w_brain_mask, "reference")
         wf.connect(node, out, fsl_apply_warp_t1_brain_mask_to_template, "ref_file")
 
         wf.connect(


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2274  by @birajstha 

## Description
<!-- Concisely describe what the pull request does. -->
Resolves the cropping issue at Overwrite transform nodeblock

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Adds additional `match_fov` node in the workflow before `apply_warp` to remove cropping issue.
This step is a engineered solution.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<img width="745" height="786" alt="image" src="https://github.com/user-attachments/assets/5f6942e6-9716-44e2-9bb0-20e12d18b40d" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
