### PR TITLE
bringing the FS brain mask to T1 space before anat skull stripping

### DIFF
--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1323,7 +1323,7 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     wf.connect(combine_mask, "out_file", binarize_combined_mask, "in_file")
 
-    # CCS brain mask is in FS space, transfer it back to native T1 space 
+    # CCS brain mask is in FS space, transfer it back to native T1 space
     match_fov_ccs_brain_mask = pe.Node(
         interface=fsl.FLIRT(), name=f"match_fov_CCS_brain_mask_{node_id}"
     )
@@ -1339,7 +1339,9 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
         name=f"convert_fs_T1_to_nifti_for_ccs_{node_id}",
     )
     wf.connect(node, out, convert_fs_T1_to_nifti, "in_file")
-    wf.connect(convert_fs_T1_to_nifti, "out_file", match_fov_ccs_brain_mask, "reference")
+    wf.connect(
+        convert_fs_T1_to_nifti, "out_file", match_fov_ccs_brain_mask, "reference"
+    )
 
     wf.connect(binarize_combined_mask, "out_file", match_fov_ccs_brain_mask, "in_file")
 

--- a/CPAC/anat_preproc/anat_preproc.py
+++ b/CPAC/anat_preproc/anat_preproc.py
@@ -1323,7 +1323,27 @@ def freesurfer_fsl_brain_connector(wf, cfg, strat_pool, pipe_num, opt):
 
     wf.connect(combine_mask, "out_file", binarize_combined_mask, "in_file")
 
-    return wf, {"space-T1w_desc-brain_mask": (binarize_combined_mask, "out_file")}
+    # CCS brain mask is in FS space, transfer it back to native T1 space 
+    match_fov_ccs_brain_mask = pe.Node(
+        interface=fsl.FLIRT(), name=f"match_fov_CCS_brain_mask_{node_id}"
+    )
+    match_fov_ccs_brain_mask.inputs.apply_xfm = True
+    match_fov_ccs_brain_mask.inputs.uses_qform = True
+    match_fov_ccs_brain_mask.inputs.interp = "nearestneighbour"
+
+    node, out = strat_pool.get_data("pipeline-fs_raw-average")
+    convert_fs_T1_to_nifti = pe.Node(
+        Function(
+            input_names=["in_file"], output_names=["out_file"], function=mri_convert
+        ),
+        name=f"convert_fs_T1_to_nifti_for_ccs_{node_id}",
+    )
+    wf.connect(node, out, convert_fs_T1_to_nifti, "in_file")
+    wf.connect(convert_fs_T1_to_nifti, "out_file", match_fov_ccs_brain_mask, "reference")
+
+    wf.connect(binarize_combined_mask, "out_file", match_fov_ccs_brain_mask, "in_file")
+
+    return wf, {"space-T1w_desc-brain_mask": (match_fov_ccs_brain_mask, "out_file")}
 
 
 def mask_T2(wf_name="mask_T2"):


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #2279 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Adds a node to convert the Freesurfer brainmask to native T1w space (pipeline-fs_raw-average).
Adds intermediate node that converts the T1w from `.mgz` to `.nii.gz`.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
```PYTHON
    # CCS brain mask is in FS space, transfer it back to native T1 space 
    match_fov_ccs_brain_mask = pe.Node(
        interface=fsl.FLIRT(), name=f"match_fov_CCS_brain_mask_{node_id}"
    )
    match_fov_ccs_brain_mask.inputs.apply_xfm = True
    match_fov_ccs_brain_mask.inputs.uses_qform = True
    match_fov_ccs_brain_mask.inputs.interp = "nearestneighbour"

    node, out = strat_pool.get_data("pipeline-fs_raw-average")
    convert_fs_T1_to_nifti = pe.Node(
        Function(
            input_names=["in_file"], output_names=["out_file"], function=mri_convert
        ),
        name=f"convert_fs_T1_to_nifti_for_ccs_{node_id}",
    )
    wf.connect(node, out, convert_fs_T1_to_nifti, "in_file")
    wf.connect(convert_fs_T1_to_nifti, "out_file", match_fov_ccs_brain_mask, "reference")

    wf.connect(binarize_combined_mask, "out_file", match_fov_ccs_brain_mask, "in_file")

    return wf, {"space-T1w_desc-brain_mask": (match_fov_ccs_brain_mask, "out_file")}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
