### PR TITLE
🐛 Climb to find `.git`

### DIFF
--- a/CPAC/info.py
+++ b/CPAC/info.py
@@ -52,13 +52,18 @@ _version_extra = "dev1"
 
 def get_cpac_gitversion() -> str | None:
     """CPAC version as reported by the last commit in git."""
-    from pathlib import Path
+    from importlib.resources import as_file, files
     import subprocess
 
-    gitpath = Path(__file__).parent.resolve()
-
-    gitpathgit = gitpath / ".git"
-    if not gitpathgit.exists():
+    with as_file(files("CPAC")) as _cpac:
+        gitpath = _cpac
+    gitpathgit = None
+    for _cpacpath in [gitpath, *gitpath.parents]:
+        git_dir = _cpacpath / ".git"
+        if git_dir.exists():
+            gitpathgit = git_dir
+            break
+    if not gitpathgit:
         return None
 
     ver = None


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to #2282 by @birajstha 

## Description
<!-- Concisely describe what the pull request does. -->

Reverts some of 651cfa57a14eafa6a3cf43dfa7602b81c07d79e6...613f1e819e6e167be503b52c4e1841218ccae0fc and fixes the issue I think those changes were targeting (not finding `../.git`).

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

651cfa57a14eafa6a3cf43dfa7602b81c07d79e6...613f1e819e6e167be503b52c4e1841218ccae0fc changed https://github.com/FCP-INDI/C-PAC/blob/651cfa57a14eafa6a3cf43dfa7602b81c07d79e6/CPAC/info.py#L53-L63 to https://github.com/FCP-INDI/C-PAC/blob/613f1e819e6e167be503b52c4e1841218ccae0fc/CPAC/info.py#L53-L62. After this PR, this section is https://github.com/FCP-INDI/C-PAC/blob/aff2c5aac9810c56d7edc9a57e6263aef9794edb/CPAC/info.py#L53-L67

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `fix/check_s3` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
