### PR TITLE
🐛 Fix logging copy datetime bug

### DIFF
--- a/CPAC/utils/monitoring/monitoring.py
+++ b/CPAC/utils/monitoring/monitoring.py
@@ -84,7 +84,7 @@ NoTime = _NoTime()
 
 
 class DatetimeWithSafeNone(datetime, _NoTime):
-    """Time class that can be None or a time value.
+    r"""Time class that can be None or a time value.
 
     Examples
     --------
@@ -148,6 +148,7 @@ class DatetimeWithSafeNone(datetime, _NoTime):
         fold: Optional[int] = 0,
     ) -> "DatetimeWithSafeNone | _NoTime":
         """Create a new instance of the class."""
+        # First check if all arguments are provided as integers
         if (
             isinstance(year, int)
             and isinstance(month, int)
@@ -170,10 +171,13 @@ class DatetimeWithSafeNone(datetime, _NoTime):
                 tzinfo,
                 fold=fold,
             )
-        else:
-            dt = year
+
+        # Otherwise, year contains the datetime-like object
+        dt = year
+
         if dt is None:
             return NoTime
+
         if isinstance(dt, datetime):
             return datetime.__new__(
                 cls,
@@ -186,6 +190,7 @@ class DatetimeWithSafeNone(datetime, _NoTime):
                 dt.microsecond,
                 dt.tzinfo,
             )
+
         if isinstance(dt, bytes):
             try:
                 tzflag: Optional[int]
@@ -219,24 +224,76 @@ class DatetimeWithSafeNone(datetime, _NoTime):
                     return datetime.__new__(
                         cls, year, month, day, hour, minute, second, microsecond, tzinfo
                     )
-                else:
-                    msg = f"Unexpected type: {[type(part) for part in [year, month, day, hour, minute, second, microsecond]]}"
-                    raise TypeError(msg)
-            except UnicodeDecodeError:
-                error = f"Cannot decode bytes to string: {dt!r}"
+                msg = f"Unexpected type: {[type(part) for part in [year, month, day, hour, minute, second, microsecond]]}"
+                raise TypeError(msg)
+            except (struct.error, IndexError) as e:
+                error = f"Cannot unpack bytes to datetime: {dt!r} - {e}"
                 raise TypeError(error)
+
         if isinstance(dt, str):
             try:
                 return DatetimeWithSafeNone(datetime.fromisoformat(dt))
             except (ValueError, TypeError):
                 error = f"Invalid ISO-format datetime string: {dt}"
-        else:
-            error = f"Cannot convert {type(dt)} to datetime"
+                raise TypeError(error)
+
+        error = f"Cannot convert {type(dt)} to datetime"
         raise TypeError(error)
 
     def __bool__(self) -> bool:
         """Return True if not NoTime."""
         return self is not NoTime
+
+    def __eq__(self, other: object) -> bool:
+        """Compare DatetimeWithSafeNone instances with tzinfo-aware logic.
+
+        If only one side has tzinfo, consider them equal if all other components match.
+        """
+        if self is NoTime and other is NoTime:
+            return True
+        if self is NoTime or other is NoTime:
+            return False
+        if not isinstance(other, (datetime, DatetimeWithSafeNone)):
+            return False
+
+        # Compare all datetime components except tzinfo
+        components_match = (
+            self.year == other.year
+            and self.month == other.month
+            and self.day == other.day
+            and self.hour == other.hour
+            and self.minute == other.minute
+            and self.second == other.second
+            and self.microsecond == other.microsecond
+        )
+
+        if not components_match:
+            return False
+
+        # If components match, check tzinfo:
+        # - If either has None tzinfo, consider them equal
+        # - If both have tzinfo, they must match
+        if self.tzinfo is None or other.tzinfo is None:
+            return True
+
+        return self.tzinfo == other.tzinfo
+
+    def __hash__(self) -> int:
+        """Return hash based on datetime components, ignoring tzinfo."""
+        if self is NoTime:
+            return hash(NoTime)
+        # Hash based on datetime components only, not tzinfo
+        return hash(
+            (
+                self.year,
+                self.month,
+                self.day,
+                self.hour,
+                self.minute,
+                self.second,
+                self.microsecond,
+            )
+        )
 
     def __sub__(self, other: "DatetimeWithSafeNone | _NoTime") -> datetime | timedelta:  # type: ignore[reportIncompatibleMethodOverride]
         """Subtract between a datetime or timedelta or None."""

--- a/CPAC/utils/monitoring/monitoring.py
+++ b/CPAC/utils/monitoring/monitoring.py
@@ -93,9 +93,9 @@ class DatetimeWithSafeNone(datetime, _NoTime):
     '2025-06-18T21:06:43.730004'
     >>> DatetimeWithSafeNone("2025-06-18T21:06:43.730004").isoformat()
     '2025-06-18T21:06:43.730004'
-    >>> DatetimeWithSafeNone(b"\\x07\\xe9\\x06\\x12\\x10\\x18\\x1c\\x88\\x6d\\x01").isoformat()
+    >>> DatetimeWithSafeNone(b"\x07\xe9\x06\x12\x10\x18\x1c\x88\x6d\x01").isoformat()
     '2025-06-18T16:24:28.028040+00:00'
-    >>> DatetimeWithSafeNone(b'\\x07\\xe9\\x06\\x12\\x10\\x18\\x1c\\x88m\\x00').isoformat()
+    >>> DatetimeWithSafeNone(b'\x07\xe9\x06\x12\x10\x18\x1c\x88m\x00').isoformat()
     '2025-06-18T16:24:28.028040'
     >>> DatetimeWithSafeNone(DatetimeWithSafeNone("2025-06-18")).isoformat()
     '2025-06-18T00:00:00'

--- a/CPAC/utils/tests/test_utils.py
+++ b/CPAC/utils/tests/test_utils.py
@@ -16,7 +16,8 @@
 # License along with C-PAC. If not, see <https://www.gnu.org/licenses/>.
 """Tests of CPAC utility functions."""
 
-from datetime import datetime, timedelta
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 import multiprocessing
 from unittest import mock
 
@@ -240,3 +241,41 @@ def test_datetime_with_safe_none(t1: OptionalDatetime, t2: OptionalDatetime):
         assert isinstance(t2 - t1, timedelta)
     else:
         assert t2 - t1 == timedelta(0)
+
+
+def test_deepcopy_datetimewithsafenone_raises_error() -> None:
+    """Test bytestring TypeError during deepcopy operation."""
+    # Create a node dictionary similar to what's used in the Gantt chart generation
+    node = {
+        "id": "test_node",
+        "hash": "abc123",
+        "start": DatetimeWithSafeNone(
+            datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        ),
+        "finish": DatetimeWithSafeNone(
+            datetime(2024, 1, 1, 11, 30, 0, tzinfo=timezone.utc)
+        ),
+        "runtime_threads": 4,
+        "runtime_memory_gb": 2.5,
+        "estimated_memory_gb": 3.0,
+        "num_threads": 4,
+    }
+
+    # This should raise: TypeError: Cannot convert <class 'bytes'> to datetime
+    # with the original code because deepcopy pickles DatetimeWithSafeNone objects
+    # as bytes, and the __new__ method doesn't properly handle the pickle protocol
+    finish_node = deepcopy(node)
+
+    assert finish_node["start"] == node["start"]
+    assert finish_node["finish"] == node["finish"]
+
+
+def test_deepcopy_datetimewithsafenone_direct():
+    """Test deepcopy directly on DatetimeWithSafeNone instance."""
+    dt = DatetimeWithSafeNone(datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc))
+
+    # This triggers the pickle/unpickle cycle which passes bytes to __new__
+    dt_copy = deepcopy(dt)
+
+    assert dt_copy == dt
+    assert isinstance(dt_copy, DatetimeWithSafeNone)


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes

```Python
C-PAC failed to start
Traceback (most recent call last):
  File "/code/CPAC/pipeline/cpac_runner.py", line 652, in run
    exitcode = run_workflow(
  File "/code/CPAC/pipeline/cpac_pipeline.py", line 806, in run_workflow
    resource_report(cb_log_filename, num_cores_per_sub, WFLOGGER)
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 598, in resource_report
    generate_gantt_chart(callback_log, num_cores)
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 419, in generate_gantt_chart
    events = create_event_dict(start_node["start"], nodes_list)
  File "/code/CPAC/utils/monitoring/draw_gantt_chart.py", line 93, in create_event_dict
    finish_node = copy.deepcopy(node)
  File "/usr/share/fsl/6.0/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/share/fsl/6.0/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/share/fsl/6.0/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/share/fsl/6.0/lib/python3.10/copy.py", line 265, in _reconstruct
    y = func(*args)
  File "/code/CPAC/utils/monitoring/monitoring.py", line 111, in __new__
    raise TypeError(error)
TypeError: Cannot convert <class 'bytes'> to datetime
```

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

`UnicodeDecodeError` was the wrong exception to catch; this updates it to `(struct.error, IndexError)` and adds tests.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

https://github.com/FCP-INDI/C-PAC/blob/40149901b2cd04094a06d5692c4821ff034e5aaf/CPAC/utils/tests/test_utils.py#L246-L281


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
